### PR TITLE
Remove check for console.warn existence

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,8 +61,7 @@ function createStream(opts) {
       }
     } catch (e) {
       if (i < addresses.length - 1) {
-        if (console && console.warn instanceof Function)
-          console.warn(e.message);
+        console.warn(e.message);
         continue;
       } else {
         throw e;


### PR DESCRIPTION
`console.warn` seems to have existed since node 0.1.x, so this should be
fine?

Is there a reason for this check that I'm not sure of?