### PR TITLE
Check message existing signature before marshalling

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -82,7 +82,7 @@ module.exports.marshall = function marshallMessage(message) {
   var type = message.type || constants.messageType.methodCall;
   var bodyLength = 0;
   var bodyBuff;
-  if (message.body) {
+  if (message.signature && message.body) {
     bodyBuff = marshall(message.signature, message.body);
     bodyLength = bodyBuff.length;
   }


### PR DESCRIPTION
Hello,

Facing a crash due to a message with an empty body and signature, I have added this robustness check. Maybe there are better ways to fix this, but, after all, it fixes the crash.


Best regards,

Emmanuel Vautrin