### PR TITLE
Return error when interfaces go missing.

### DIFF
--- a/lib/introspect.js
+++ b/lib/introspect.js
@@ -11,6 +11,7 @@ module.exports = function(obj, callback) {
       var parser = new xml2js.Parser({explicitArray: true});
       parser.parseString(xml, function (err, result) {
           if (err) return callback(err);
+          if (!result.interface) return callback(new Error('No such interface found'));
           var proxy = {};
           var i, m, s, ifaceName, method, property, signal, iface, a, arg, signature, currentIface;
           var ifaces = result['interface'];


### PR DESCRIPTION
This should close sidorares/node-dbus#43

This fixes a crash when trying to get an interface which does not exist.
