### PR TITLE
Support for xml2js beyond 0.1 and attempt at unit test

### DIFF
--- a/bin/dbus2js.js
+++ b/bin/dbus2js.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const xml2js = require('xml2js');
+const xml2js_opts = Object.assign({}, xml2js.defaults["0.1"], { explicitArray: true });
 const dbus = require('../index');
 const optimist = require('optimist');
 
@@ -43,7 +44,7 @@ if (!argv.server) {
 
     var output = [];
 
-    var parser = new xml2js.Parser({ explicitArray: true });
+    var parser = new xml2js.Parser(xml2js_opts);
     parser.parseString(xml, function(err, result) {
       if (err) die(err);
 

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -1,7 +1,7 @@
 const EventEmitter = require('events').EventEmitter;
 const constants = require('./constants');
 const stdDbusIfaces = require('./stdifaces');
-const introspect = require('./introspect');
+const introspect = require('./introspect').introspectBus;
 
 module.exports = function bus(conn, opts) {
   if (!(this instanceof bus)) {

--- a/lib/introspect.js
+++ b/lib/introspect.js
@@ -1,6 +1,6 @@
 const xml2js = require('xml2js');
 
-module.exports = function(obj, callback) {
+module.exports.introspectBus = function(obj, callback) {
   var bus = obj.service.bus;
   bus.invoke(
     {
@@ -9,183 +9,193 @@ module.exports = function(obj, callback) {
       interface: 'org.freedesktop.DBus.Introspectable',
       member: 'Introspect'
     },
-    function(err, xml) {
-      if (err) return callback(err);
-      var parser = new xml2js.Parser({ explicitArray: true });
-      parser.parseString(xml, function(err, result) {
-        if (err) return callback(err);
-        if (!result.interface) {
-          if (result.node && result.node.length > 0 && result.node[0]['@']) {
-            var subObj = Object.assign(obj, {});
-            if (subObj.name.slice(-1) !== '/') subObj.name += '/';
-            subObj.name += result.node[0]['@'].name;
-            return module.exports(subObj, callback);
-          }
-          return callback(new Error('No such interface found'));
-        }
-        var proxy = {};
-        var nodes = [];
-        var ifaceName, method, property, iface, arg, signature, currentIface;
-        var ifaces = result['interface'];
-        var xmlnodes = result['node'] || [];
-
-        for (var n = 1; n < xmlnodes.length; ++n) {
-          // Start at 1 because we want to skip the root node
-          nodes.push(xmlnodes[n]['@']['name']);
-        }
-
-        for (var i = 0; i < ifaces.length; ++i) {
-          iface = ifaces[i];
-          ifaceName = iface['@'].name;
-          currentIface = proxy[ifaceName] = {};
-
-          (function() {
-            var callbacks = [];
-            var sigHandlers = [];
-            function getSigHandler(callback) {
-              var index;
-              if ((index = callbacks.indexOf(callback)) === -1) {
-                index = callbacks.push(callback) - 1;
-                sigHandlers[index] = function(messageBody) {
-                  callback.apply(null, messageBody);
-                };
-              }
-              return sigHandlers[index];
-            }
-
-            function getMatchRule(objName, ifName, signame) {
-              return `type='signal',path='${objName}',interface='${
-                ifName
-              }',member='${signame}'`;
-            }
-
-            currentIface.addListener = currentIface.on = (function(ifName) {
-              return function(signame, callback) {
-                // http://dbus.freedesktop.org/doc/api/html/group__DBusBus.html#ga4eb6401ba014da3dbe3dc4e2a8e5b3ef
-                // An example is "type='signal',sender='org.freedesktop.DBus', interface='org.freedesktop.DBus',member='Foo', path='/bar/foo',destination=':452345.34'" ...
-
-                var signalFullName = bus.mangle(obj.name, ifName, signame);
-
-                if (!bus.signals.listeners(signalFullName).length) {
-                  // This is the first time, so call addMatch
-                  var match = getMatchRule(obj.name, ifName, signame);
-                  bus.addMatch(match, function(err) {
-                    if (err) throw new Error(err);
-
-                    bus.signals.on(signalFullName, getSigHandler(callback));
-                  });
-                } else {
-                  // The match is already there, just add event listener
-                  bus.signals.on(signalFullName, getSigHandler(callback));
-                }
-              };
-            })(ifaceName);
-
-            currentIface.removeListener = (function(ifName) {
-              return function(signame, callback) {
-                var signalFullName = bus.mangle(obj.name, ifName, signame);
-                bus.signals.removeListener(
-                  signalFullName,
-                  getSigHandler(callback)
-                );
-
-                if (!bus.signals.listeners(signalFullName).length) {
-                  // There is no event handlers for this match
-                  var match = getMatchRule(obj.name, ifName, signame);
-                  bus.removeMatch(match, function(err) {
-                    if (err) throw new Error(err);
-
-                    // Now it is safe to empty these arrays
-                    callbacks.length = 0;
-                    sigHandlers.length = 0;
-                  });
-                }
-              };
-            })(ifaceName);
-          })();
-
-          for (var m = 0; iface.method && m < iface.method.length; ++m) {
-            method = iface.method[m];
-            signature = '';
-            var methodName = method['@'].name;
-            for (var a = 0; method.arg && a < method.arg.length; ++a) {
-              arg = method.arg[a]['@'];
-              if (arg.direction === 'in') signature += arg.type;
-            }
-
-            // add method
-            currentIface[methodName] = (function(ifName, mName, signature) {
-              return function() {
-                var args = Array.prototype.slice.apply(arguments);
-                var callback =
-                  typeof args[args.length - 1] === 'function'
-                    ? args.pop()
-                    : function() {};
-                var msg = {
-                  destination: obj.service.name,
-                  path: obj.name,
-                  interface: ifName,
-                  member: mName
-                };
-                if (signature !== '') {
-                  msg.signature = signature;
-                  msg.body = args;
-                }
-                bus.invoke(msg, callback);
-              };
-            })(ifaceName, methodName, signature);
-          }
-          for (var p = 0; iface.property && p < iface.property.length; ++p) {
-            property = iface.property[p];
-            var propertyName = property['@'].name;
-            //TODO: move up
-            var addReadProp = function(iface, ifName, propName, property) {
-              Object.defineProperty(iface, propName, {
-                enumerable: true,
-                get: function() {
-                  return function(callback) {
-                    bus.invoke(
-                      {
-                        destination: obj.service.name,
-                        path: obj.name,
-                        interface: 'org.freedesktop.DBus.Properties',
-                        member: 'Get',
-                        signature: 'ss',
-                        body: [ifName, propName]
-                      },
-                      function(err, val) {
-                        if (err) {
-                          callback(err);
-                        } else {
-                          var signature = val[0];
-                          if (signature.length === 1) {
-                            callback(err, val[1][0]);
-                          } else {
-                            callback(err, val[1]);
-                          }
-                        }
-                      }
-                    );
-                  };
-                },
-                set: function(val) {
-                  bus.invoke({
-                    destination: obj.service.name,
-                    path: obj.name,
-                    interface: 'org.freedesktop.DBus.Properties',
-                    member: 'Set',
-                    signature: 'ssv',
-                    body: [ifName, propName, [property['@'].type, val]]
-                  });
-                }
-              });
-            };
-            addReadProp(currentIface, ifaceName, propertyName, property);
-          }
-          // TODO: introspect signals
-        }
-        callback(null, proxy, nodes);
-      });
-    }
+    function(err, xml) { module.exports.processXML(err, xml, obj, callback); }
   );
 };
+
+module.exports.processXML = function(err, xml, obj, callback) {
+  if (err) return callback(err);
+  var parser = new xml2js.Parser();
+  parser.parseString(xml, function(err, result) {
+    if (err) return callback(err);
+    if (!result.node) throw new Error('No root XML node');
+    result = result.node; // unwrap the root node
+    // If no interface, try first sub node?
+    if (!result.interface) {
+      if (result.node && result.node.length > 0 && result.node[0]['$']) {
+        var subObj = Object.assign(obj, {});
+        if (subObj.name.slice(-1) !== '/') subObj.name += '/';
+        subObj.name += result.node[0]['$'].name;
+        return module.exports.introspectBus(subObj, callback);
+      }
+      return callback(new Error('No such interface found'));
+    }
+    var proxy = {};
+    var nodes = [];
+    var ifaceName, method, property, iface, arg, signature, currentIface;
+    var ifaces = result['interface'];
+    var xmlnodes = result['node'] || [];
+
+    for (var n = 1; n < xmlnodes.length; ++n) {
+      // Start at 1 because we want to skip the root node
+      nodes.push(xmlnodes[n]['$']['name']);
+    }
+
+    for (var i = 0; i < ifaces.length; ++i) {
+      iface = ifaces[i];
+      ifaceName = iface['$'].name;
+      currentIface = proxy[ifaceName] = new DBusInterface(obj, ifaceName);
+
+      for (var m = 0; iface.method && m < iface.method.length; ++m) {
+        method = iface.method[m];
+        signature = '';
+        var methodName = method['$'].name;
+        for (var a = 0; method.arg && a < method.arg.length; ++a) {
+          arg = method.arg[a]['$'];
+          if (arg.direction === 'in') signature += arg.type;
+        }
+        // add method
+        currentIface.$createMethod(methodName, signature);
+      }
+      for (var p = 0; iface.property && p < iface.property.length; ++p) {
+        property = iface.property[p];
+        currentIface.$createProp(property['$'].name, property['$'].type, property['$'].access)
+      }
+      // TODO: introspect signals
+    }
+    callback(null, proxy, nodes);
+  });
+}
+
+
+function DBusInterface(parent_obj, ifname)
+{
+  // Since methods and props presently get added directly to the object, to avoid collision with existing names we must use $ naming convention as $ is invalid for dbus member names
+  // https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names
+  this.$parent = parent_obj; // parent DbusObject
+  this.$name = ifname; // string interface name
+  this.$methods = {}; // dictionary of methods (exposed for test), should we just store signature or use object to store more info?
+  //this.$signals = {};
+  this.$properties = {};
+  this.$callbacks = [];
+  this.$sigHandlers = [];
+}
+DBusInterface.prototype.$getSigHandler = function(callback) {
+  var index;
+  if ((index = this.$callbacks.indexOf(callback)) === -1) {
+    index = this.$callbacks.push(callback) - 1;
+    this.$sigHandlers[index] = function(messageBody) {
+      callback.apply(null, messageBody);
+    };
+  }
+  return this.$sigHandlers[index];
+}
+DBusInterface.prototype.addListener = DBusInterface.prototype.on = function(signame, callback) {
+  // http://dbus.freedesktop.org/doc/api/html/group__DBusBus.html#ga4eb6401ba014da3dbe3dc4e2a8e5b3ef
+  // An example is "type='signal',sender='org.freedesktop.DBus', interface='org.freedesktop.DBus',member='Foo', path='/bar/foo',destination=':452345.34'" ...
+  var bus = this.$parent.service.bus;
+  var signalFullName = bus.mangle(this.$parent.name, this.$name, signame);
+  if (!bus.signals.listeners(signalFullName).length) {
+    // This is the first time, so call addMatch
+    var match = getMatchRule(this.$parent.name, this.$name, signame);
+    bus.addMatch(match, function(err) {
+      if (err) throw new Error(err);
+      bus.signals.on(signalFullName, this.$getSigHandler(callback));
+    }.bind(this));
+  } else {
+    // The match is already there, just add event listener
+    bus.signals.on(signalFullName, this.$getSigHandler(callback));
+  }
+}
+DBusInterface.prototype.removeListener = DBusInterface.prototype.off = function(signame, callback) {
+  var bus = this.$parent.service.bus;
+  var signalFullName = bus.mangle(this.$parent.name, this.$name, signame);
+  bus.signals.removeListener( signalFullName, this.$getSigHandler(callback) );
+  if (!bus.signals.listeners(signalFullName).length) {
+    // There is no event handlers for this match
+    var match = getMatchRule(this.$parent.name, this.$name, signame);
+    bus.removeMatch(match, function(err) {
+      if (err) throw new Error(err);
+      // Now it is safe to empty these arrays
+      this.$callbacks.length = 0;
+      this.$sigHandlers.length = 0;
+    }.bind(this));
+  }
+}
+DBusInterface.prototype.$createMethod = function(mName, signature)
+{
+  this.$methods[mName] = signature;
+  this[mName] = function() { this.$callMethod(mName, arguments); }
+}
+DBusInterface.prototype.$callMethod = function(mName, args)
+{
+  var bus = this.$parent.service.bus;
+  if (!Array.isArray(args)) args = Array.from(args); // Array.prototype.slice.apply(args)
+  var callback =
+    typeof args[args.length - 1] === 'function'
+      ? args.pop()
+      : function() {};
+  var msg = {
+    destination: this.$parent.service.name,
+    path: this.$parent.name,
+    interface: this.$name,
+    member: mName
+  };
+  if (this.$methods[mName] !== '') {
+    msg.signature = this.$methods[mName];
+    msg.body = args;
+  }
+  bus.invoke(msg, callback);
+}
+DBusInterface.prototype.$createProp = function(propName, propType, propAccess)
+{
+  this.$properties[propName] = { type: propType, access: propAccess };
+  Object.defineProperty(this, propName, {
+    enumerable: true,
+    get: function(callback) { this.$readProp(propName, callback) },
+    set: function(val) { this.$writeProp(propName, val) }
+  });
+}
+DBusInterface.prototype.$readProp = function(propName, callback)
+{
+  var bus = this.$parent.service.bus;
+  bus.invoke(
+    {
+      destination: this.$parent.service.name,
+      path: this.$parent.name,
+      interface: 'org.freedesktop.DBus.Properties',
+      member: 'Get',
+      signature: 'ss',
+      body: [this.$name, propName]
+    },
+    function(err, val) {
+      if (err) {
+        callback(err);
+      } else {
+        var signature = val[0];
+        if (signature.length === 1) {
+          callback(err, val[1][0]);
+        } else {
+          callback(err, val[1]);
+        }
+      }
+    }
+  );
+}
+DBusInterface.prototype.$writeProp = function(propName, val)
+{
+  var bus = this.$parent.service.bus;
+  bus.invoke({
+    destination: this.$parent.service.name,
+    path: this.$parent.name,
+    interface: 'org.freedesktop.DBus.Properties',
+    member: 'Set',
+    signature: 'ssv',
+    body: [this.$name, propName, [this.$properties[propName].type, val]]
+  });
+}
+
+
+function getMatchRule(objName, ifName, signame) {
+  return `type='signal',path='${objName}',interface='${ifName}',member='${signame}'`;
+}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "optimist": "^0.6.1",
     "put": "0.0.6",
     "safe-buffer": "^5.1.1",
-    "xml2js": "0.1.14"
+    "xml2js": "^0.4.17"
   },
   "optionalDependencies": {
     "abstract-socket": "^2.0.0"

--- a/test/fixtures/introspection/example.json
+++ b/test/fixtures/introspection/example.json
@@ -1,0 +1,13 @@
+{
+    "interfaces":[
+        {
+            "name":"com.example.MyService1.InterestingInterface",
+            "methods": [
+                {"name":"AddContact", "signature":"ss"}
+            ],
+            "properties": [
+                {"name":"Status", "type":"u", "access":"read"}
+            ]
+        }
+    ]
+}

--- a/test/fixtures/introspection/example.xml
+++ b/test/fixtures/introspection/example.xml
@@ -1,0 +1,28 @@
+<!DOCTYPE node PUBLIC
+    "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+    "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd" >
+    <!-- https://www.gnu.org/software/emacs/manual/html_node/dbus/Introspection.html -->
+    <!-- https://dbus.freedesktop.org/doc/dbus-api-design.html#interface-files -->
+<node xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <interface name="com.example.MyService1.InterestingInterface">
+    <method name="AddContact">
+      <arg name="name" direction="in" type="s">
+        <doc:doc><doc:summary>Name of new contact</doc:summary></doc:doc>
+      </arg>
+      <arg name="email" direction="in" type="s">
+        <doc:doc><doc:summary>E-mail address of new contact</doc:summary></doc:doc>
+      </arg>
+      <arg name="id" direction="out" type="u">
+        <doc:doc><doc:summary>ID of newly added contact</doc:summary></doc:doc>
+      </arg>
+    </method>
+    <signal name="StateChanged">
+        <arg name="state" type="i"/>
+        <arg name="error" type="s"/>
+    </signal>
+    <property name="Status" type="u" access="read"/>
+  </interface>
+  <!-- subnodes ?
+  <node name="service_network"/>
+  -->
+</node>

--- a/test/test_introspect.js
+++ b/test/test_introspect.js
@@ -1,0 +1,73 @@
+const introspect = require('../lib/introspect');
+const fs = require('fs');
+const path = require('path');
+
+// Introspection test cases
+var testCases = [
+    {desc:'Basic Example', file:'example'}
+];
+
+describe('given introspect xml', function() {
+    for (var i=0; i<testCases.length; ++i)
+    {
+        var curTest = testCases[i];
+        it('should correctly process ' + curTest.desc, function() {
+            return testXml(curTest.file);
+        });
+    }
+  });
+
+const dummyObj = {};
+function testXml(fname)
+{
+    var fpath = path.join(__dirname, 'fixtures', 'introspection', fname);
+    return new Promise((resolve,reject)=>
+    {
+        // get expected data from json file
+        fs.readFile(fpath+'.json', 'utf8', function (err, data)
+        {
+            if (err) reject(err);
+            var test_obj = JSON.parse(data);
+            // get introspect xml from xml file
+            fs.readFile(fpath+'.xml', function(err, xml_data)
+            {
+                if (err) reject(err);
+                else
+                {
+                    introspect.processXML(err, xml_data, dummyObj, function(err, proxy, nodes)
+                    {
+                        if (err) reject(err);
+                        else
+                        {
+                            checkIntrospection(test_obj, proxy, nodes)
+                            resolve();
+                        }
+                    });
+                };
+            });
+        });
+    });
+}
+
+function checkIntrospection(test_obj, proxy, nodes)
+{
+    for (var i=0; i<test_obj.interfaces.length; ++i)
+    {
+        var testInterface = test_obj.interfaces[i];
+        if (proxy[testInterface.name]==undefined) throw new Error('Failed to introspect interface name ' + testInterface.name);
+        for (var m=0; m<testInterface.methods.length; ++m)
+        {
+            var methodName = testInterface.methods[m].name;
+            var curMethod = proxy[testInterface.name].$methods[methodName];
+            if (curMethod==undefined)  throw new Error('Failed to introspect method name ' + methodName + ' of ' + testInterface.name);
+            if (curMethod !== testInterface.methods[m].signature) throw new Error('Failed to introspect method args of ' + methodName + ' of ' + testInterface.name);
+        }
+        for (var p=0; p<testInterface.properties.length; ++p)
+        {
+            var propName = testInterface.properties[p].name;
+            var curProp = proxy[testInterface.name].$properties[propName];
+            if (curProp==undefined) throw new Error('Failed to introspect property name ' + propName + ' of ' + testInterface.name);
+            if (curProp.type !== testInterface.properties[p].type) throw new Error('Failed to introspect property type of ' + propName + ' of ' + testInterface.name);
+        }
+    }
+}


### PR DESCRIPTION
xml2js changed up default options when transitioning from 0.1 to 0.2, so I tried to accommodate those changes. I was not exactly sure how to test introspection changes, so I made a feeble attempt at creating some form of test fixturing. However in order to test introspection, I needed to isolate the XML processing portion of introspection, which was the source of the heaviest changes. Not sure how desirable or palatable these changes are, so I figured I would create this PR and they could be reviewed.