### PR TITLE
Update travis node version configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
-  - 4.5
-  - 6.6
+  - 4.2
+  - 6
+  - 8


### PR DESCRIPTION
* Use 4.2 for 4.x since 4.2 is the latest 4.x in last Ubuntu LTS
* Use 6 not 6.6
 * Add 8

 I don't see a reason to get too specific on 8.x atm, since it hasn't
 appeared in any LTS version of Ubuntu, or in a Debian release.