### PR TITLE
Reply with an error when handler throws exception

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -133,11 +133,12 @@ module.exports = function bus(conn, opts) {
           try {
             methodReturnResult = func.apply(impl, msg.body);
           } catch (e) {
-            console.error(
-              'Caught exception while trying to execute handler: ',
-              e
+            self.sendError(
+              msg,
+              e.dbusName || 'org.freedesktop.DBus.Error.Failed',
+              e.message || ''
             );
-            throw e;
+            return;
           }
           // TODO safety check here
           var resultSignature = iface[0].methods[msg.member][1];


### PR DESCRIPTION
Reply with an error, named by the 'dbusName' property or
'org.freedesktop.DBus.Error.Failed', when the handler throws an
exception.