### PR TITLE
Remove unnecessary signature from listActivatableNames

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -336,10 +336,7 @@ module.exports = function bus(conn, opts) {
   };
 
   this.listActivatableNames = function(callback) {
-    this.invokeDbus(
-      { member: 'ListActivatableNames', signature: 's', body: [name] },
-      callback
-    );
+    this.invokeDbus({ member: 'ListActivatableNames' }, callback);
   };
 
   this.updateActivationEnvironment = function(env, callback) {


### PR DESCRIPTION
`listActivatableNames` takes no arguments.

https://dbus.freedesktop.org/doc/dbus-specification.html#bus-messages-list-activatable-names