### PR TITLE
Fix signal callbacks

### DIFF
--- a/lib/introspect.js
+++ b/lib/introspect.js
@@ -33,7 +33,10 @@ module.exports = function(obj, callback) {
                           // TODO: share signal mangling code
                           var signalFullName = [/*obj.service.namei, */ obj.name, ifName, signame].join('#');
                           console.log('trying to listen' +  signalFullName);
-                          bus.signals.on(signalFullName, callback);
+                          bus.signals.on(signalFullName, function(messageBody)
+                          {
+                               callback.apply(null, messageBody)
+                          });
                       });
                   }
               })(ifaceName);


### PR DESCRIPTION
Signal callbacks received only one argument which is really an array of all the actual arguments.
Fixed that, now signal callbacks receive arguments as expected.
