### PR TITLE
bus.js: don't check for service name in addMatch & removeMatch

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -297,7 +297,6 @@ module.exports = function bus(conn, opts) {
 
   // bus meta functions
   this.addMatch = function(match, callback) {
-    if (!self.name) return callback(null, null);
     this.invokeDbus(
       { member: 'AddMatch', signature: 's', body: [match] },
       callback
@@ -305,7 +304,6 @@ module.exports = function bus(conn, opts) {
   };
 
   this.removeMatch = function(match, callback) {
-    if (!self.name) return callback(null, null);
     this.invokeDbus(
       { member: 'RemoveMatch', signature: 's', body: [match] },
       callback


### PR DESCRIPTION
Hi, according D-Bus specs, its not necessary to have registered for a name to receive signals.

Background: I was looking for a way to receive pretty much all signals, and ended up doing that like below. Ofcourse welcome to let me know if I can somehow in a more clever way use your library for this!

Thanks for the nice lib.

Matthijs

```
const dbus = require('dbus-native');
const bus = dbus.sessionBus();

if (!bus) {
	throw new Error('Could not connect to the DBus session bus.');
}

function signal_receive(m) {
	if (m.interface == 'com.victronenergy.BusItem' && m.member == 'PropertiesChanged') {
		properties_changed(m);
	}
}

function properties_changed(m) {
        // Message contents:
	// { serial: 5192,
	//   path: '/Dc/0/Power',
	//   interface: 'com.victronenergy.BusItem',
	//   member: 'PropertiesChanged',
	//   signature: 'a{sv}',
	//   sender: ':1.104',
	//   type: 4,
	//   flags: 1,
	//   body: [ [ [Object], [Object] ] ]}

	m.text  = m.body[0][0][1][1][0];
	m.value = m.body[0][1][1][1][0];

	console.log("Receiving signal %d", m.serial);
	console.log("  " + m.path);              // '/Dc/0/Voltage'
	console.log("  " + m.sender);            // ':1.104'
	console.log("  " + m.text);              // The new value as a (sometimes formatted) string
	console.log("  " + m.value);             // The new value as a plain value
	console.log("  " + Object.prototype.toString.call(m.value))

	return true;
}

bus.connection.on('message', signal_receive);
bus.addMatch("type='signal',interface='com.victronenergy.BusItem',member='PropertiesChanged'", d => {});
```