### PR TITLE
Throw error when getting object with undefined name

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -255,7 +255,7 @@ module.exports = function bus(conn, opts) {
     this.bus = bus;
     this.getObject = function(name, callback) {
       if(name==undefined)
-        callback("Object name is null or undefined");
+        return callback("Object name is null or undefined");
       var obj = new DBusObject(name, this);
       introspect(obj, function(err, ifaces, nodes) {
         if (err) return callback(err);

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -254,6 +254,8 @@ module.exports = function bus(conn, opts) {
     this.name = name;
     this.bus = bus;
     this.getObject = function(name, callback) {
+      if(name==undefined)
+        callback("Object name is null or undefined");
       var obj = new DBusObject(name, this);
       introspect(obj, function(err, ifaces, nodes) {
         if (err) return callback(err);

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -255,7 +255,7 @@ module.exports = function bus(conn, opts) {
     this.bus = bus;
     this.getObject = function(name, callback) {
       if(name==undefined)
-        return callback("Object name is null or undefined");
+        return callback(new Error('Object name is null or undefined'));
       var obj = new DBusObject(name, this);
       introspect(obj, function(err, ifaces, nodes) {
         if (err) return callback(err);


### PR DESCRIPTION
When getting an object with an undefined name, the exception you get doesn't have a nice stack trace and can be very difficult to debug. 

I recently changed a variable name in a project, only to find strange `Uncaught Error: write EPIPE` exceptions occurring at random moments. This only told me something had gone wrong with the dbus connection, but it was very difficult to find out what it was. It took me a few hours to add enough logging to find that I forgot to change a single reference, so now `undefined` was passed to the getObject method. 

This pull request adds a more verbose exception at such a moment.