### PR TITLE
Fix a number of issues in handshake code

### DIFF
--- a/lib/handshake.js
+++ b/lib/handshake.js
@@ -108,5 +108,9 @@ function tryAuth(stream, methods, cb) {
       stream.write('AUTH ANONYMOUS \r\n');
       beginOrNextAuth();
       break;
+    default:
+      console.error("Unsupported auth method: " + authMethod);
+      beginOrNextAuth();
+      break;
   }
 }


### PR DESCRIPTION
The existing code:
- tries to use an `undefined` auth method if it tried all the available methods without success
- silently does nothing (i.e never proceeds) if it encounters an unknown auth method (like `undefined` ;))
- sends a new NUL byte before attempting _each_ auth method, while the spec (from http://dbus.freedesktop.org/doc/dbus-specification.html#auth-protocol-overview) says that it should only send one in total:

> Immediately after connecting to the server, the client must send a single nul byte. [ ... ]
> A nul byte in any context other than the initial byte is an error; the protocol is ASCII-only.
