### PR TITLE
Fix issue where getter for properties would return undefined

### DIFF
--- a/lib/introspect.js
+++ b/lib/introspect.js
@@ -152,7 +152,7 @@ DBusInterface.prototype.$createProp = function(propName, propType, propAccess)
   this.$properties[propName] = { type: propType, access: propAccess };
   Object.defineProperty(this, propName, {
     enumerable: true,
-    get: function(callback) { this.$readProp(propName, callback) },
+    get: () => callback => this.$readProp(propName, callback),
     set: function(val) { this.$writeProp(propName, val) }
   });
 }


### PR DESCRIPTION
Trying to access properties on dbus interfaces would result in undefined instead of returning a function taking a callback.