### PR TITLE
Implement org.freedesktop.DBus.Properties.Set

### DIFF
--- a/lib/stdifaces.js
+++ b/lib/stdifaces.js
@@ -1,5 +1,6 @@
 const constants = require('./constants');
 const parseSignature = require('./signature');
+const variant = require('./variant');
 
 // TODO: use xmlbuilder
 
@@ -109,7 +110,10 @@ module.exports = function(msg, bus) {
         propertiesReply.signature = 'v';
         propertiesReply.body = [[propType, propValue]];
       } else {
-        impl[propertyName] = 1234; // TODO: read variant and set property value
+        if (variant.typesEqual(propType, msg.body[2][0])) {
+          // TODO error if types are not equal
+          impl[propertyName] = variant.parse(msg.body[2]);
+        }
       }
     } else if (msg.member === 'GetAll') {
       propertiesReply.signature = 'a{sv}';
@@ -152,9 +156,9 @@ function interfaceToXML(iface) {
       var argName = argsNames ? argsNames[num] : direction + num;
       var dirStr = direction === 'signal' ? '' : `" direction="${direction}`;
       result.push(
-        `      <arg type="${dumpSignature([arg])}" name="${argName}${
-          dirStr
-        }" />`
+        `      <arg type="${dumpSignature([
+          arg
+        ])}" name="${argName}${dirStr}" />`
       );
     });
   };

--- a/lib/variant.js
+++ b/lib/variant.js
@@ -1,0 +1,68 @@
+const assert = require('assert');
+const parseSignature = require('./signature');
+
+function valueIsVariant(value) {
+  return Array.isArray(value) && value.length == 2 && value[0][0].type;
+}
+
+function typesEqual(typeA, typeB) {
+  if (typeof typeA === 'string') {
+    typeA = parseSignature(typeA);
+  }
+  if (typeof typeB === 'string') {
+    typeB = parseSignature(typeB);
+  }
+
+  try {
+    assert.deepEqual(typeA, typeB);
+  } catch (e) {
+    return false;
+  }
+
+  return true;
+}
+
+function parse(variant) {
+  // parses a single complete variant
+  var type = variant[0][0];
+  var value = variant[1][0];
+
+  if (!type.child.length) {
+    if (valueIsVariant(value)) {
+      return parse(value);
+    } else {
+      return value;
+    }
+  }
+
+  if (type.type === 'a') {
+    if (type.child[0].type === '{') {
+      // this is an array of dictionary entries
+      var result = {};
+      for (var i = 0; i < value.length; ++i) {
+        // dictionary keys must have basic types
+        result[value[i][0]] = parse([[type.child[0].child[1]], [value[i][1]]]);
+      }
+      return result;
+    } else {
+      // other arrays only have one type
+      var result = [];
+      for (var i = 0; i < value.length; ++i) {
+        result[i] = parse([[type.child[0]], [value[i]]]);
+      }
+      return result;
+    }
+  } else if (type.type === '(') {
+    // structs have types equal to the number of children
+    var result = [];
+    for (var i = 0; i < value.length; ++i) {
+      result[i] = parse([[type.child[i]], [value[i]]]);
+    }
+    return result;
+  }
+}
+
+module.exports = {
+  parse: parse,
+  typesEqual: typesEqual
+};

