### PR TITLE
Fix for loop in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function createStream(opts) {
   if (!busAddress) throw new Error('unknown bus address');
 
   var addresses = busAddress.split(';');
-  for (var i in addresses) {
+  for (var i = 0; i < addresses.length; ++i) {
     var address = addresses[i];
     var familyParams = address.split(':');
     var family = familyParams[0];


### PR DESCRIPTION
The for loop seems loop in all passed addresses and then warn on every
failure until the last one upon which an exception is raised. The
comparison isn't valid though, because `i` will likely never be a
number.

I'm referring to this bit `if (i < addresses.length - 1) {` in https://github.com/sidorares/dbus-native/blob/98f333a0b1f3def6f7cdbb490e11565ee2fd0a3c/index.js#L63