### PR TITLE
Returning error on pending callbacks when connection dies

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -86,6 +86,16 @@ module.exports = function bus(conn, opts) {
     this.connection.message(reply);
   };
 
+  this.connection.on('end', function() {
+    // complete all pending callbacks with error
+    var handler;
+    for (var cookie in self.cookies) {
+      handler = self.cookies[cookie];
+      delete self.cookies[cookie];
+      handler(new Error("connection was closed"));
+    }
+  });
+
   // route reply/error
   this.connection.on('message', function(msg) {
     var handler;


### PR DESCRIPTION
Need to return an error on pending callbacks when the connection dies, otherwise waiting callbacks will hang forever.