### PR TITLE
Remove optimist from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
     "husky": "^0.14.3",
     "lint-staged": "^4.2.3",
     "mocha": "*",
-    "prettier": "^1.7.4",
-    "optimist": "0.6.1"
+    "prettier": "^1.7.4"
   },
   "scripts": {
     "lint": "npm run lint:docs && npm run lint:code",


### PR DESCRIPTION
This fixes an issue noted in #206.

It should be a regular dependency, since it's used in both scripts in `bin/`.