### PR TITLE
Use Buffer.from and Buffer.alloc wherever we deal with Buffers

### DIFF
--- a/lib/align.js
+++ b/lib/align.js
@@ -1,10 +1,11 @@
+const Buffer = require('safe-buffer').Buffer;
+
 function align(ps, n) {
   var pad = n - ps._offset % n;
   if (pad === 0 || pad === n) return;
   // TODO: write8(0) in a loop (3 to 7 times here) could be more efficient
-  var padBuff = Buffer(pad);
-  padBuff.fill(0);
-  ps.put(Buffer(padBuff));
+  var padBuff = Buffer.alloc(pad);
+  ps.put(Buffer.from(padBuff));
   ps._offset += pad;
 }
 

--- a/lib/handshake.js
+++ b/lib/handshake.js
@@ -1,3 +1,4 @@
+const Buffer = require('safe-buffer').Buffer;
 const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
@@ -50,7 +51,7 @@ function getCookie(context, id, cb) {
 }
 
 function hexlify(input) {
-  return Buffer(input.toString(), 'ascii').toString('hex');
+  return Buffer.from(input.toString(), 'ascii').toString('hex');
 }
 
 module.exports = function auth(stream, opts, cb) {
@@ -99,7 +100,7 @@ function tryAuth(stream, methods, cb) {
     case 'DBUS_COOKIE_SHA1':
       stream.write('AUTH ' + authMethod + ' ' + id + '\r\n');
       readLine(stream, function(line) {
-        var data = new Buffer(
+        var data = Buffer.from(
           line
             .toString()
             .split(' ')[1]

--- a/lib/hello-message.js
+++ b/lib/hello-message.js
@@ -1,6 +1,8 @@
+const Buffer = require('safe-buffer').Buffer;
+
 // Pre-serialised hello message. serial = 1
 module.exports = function() {
-  return new Buffer(
+  return Buffer.from(
     '6c01 0001 0000 0000 0100 0000 6d00 0000' +
       '0101 6f00 1500 0000 2f6f 7267 2f66 7265' +
       '6564 6573 6b74 6f70 2f44 4275 7300 0000' +

--- a/lib/marshallers.js
+++ b/lib/marshallers.js
@@ -1,3 +1,4 @@
+const Buffer = require('safe-buffer').Buffer;
 const align = require('./align').align;
 const parseSignature = require('../lib/signature');
 const Long = require('long');
@@ -65,7 +66,7 @@ var MakeSimpleMarshaller = function(signature) {
         this.check(data);
         // utf8 string
         align(ps, 4);
-        const buff = new Buffer(data, 'utf8');
+        const buff = Buffer.from(data, 'utf8');
         ps
           .word32le(buff.length)
           .put(buff)
@@ -82,7 +83,7 @@ var MakeSimpleMarshaller = function(signature) {
       marshaller.marshall = function(ps, data) {
         this.check(data);
         // signature
-        const buff = new Buffer(data, 'ascii');
+        const buff = Buffer.from(data, 'ascii');
         ps
           .word8(data.length)
           .put(buff)
@@ -125,7 +126,7 @@ var MakeSimpleMarshaller = function(signature) {
       marshaller.marshall = function(ps, data) {
         this.check(data);
         align(ps, 2);
-        const buff = new Buffer(2);
+        const buff = Buffer.alloc(2);
         buff.writeInt16LE(parseInt(data), 0);
         ps.put(buff);
         ps._offset += 2;
@@ -153,7 +154,7 @@ var MakeSimpleMarshaller = function(signature) {
       marshaller.marshall = function(ps, data) {
         this.check(data);
         align(ps, 4);
-        const buff = new Buffer(4);
+        const buff = Buffer.alloc(4);
         buff.writeInt32LE(parseInt(data), 0);
         ps.put(buff);
         ps._offset += 4;
@@ -213,7 +214,7 @@ var MakeSimpleMarshaller = function(signature) {
       marshaller.marshall = function(ps, data) {
         this.check(data);
         align(ps, 8);
-        const buff = new Buffer(8);
+        const buff = Buffer.alloc(8);
         buff.writeDoubleLE(parseFloat(data), 0);
         ps.put(buff);
         ps._offset += 8;

--- a/lib/message.js
+++ b/lib/message.js
@@ -1,3 +1,4 @@
+const Buffer = require('safe-buffer').Buffer;
 const marshall = require('./marshall');
 const constants = require('./constants');
 const DBusBuffer = require('./dbuffer');
@@ -108,8 +109,7 @@ module.exports.marshall = function marshallMessage(message) {
   var headerLenAligned =
     ((headerBuff.length + fieldsBuff.length + 7) >> 3) << 3;
   var messageLen = headerLenAligned + bodyLength;
-  var messageBuff = Buffer(messageLen);
-  messageBuff.fill(0);
+  var messageBuff = Buffer.alloc(messageLen);
   headerBuff.copy(messageBuff);
   fieldsBuff.copy(messageBuff, headerBuff.length);
   if (bodyLength > 0) bodyBuff.copy(messageBuff, headerLenAligned);

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -1,3 +1,5 @@
+const Buffer = require('safe-buffer').Buffer;
+
 module.exports = function readOneLine(stream, cb) {
   var bytes = [];
   function readable() {
@@ -7,7 +9,7 @@ module.exports = function readOneLine(stream, cb) {
       var b = buf[0];
       if (b === 0x0a) {
         try {
-          cb(new Buffer(bytes));
+          cb(Buffer.from(bytes));
         } catch (error) {
           stream.emit('error', error);
         }

--- a/lib/server-handshake.js
+++ b/lib/server-handshake.js
@@ -1,3 +1,4 @@
+const Buffer = require('safe-buffer').Buffer;
 const readLine = require('./readline');
 
 module.exports = function serverHandshake(stream, opts, cb) {
@@ -8,7 +9,7 @@ module.exports = function serverHandshake(stream, opts, cb) {
     readLine(stream, function() {
       stream.write(
         'DATA ' +
-          Buffer(
+          Buffer.from(
             'org_freedesktop_general 642038150 b9ce247a275f427c8586e4c9de9bb951'
           ).toString('hex') +
           '\r\n'

--- a/lib/unmarshall.js
+++ b/lib/unmarshall.js
@@ -1,8 +1,9 @@
+const Buffer = require('safe-buffer').Buffer;
 const DBusBuffer = require('./dbuffer');
 
 module.exports = function unmarshall(buffer, signature, startPos, options) {
   if (!startPos) startPos = 0;
-  if (signature === '') return new Buffer();
+  if (signature === '') return Buffer.from('');
   var dbuff = new DBusBuffer(buffer, startPos, options);
   return dbuff.read(signature);
 };

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "long": "^3.0.1",
     "optimist": "^0.6.1",
     "put": "0.0.6",
+    "safe-buffer": "^5.1.1",
     "xml2js": "0.1.14"
   },
   "optionalDependencies": {

--- a/test/example-messages.js
+++ b/test/example-messages.js
@@ -1,3 +1,4 @@
+const Buffer = require('safe-buffer').Buffer;
 const fs = require('fs');
 const assert = require('assert');
 const unmarshall = require('../lib/message').unmarshall;
@@ -10,7 +11,7 @@ describe('given base-64 encoded files with complete messages', function() {
     var messages = fs.readdirSync(dir);
     messages.forEach(function(name) {
       var msg = fs.readFileSync(dir + name, 'ascii');
-      var msgBin = new Buffer(msg, 'base64');
+      var msgBin = Buffer.from(msg, 'base64');
       var unmarshalledMsg = unmarshall(msgBin);
       var marshalled = marshall(unmarshalledMsg);
       assert.deepStrictEqual(unmarshalledMsg, unmarshall(marshalled));

--- a/test/unmarshall-basic.js
+++ b/test/unmarshall-basic.js
@@ -1,3 +1,4 @@
+const Buffer = require('safe-buffer').Buffer;
 const marshall = require('../lib/marshall');
 const unmarshall = require('../lib/unmarshall');
 const assert = require('assert');
@@ -49,8 +50,7 @@ function test(signature, data, other_result, unmarshall_opts) {
 var str300chars = '';
 for (var i = 0; i < 300; ++i) str300chars += 'i';
 
-var b30000bytes = Buffer(30000);
-b30000bytes.fill(60);
+var b30000bytes = Buffer.alloc(30000, 60);
 var str30000chars = b30000bytes.toString('ascii');
 
 function expectMarshallToThrowOnBadArguments(badSig, badData, errorRegex) {
@@ -343,7 +343,9 @@ describe('marshall/unmarshall', function() {
       ['a(ai)', [[[[1, 2, 3, 4, 5, 6]], [[15, 4, 5, 6]]]]],
       ['aai', [[[1, 2, 3, 4, 5, 6], [15, 4, 5, 6]]]]
     ],
-    buffers: [['ayay', [Buffer([0, 1, 2, 3, 4, 5, 6, 0xff]), Buffer([])]]]
+    buffers: [
+      ['ayay', [Buffer.from([0, 1, 2, 3, 4, 5, 6, 0xff]), Buffer.from([])]]
+    ]
   };
 
   var testName, testData, testNum;

--- a/test/utils/packetcapture.js
+++ b/test/utils/packetcapture.js
@@ -1,3 +1,4 @@
+const Buffer = require('safe-buffer').Buffer;
 const net = require('net');
 const abs = require('abstract-socket');
 const hexy = require('hexy').hexy;
@@ -56,7 +57,7 @@ net
           console.error(hexy(packet, { prefix: 'packet: ' }));
           console.error(' ====== PACKET END ====== ');
           if (packet[0] === 0x6c) {
-            var len = new Buffer(4);
+            var len = Buffer.alloc(4);
             len.writeUInt32LE(packet.length, 0);
             console.error(hexy(len, { prefix: 'packet header: ' }));
             packetfile.write(len);


### PR DESCRIPTION
Using the `Buffer` constructor is deprecated, so instead we use
`Buffer.from` and `Buffer.alloc`. These are only available in Node >
4.5, so we'll use the polyfill from `safe-buffer` to provide them.