### PR TITLE
Update lib/introspect.js

### DIFF
--- a/lib/introspect.js
+++ b/lib/introspect.js
@@ -51,26 +51,27 @@ module.exports = function(obj, callback) {
                       console.log(arg);
                       if (arg.direction === 'in')
                           signature += arg.type;
-                      
-                      // add method
-                      currentIface[name] = (function(ifName, methodName, signature) {
-                          return function() {
-                              var args = Array.prototype.slice.apply(arguments);
-                              var callback = args[args.length - 1];
-                              var msg = {
-                                  destination: obj.service.name,
-                                  path: obj.name,
-                                  'interface': ifName,
-                                  member: methodName
-                              };
-                              if (signature !== '') {
-                                  msg.signature = signature;
-                                  msg.body = args.slice(0,-1);
-                              }
-                              bus.invoke(msg, callback);
-                         };
-                      })(ifaceName, name, signature);
                   }
+                      
+    			 // add method
+				  currentIface[name] = (function(ifName, methodName, signature) {
+					  return function() {
+						  var args = Array.prototype.slice.apply(arguments);
+    					  var callback = (typeof(args[args.length - 1]) == "function") ? args.pop() : function() {};
+						  var msg = {
+							  destination: obj.service.name,
+							  path: obj.name,
+							  'interface': ifName,
+							  member: methodName
+						  };
+						  if (signature !== '') {
+							  msg.signature = signature;
+							  msg.body = args;
+						  }
+						  bus.invoke(msg, callback);
+					 };
+				  })(ifaceName, name, signature);
+
                   console.log('    method: ', name, signature);
               }
               for (p=0; iface.property && p < iface.property.length; ++p)


### PR DESCRIPTION
1. The "add method" procedure does not belong in the loop that builds the signature. It is just re-defined for each new signature part.
2. Made callback optional for cases in which we do not care about the method result. E.g.

``` javascript
player.playPause(false);
```
