### PR TITLE
Fix get property handler

### DIFF
--- a/lib/introspect.js
+++ b/lib/introspect.js
@@ -154,12 +154,15 @@ module.exports = function(obj, callback) {
                         body: [ifName, propName]
                       },
                       function(err, val) {
-                        if (err) callback(err);
-                        var signature = val[0];
-                        if (signature.length === 1) {
-                          callback(err, val[1][0]);
+                        if (err) {
+                          callback(err);
                         } else {
-                          callback(err, val[1]);
+                          var signature = val[0];
+                          if (signature.length === 1) {
+                            callback(err, val[1][0]);
+                          } else {
+                            callback(err, val[1]);
+                          }
                         }
                       }
                     );


### PR DESCRIPTION
Current handler for get property allows fall through when an error is detected, thereby calling the callback multiple times and with a non-existent value.