### PR TITLE
Prevent recursive introspect and all nodes

### DIFF
--- a/lib/introspect.js
+++ b/lib/introspect.js
@@ -20,24 +20,13 @@ module.exports.processXML = function(err, xml, obj, callback) {
     if (err) return callback(err);
     if (!result.node) throw new Error('No root XML node');
     result = result.node; // unwrap the root node
-    // If no interface, try first sub node?
-    if (!result.interface) {
-      if (result.node && result.node.length > 0 && result.node[0]['$']) {
-        var subObj = Object.assign(obj, {});
-        if (subObj.name.slice(-1) !== '/') subObj.name += '/';
-        subObj.name += result.node[0]['$'].name;
-        return module.exports.introspectBus(subObj, callback);
-      }
-      return callback(new Error('No such interface found'));
-    }
     var proxy = {};
     var nodes = [];
     var ifaceName, method, property, iface, arg, signature, currentIface;
-    var ifaces = result['interface'];
+    var ifaces = result['interface'] || [];
     var xmlnodes = result['node'] || [];
 
-    for (var n = 1; n < xmlnodes.length; ++n) {
-      // Start at 1 because we want to skip the root node
+    for (var n = 0; n < xmlnodes.length; ++n) {
       nodes.push(xmlnodes[n]['$']['name']);
     }
 

--- a/lib/introspect.js
+++ b/lib/introspect.js
@@ -9,7 +9,9 @@ module.exports.introspectBus = function(obj, callback) {
       interface: 'org.freedesktop.DBus.Introspectable',
       member: 'Introspect'
     },
-    function(err, xml) { module.exports.processXML(err, xml, obj, callback); }
+    function(err, xml) {
+      module.exports.processXML(err, xml, obj, callback);
+    }
   );
 };
 
