### PR TITLE
Fix a problem in method name resolution

### DIFF
--- a/lib/introspect.js
+++ b/lib/introspect.js
@@ -125,7 +125,7 @@ module.exports = function(obj, callback) {
                   destination: obj.service.name,
                   path: obj.name,
                   interface: ifName,
-                  member: methodName
+                  member: mName
                 };
                 if (signature !== '') {
                   msg.signature = signature;


### PR DESCRIPTION
While inspecting dbus traffic, i noticed the last introspected method always got invoked. This fixes the issue. The problem was probably introduced by #200 / 0.2.4