### PR TITLE
Fixed problems with introspection, the path names and structure were not

### DIFF
--- a/lib/stdifaces.js
+++ b/lib/stdifaces.js
@@ -20,10 +20,15 @@ function respondError(bus, msg, name, text)
     bus.connection.message(msg);
 }
 
+function reducepath(path, str) {
+    str = str.substring(path.length);
+    if(str.charAt(0) == '/')
+        str = str.substring(1);
+    return str;
+}
+
 module.exports = function(msg, bus) {
     if (msg['interface'] === 'org.freedesktop.DBus.Introspectable' && msg.member === 'Introspect') {
-        if (msg.path == '/')
-            msg.path = '';
 
         var resultXml = [xmlHeader];
         var nodes = {};
@@ -32,16 +37,17 @@ module.exports = function(msg, bus) {
         // need to build objects tree as they are exported and walk this tree on introspect request
         for (var path in bus.exportedObjects) {
            if (path.indexOf(msg.path) === 0) {// objects path starts with requested
-               obj = bus.exportedObjects[msg.path];
+               obj = bus.exportedObjects[path];
                if (obj)
-                   nodes[msg.path] = obj;
-               else {
-                   if (path[msg.path.length] != '/')
-                       continue;
-                   var localPath = path.substr(msg.path.length);
-                   var pathParts = localPath.split('/');
-                   var localName = pathParts[1];
-                   nodes[localName] = null;
+               {
+                   var reduced = reducepath(msg.path, path);
+                   if(path == msg.path) // exact path match
+                       nodes[path] = obj;
+                   else
+                   {
+                       if(reduced.indexOf('/') < 0) // reduced path has no '/' character
+                           nodes[path] = null; //{};
+                   }
                }
            }
         }
@@ -66,16 +72,16 @@ module.exports = function(msg, bus) {
         } else {
             resultXml.push('<node>');
             for (var name in nodes) {
-                if (nodes[name] === null)
-                    resultXml.push('  <node name="' + name + '" />');
-                else {
+                if (nodes[name] === null) {
+                    var reduced = reducepath(msg.path, name);
+                    if(reduced.length>0)
+                        resultXml.push('  <node name="' + reduced + '" />');
+                } else {
                     obj = nodes[name];
-                    resultXml.push('  <node name="' + name + '" >');
                     for (ifaceName in obj) {
                         resultXml.push(interfaceToXML(obj[ifaceName][0]));
                     }
                     resultXml.push(stdIfaces);
-                    resultXml.push('  </node>');
                 }
             }
             resultXml.push('</node>');
@@ -112,8 +118,8 @@ module.exports = function(msg, bus) {
             var propType = obj[interfaceName][0].properties[propertyName];
             if (msg.member === 'Get') {
                 var propValue = impl[propertyName];
-                reply.signature = 'v';
-                reply.body = [[propType, propValue]];
+                reply.signature = propType;
+                reply.body = [propValue];
             } else {
                 impl[propertyName] = 1234; // TODO: read variant and set property value
             }


### PR DESCRIPTION
correct and didn't allow for proper recursion. Now the path names for all
child nodes have names relative to the path specified in the query, and are
provided with a null node placeholder entry so they appear in the xml, and
the caller can then recursively scan as desired.

The code could probably be made more efficient with fewer checks for
exceptions.