### PR TITLE
Don't enforce strict equality checks for null

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,7 +11,7 @@
   ],
   "rules": {
     "no-constant-condition": ["error", { "checkLoops": false }],
-    "eqeqeq": ["error", "always"],
+    "eqeqeq": ["error", "always", {"null": "ignore"}],
     "no-console": "off",
     "no-empty": "off"
   },


### PR DESCRIPTION
This bit us and led to https://github.com/sidorares/dbus-native/pull/209

https://eslint.org/docs/rules/eqeqeq#allow-null