@@ -23,7 +25,25 @@ module.exports.processXML = function(err, xml, obj, callback) {
     var proxy = {};
     var nodes = [];
     var ifaceName, method, property, iface, arg, signature, currentIface;
-    var ifaces = result['interface'] || [];
+    var ifaces = result['interface'] || [
+      {
+        $: { name: 'org.freedesktop.DBus.Introspectable' },
+        method: [
+          {
+            $: { name: 'Introspect' },
+            arg: [
+              {
+                $: {
+                  type: 's',
+                  name: 'xml_data',
+                  direction: 'out'
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ];
     var xmlnodes = result['node'] || [];
 
     for (var n = 0; n < xmlnodes.length; ++n) {
@@ -48,17 +68,19 @@ module.exports.processXML = function(err, xml, obj, callback) {
       }
       for (var p = 0; iface.property && p < iface.property.length; ++p) {
         property = iface.property[p];
-        currentIface.$createProp(property['$'].name, property['$'].type, property['$'].access)
+        currentIface.$createProp(
+          property['$'].name,
+          property['$'].type,
+          property['$'].access
+        );
       }
       // TODO: introspect signals
     }
     callback(null, proxy, nodes);
   });
-}
+};
 
-
-function DBusInterface(parent_obj, ifname)
-{
+function DBusInterface(parent_obj, ifname) {
   // Since methods and props presently get added directly to the object, to avoid collision with existing names we must use $ naming convention as $ is invalid for dbus member names
   // https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names
   this.$parent = parent_obj; // parent DbusObject
@@ -78,8 +100,11 @@ DBusInterface.prototype.$getSigHandler = function(callback) {
     };
   }
   return this.$sigHandlers[index];
-}
-DBusInterface.prototype.addListener = DBusInterface.prototype.on = function(signame, callback) {
+};
+DBusInterface.prototype.addListener = DBusInterface.prototype.on = function(
+  signame,
+  callback
+) {
   // http://dbus.freedesktop.org/doc/api/html/group__DBusBus.html#ga4eb6401ba014da3dbe3dc4e2a8e5b3ef
   // An example is "type='signal',sender='org.freedesktop.DBus', interface='org.freedesktop.DBus',member='Foo', path='/bar/foo',destination=':452345.34'" ...
   var bus = this.$parent.service.bus;
@@ -87,43 +112,50 @@ DBusInterface.prototype.addListener = DBusInterface.prototype.on = function(sign
   if (!bus.signals.listeners(signalFullName).length) {
     // This is the first time, so call addMatch
     var match = getMatchRule(this.$parent.name, this.$name, signame);
-    bus.addMatch(match, function(err) {
-      if (err) throw new Error(err);
-      bus.signals.on(signalFullName, this.$getSigHandler(callback));
-    }.bind(this));
+    bus.addMatch(
+      match,
+      function(err) {
+        if (err) throw new Error(err);
+        bus.signals.on(signalFullName, this.$getSigHandler(callback));
+      }.bind(this)
+    );
   } else {
     // The match is already there, just add event listener
     bus.signals.on(signalFullName, this.$getSigHandler(callback));
   }
-}
-DBusInterface.prototype.removeListener = DBusInterface.prototype.off = function(signame, callback) {
+};
+DBusInterface.prototype.removeListener = DBusInterface.prototype.off = function(
+  signame,
+  callback
+) {
   var bus = this.$parent.service.bus;
   var signalFullName = bus.mangle(this.$parent.name, this.$name, signame);
-  bus.signals.removeListener( signalFullName, this.$getSigHandler(callback) );
+  bus.signals.removeListener(signalFullName, this.$getSigHandler(callback));
   if (!bus.signals.listeners(signalFullName).length) {
     // There is no event handlers for this match
     var match = getMatchRule(this.$parent.name, this.$name, signame);
-    bus.removeMatch(match, function(err) {
-      if (err) throw new Error(err);
-      // Now it is safe to empty these arrays
-      this.$callbacks.length = 0;
-      this.$sigHandlers.length = 0;
-    }.bind(this));
+    bus.removeMatch(
+      match,
+      function(err) {
+        if (err) throw new Error(err);
+        // Now it is safe to empty these arrays
+        this.$callbacks.length = 0;
+        this.$sigHandlers.length = 0;
+      }.bind(this)
+    );
   }
-}
-DBusInterface.prototype.$createMethod = function(mName, signature)
-{
+};
+DBusInterface.prototype.$createMethod = function(mName, signature) {
   this.$methods[mName] = signature;
-  this[mName] = function() { this.$callMethod(mName, arguments); }
-}
-DBusInterface.prototype.$callMethod = function(mName, args)
-{
+  this[mName] = function() {
+    this.$callMethod(mName, arguments);
+  };
+};
+DBusInterface.prototype.$callMethod = function(mName, args) {
   var bus = this.$parent.service.bus;
   if (!Array.isArray(args)) args = Array.from(args); // Array.prototype.slice.apply(args)
   var callback =
-    typeof args[args.length - 1] === 'function'
-      ? args.pop()
-      : function() {};
+    typeof args[args.length - 1] === 'function' ? args.pop() : function() {};
   var msg = {
     destination: this.$parent.service.name,
     path: this.$parent.name,
@@ -135,18 +167,20 @@ DBusInterface.prototype.$callMethod = function(mName, args)
     msg.body = args;
   }
   bus.invoke(msg, callback);
-}
-DBusInterface.prototype.$createProp = function(propName, propType, propAccess)
-{
+};
+DBusInterface.prototype.$createProp = function(propName, propType, propAccess) {
   this.$properties[propName] = { type: propType, access: propAccess };
   Object.defineProperty(this, propName, {
     enumerable: true,
-    get: function(callback) { this.$readProp(propName, callback) },
-    set: function(val) { this.$writeProp(propName, val) }
+    get: function(callback) {
+      this.$readProp(propName, callback);
+    },
+    set: function(val) {
+      this.$writeProp(propName, val);
+    }
   });
-}
-DBusInterface.prototype.$readProp = function(propName, callback)
-{
+};
+DBusInterface.prototype.$readProp = function(propName, callback) {
   var bus = this.$parent.service.bus;
   bus.invoke(
     {
@@ -170,9 +204,8 @@ DBusInterface.prototype.$readProp = function(propName, callback)
       }
     }
   );
-}
-DBusInterface.prototype.$writeProp = function(propName, val)
-{
+};
+DBusInterface.prototype.$writeProp = function(propName, val) {
   var bus = this.$parent.service.bus;
   bus.invoke({
     destination: this.$parent.service.name,
@@ -182,8 +215,7 @@ DBusInterface.prototype.$writeProp = function(propName, val)
     signature: 'ssv',
     body: [this.$name, propName, [this.$properties[propName].type, val]]
   });
-}
-
+};
 
 function getMatchRule(objName, ifName, signame) {
   return `type='signal',path='${objName}',interface='${ifName}',member='${signame}'`;


### PR DESCRIPTION
The current implementation recursively looks for an object which has a list of interfaces. This makes it impossible to do proper node introspection on the root node or any node that does not have interfaces. Also, the first node in the list of subnodes is being skipped on the assumption that it represents the root node. I can't seem to find any dbus object that includes the parent node in the list of subnodes.

This PR removes recursive introspection and instead returns the introspection details for the path that was explicitly requested. It also includes all subnodes in the result.

### Example Usage

```javascript
var dbus = require('dbus-native');
sessionBus = dbus.sessionBus();
sessionBus.getObject('org.gnome.Calendar', '/', function(err, obj){ console.log(obj); })
```

`proxy` in this result is empty and `nodes` is `[ 'org' ]`