### PR TITLE
Reply with standard DBus error on unknown method

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -125,9 +125,12 @@ module.exports = function bus(conn, opts) {
           impl = iface[1];
           var func = impl[msg.member];
           if (!func) {
-            // TODO: respond with standard dbus error
-            console.error(`Method ${msg.member} is not implemented `);
-            throw new Error(`Method ${msg.member} is not implemented `);
+            self.sendError(
+              msg,
+              'org.freedesktop.DBus.Error.UnknownMethod',
+              `Method "${msg.member}" on interface "${msg.interface}" doesn't exist`
+            );
+            return;
           }
           var methodReturnResult;
           try {


### PR DESCRIPTION
Reply with org.freedesktop.DBus.Error.UnknownMethod when a method call
message arrives for an unknown method, instead of throwin an exception.