### PR TITLE
Use correct interface name variable in currentIface.on

### DIFF
--- a/lib/introspect.js
+++ b/lib/introspect.js
@@ -31,7 +31,7 @@ module.exports = function(obj, callback) {
                       bus.addMatch(match, function(err, result) {
                           if (err) throw new Error(err);
                           // TODO: share signal mangling code
-                          var signalFullName = bus.mangle(obj.name, ifaceName, signame); 
+                          var signalFullName = bus.mangle(obj.name, ifName, signame); 
                           //console.log('trying to listen' +  signalFullName, obj);
                           bus.signals.on(signalFullName, function(messageBody)
                           {


### PR DESCRIPTION
I noticed that currentIface.on in not using the correct variable when calling `bus.mangle` should be `ifName` not `ifaceName`.
