### PR TITLE
Return promises from methods if no callback is provided

### DIFF
--- a/lib/introspect.js
+++ b/lib/introspect.js
@@ -125,7 +125,7 @@ DBusInterface.prototype.removeListener = DBusInterface.prototype.off = function(
 DBusInterface.prototype.$createMethod = function(mName, signature)
 {
   this.$methods[mName] = signature;
-  this[mName] = function() { this.$callMethod(mName, arguments); }
+  this[mName] = function() { return this.$callMethod(mName, arguments); }
 }
 DBusInterface.prototype.$callMethod = function(mName, args)
 {
@@ -134,18 +134,30 @@ DBusInterface.prototype.$callMethod = function(mName, args)
   var callback =
     typeof args[args.length - 1] === 'function'
       ? args.pop()
-      : function() {};
+      : undefined;
+
   var msg = {
     destination: this.$parent.service.name,
     path: this.$parent.name,
     interface: this.$name,
     member: mName
   };
+
   if (this.$methods[mName] !== '') {
     msg.signature = this.$methods[mName];
     msg.body = args;
   }
-  bus.invoke(msg, callback);
+
+  if (callback) {
+    bus.invoke(msg, callback);
+  } else {
+    return new Promise((resolve, reject) => {
+      bus.invoke(msg, (err, result) => {
+        if (err) reject(err);
+        else resolve(result);
+      });
+    });
+  }
 }
 DBusInterface.prototype.$createProp = function(propName, propType, propAccess)
 {


### PR DESCRIPTION
It turns out that with a tiny change, it's possible to support calling methods async with promises, without breaking the existing callback functionality.