--- a/test/variant.js
+++ b/test/variant.js
@@ -1,0 +1,280 @@
+assert = require('assert');
+const variant = require('../lib/variant');
+
+// Test methodology:
+// 1. Send a dbus command with the variant in the designated form such as this:
+// gdbus call --session --dest org.test --object-path /org/test --method org.freedesktop.DBus.Properties.Set org.test.interface TestProp "<{'bat': <'baz'>}>"
+// 2. Inspect the kind of object the marshaller turns it into
+// 3. Parse the variant with variant.parse()
+// 4. Make sure you get the desired JS object back
+
+// <{'foo': 'bar', 'bat': 'baz'}>
+var simpleDict = [
+  [
+    {
+      type: 'a',
+      child: [
+        {
+          type: '{',
+          child: [{ type: 's', child: [] }, { type: 's', child: [] }]
+        }
+      ]
+    }
+  ],
+  [[['foo', 'bar'], ['bat', 'baz']]]
+];
+assert.deepEqual(variant.parse(simpleDict), { foo: 'bar', bat: 'baz' });
+
+// <{'foo': <'bar'>, 'bat': <53>}>
+var dictOfStringVariant = [
+  [
+    {
+      type: 'a',
+      child: [
+        {
+          type: '{',
+          child: [{ type: 's', child: [] }, { type: 'v', child: [] }]
+        }
+      ]
+    }
+  ],
+  [
+    [
+      ['foo', [[{ type: 's', child: [] }], ['bar']]],
+      ['bat', [[{ type: 'i', child: [] }], [53]]]
+    ]
+  ]
+];
+assert.deepEqual(variant.parse(dictOfStringVariant), { foo: 'bar', bat: 53 });
+
+// <{'foo': [<'bar'>, <53>], 'bat': [<'baz'>, <21>]}>
+var dictOfVariantLists = [
+  [
+    {
+      type: 'a',
+      child: [
+        {
+          type: '{',
+          child: [
+            { type: 's', child: [] },
+            { type: 'a', child: [{ type: 'v', child: [] }] }
+          ]
+        }
+      ]
+    }
+  ],
+  [
+    [
+      [
+        'foo',
+        [
+          [[{ type: 's', child: [] }], ['bar']],
+          [[{ type: 'i', child: [] }], [53]]
+        ]
+      ],
+      [
+        'bat',
+        [
+          [[{ type: 's', child: [] }], ['baz']],
+          [[{ type: 'i', child: [] }], [21]]
+        ]
+      ]
+    ]
+  ]
+];
+
+assert.deepEqual(variant.parse(dictOfVariantLists), {
+  foo: ['bar', 53],
+  bat: ['baz', 21]
+});
+
+// <[<{'foo':'bar'}>, <{'bat':'baz'}>, <53>]>
+var listOfVariantDicts = [
+  [{ type: 'a', child: [{ type: 'v', child: [] }] }],
+  [
+    [
+      [
+        [
+          {
+            type: 'a',
+            child: [
+              {
+                type: '{',
+                child: [{ type: 's', child: [] }, { type: 's', child: [] }]
+              }
+            ]
+          }
+        ],
+        [[['foo', 'bar']]]
+      ],
+      [
+        [
+          {
+            type: 'a',
+            child: [
+              {
+                type: '{',
+                child: [{ type: 's', child: [] }, { type: 's', child: [] }]
+              }
+            ]
+          }
+        ],
+        [[['bat', 'baz']]]
+      ],
+      [[{ type: 'i', child: [] }], [53]]
+    ]
+  ]
+];
+assert.deepEqual(variant.parse(listOfVariantDicts), [
+  { foo: 'bar' },
+  { bat: 'baz' },
+  53
+]);
+
+// <'foo'>
+var simpleString = [[{ type: 's', child: [] }], ['foo']];
+assert.equal(variant.parse(simpleString), 'foo');
+
+// <['foo', 'bar']>
+var listOfStrings = [
+  [{ type: 'a', child: [{ type: 's', child: [] }] }],
+  [['foo', 'bar']]
+];
+assert.deepEqual(variant.parse(listOfStrings), ['foo', 'bar']);
+
+// <('foo', 'bar')>
+var simpleStruct = [
+  [{ type: '(', child: [{ type: 's', child: [] }, { type: 's', child: [] }] }],
+  [['foo', 'bar']]
+];
+assert.deepEqual(variant.parse(simpleStruct), ['foo', 'bar']);
+
+// <(<'foo'>, 53)>
+var structWithVariant = [
+  [{ type: '(', child: [{ type: 'v', child: [] }, { type: 'i', child: [] }] }],
+  [[[[{ type: 's', child: [] }], ['foo']], 53]]
+];
+assert.deepEqual(variant.parse(structWithVariant), ['foo', 53]);
+
+// <[('foo', 'bar'), ('bat', 'baz')]>
+var listOfStructs = [
+  [
+    {
+      type: 'a',
+      child: [
+        {
+          type: '(',
+          child: [{ type: 's', child: [] }, { type: 's', child: [] }]
+        }
+      ]
+    }
+  ],
+  [[['foo', 'bar'], ['bat', 'baz']]]
+];
+assert.deepEqual(variant.parse(listOfStructs), [
+  ['foo', 'bar'],
+  ['bat', 'baz']
+]);
+
+// <('foo', 'bar', ('bat', 'baz'))>
+var nestedStruct = [
+  [
+    {
+      type: '(',
+      child: [
+        { type: 's', child: [] },
+        { type: 's', child: [] },
+        {
+          type: '(',
+          child: [
+            { type: 's', child: [] },
+            {
+              type: '(',
+              child: [{ type: 's', child: [] }, { type: 's', child: [] }]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  [['foo', 'bar', ['bat', ['baz', 'bar']]]]
+];
+assert.deepEqual(variant.parse(nestedStruct), [
+  'foo',
+  'bar',
+  ['bat', ['baz', 'bar']]
+]);
+
+// <('foo', 'bar', ('bat', ('baz', <'bar'>)))>
+var nestedStructWithVariant = [
+  [
+    {
+      type: '(',
+      child: [
+        { type: 's', child: [] },
+        { type: 's', child: [] },
+        {
+          type: '(',
+          child: [
+            { type: 's', child: [] },
+            {
+              type: '(',
+              child: [{ type: 's', child: [] }, { type: 'v', child: [] }]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  [['foo', 'bar', ['bat', ['baz', [[{ type: 's', child: [] }], ['bar']]]]]]
+];
+assert.deepEqual(variant.parse(nestedStructWithVariant), [
+  'foo',
+  'bar',
+  ['bat', ['baz', 'bar']]
+]);
+
+// <[<'foo'>, <('bar', ('bat', <[<'baz'>, <53>]>))>]>
+var arrayWithinStruct = [
+  [{ type: 'a', child: [{ type: 'v', child: [] }] }],
+  [
+    [
+      [[{ type: 's', child: [] }], ['foo']],
+      [
+        [
+          {
+            type: '(',
+            child: [
+              { type: 's', child: [] },
+              {
+                type: '(',
+                child: [{ type: 's', child: [] }, { type: 'v', child: [] }]
+              }
+            ]
+          }
+        ],
+        [
+          [
+            'bar',
+            [
+              'bat',
+              [
+                [{ type: 'a', child: [{ type: 'v', child: [] }] }],
+                [
+                  [
+                    [[{ type: 's', child: [] }], ['baz']],
+                    [[{ type: 'i', child: [] }], [53]]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  ]
+];
+assert.deepEqual(variant.parse(arrayWithinStruct), [
+  'foo',
+  ['bar', ['bat', ['baz', 53]]]
+]);


### PR DESCRIPTION
Add a new variant parser to turn a variant into a JS object.

When the `Set` method is called, use the parser to set the object if it
matches the signature.

fixes #129