### PR TITLE
Make dbus-native itself non-callable

### DIFF
--- a/examples/monitor.js
+++ b/examples/monitor.js
@@ -1,7 +1,7 @@
 const dbus = require('../index');
 
-//var conn = dbus({socket: '/var/run/dbus/system_bus_socket'});
-var conn = dbus();
+//var conn = dbus.createConnection({socket: '/var/run/dbus/system_bus_socket'});
+var conn = dbus.createConnection();
 
 conn.message({
   type: 1,

--- a/index.js
+++ b/index.js
@@ -132,8 +132,6 @@ function createConnection(opts) {
   return self;
 }
 
-module.exports = createConnection;
-
 module.exports.createClient = function(params) {
   var connection = createConnection(params || {});
   return new MessageBus(connection, params || {});
@@ -152,6 +150,6 @@ module.exports.sessionBus = function(opts) {
 };
 
 module.exports.messageType = constants.messageType;
-module.exports.createConnection = module.exports;
+module.exports.createConnection = createConnection;
 
 module.exports.createServer = server.createServer;


### PR DESCRIPTION
The `dbus-native` module shouldn't have a default export AND other
exported methods.

Now you must call `sessionBus()`, `systemBus()`, etc.

This is a BC break, so the version should be bumped to `0.3.0`.

Fixes #191