### PR TITLE
Remove extra development files from npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,11 @@
     "kde"
   ],
   "description": "D-bus protocol implementation in native javascript",
+  "files": [
+    "lib/*",
+    "index.js",
+    "package.json"
+  ],
   "directories": {
     "lib": "lib",
     "test": "test",


### PR DESCRIPTION
Npm install of dbus-native includes a lot of developer files which are not necessary when installing it as a production dependency. It seems to be the convention for developers to access the extras from git if needed.

Does anyone depend on npm installing all the extra dev files? 
This PR is largely a convenience item, so whatever you all think is best.