### PR TITLE
Listener api changes

### DIFF
--- a/lib/introspect.js
+++ b/lib/introspect.js
@@ -20,7 +20,7 @@ module.exports = function(obj, callback) {
               currentIface = proxy[ifaceName] = {};
 
               currentIface.addListener = currentIface.on = (function(ifName) {
-                  return function(signame, callback) {
+                  return function(signame, callback, done) {
                       // TODO: check if AddMatch had already been called
                       // http://dbus.freedesktop.org/doc/api/html/group__DBusBus.html#ga4eb6401ba014da3dbe3dc4e2a8e5b3ef
                       // An example is "type='signal',sender='org.freedesktop.DBus', interface='org.freedesktop.DBus',member='Foo', path='/bar/foo',destination=':452345.34'" ...
@@ -28,8 +28,9 @@ module.exports = function(obj, callback) {
                       
                       //TODO: add path and interface to path
                       var match = "type='signal',member='" + signame + "'";
+                      
                       bus.addMatch(match, function(err, result) {
-                          if (err) throw new Error(err);
+                          if (err) return done(err);
                           // TODO: share signal mangling code
                           var signalFullName = bus.mangle(obj.name, ifName, signame); 
                           //console.log('trying to listen' +  signalFullName, obj);

--- a/lib/introspect.js
+++ b/lib/introspect.js
@@ -29,15 +29,28 @@ module.exports = function(obj, callback) {
                       //TODO: add path and interface to path
                       var match = "type='signal',member='" + signame + "'";
                       
+                      // TODO: share signal mangling code
+                      var signalFullName = bus.mangle(obj.name, ifName, signame); 
+
+                      var signalHandler = function(messageBody) {
+                          callback.apply(null, messageBody)
+                      };
+
                       bus.addMatch(match, function(err, result) {
                           if (err) return done(err);
-                          // TODO: share signal mangling code
-                          var signalFullName = bus.mangle(obj.name, ifName, signame); 
                           //console.log('trying to listen' +  signalFullName, obj);
-                          bus.signals.on(signalFullName, function(messageBody)
-                          {
-                               callback.apply(null, messageBody)
-                          });
+                          bus.signals.on(signalFullName, signalHandler);
+
+                          var rv = {
+                              remove: function(callback) {
+                                  bus.signals.removeListener(signalFullName, signalHandler);
+                                  bus.removeMatch(match, function(err, result) {
+                                      if (err) return callback(err);
+                                      callback(err, result);
+                                  });
+                              }
+                          };
+                          done(null, rv);
                       });
                   }
               })(ifaceName);


### PR DESCRIPTION
A couple of changes to the listener API.

I've opted for returning a value with a `.remove()` method rather than providing a `removeListener` method, since we need access to the signal handler function. I believe this won't work if you have two listeners for the same property name though - the EventEmitter stuff will be handled properly, but the dbus match will be removed.
