### PR TITLE
docs: fold the wire-layer audit into ROADMAP as PR-sized blocks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ lib/
   put.js              tiny byte-buffer builder used by the marshaller
   align.js            D-Bus padding rules
   handshake.js        client SASL auth (EXTERNAL, DBUS_COOKIE_SHA1, ANONYMOUS)
-  server-handshake.js server-side auth -- a STUB, see ROADMAP 3.5
+  server-handshake.js server-side auth -- a STUB, see ROADMAP 4.5
   introspect.js       XML introspection -> proxy objects
   stdifaces.js        org.freedesktop.DBus.{Introspectable,Properties,Peer}
   constants.js        message types, header fields, endianness
@@ -96,7 +96,7 @@ docker run --rm -it -v "$PWD":/app -w /app node:24 \
   with debug tooling).
 - Callback style is `(err, result)` and is **public API**. Adding promise
   support means returning a promise when no callback is given — never replacing
-  the callback path. See ROADMAP 2.1.
+  the callback path. See ROADMAP 3.1.
 - Commits should be [Conventional Commits](https://www.conventionalcommits.org/)
   (`feat:`, `fix:`, `deps:`, `docs:`, `chore:`). release-please derives the
   changelog and the version bump from them, so a mislabelled commit ships the
@@ -117,11 +117,11 @@ These have each bitten someone before:
   bookkeeping or everything after it misaligns.
 - **Variants unmarshal as `[signatureTree, [value]]`.** The value is at
   `[1][0]`. This leaks the parser's internal tree into the public API; it is
-  ugly, widely depended on, and changing it is a breaking change (ROADMAP 3.1).
+  ugly, widely depended on, and changing it is a breaking change (ROADMAP 4.1).
 - **`ay` is special-cased to a Buffer** (`options.ayBuffer`, default true), so
   byte arrays do not round-trip as plain arrays.
 - **64-bit types go through `long.js` and lose precision above 2^53** unless
-  `ReturnLongjs` is set. Replacing this with BigInt is planned (ROADMAP 2.2).
+  `ReturnLongjs` is set. Replacing this with BigInt is planned (ROADMAP 3.2).
 - **`lib/server-handshake.js` is not a real implementation.** It replies with a
   hardcoded GUID and cookie and logs to stdout. Do not treat `createServer` as
   working infrastructure.
@@ -145,3 +145,9 @@ These have each bitten someone before:
 `ROADMAP.md` has the triaged backlog, including which open PRs are worth
 reviving and the current state of the `dbus-next` / `@homebridge/dbus-native`
 fork situation.
+
+If you are touching the wire layer specifically, read **ROADMAP §2** first. It
+is a measured audit of the marshaller, unmarshaller and stream framing, broken
+into PR-sized blocks — including the known crash-on-malformed-input paths and
+the ~2000× headroom on byte-array marshalling. Several of the landmines above
+are scheduled to change there.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ of the three and is now the most modern. Instead:
 
 1. Reach out to the Homebridge maintainers about folding their fork back in.
    Their three deltas are already addressed here except the `long.js` ARMv6
-   workaround — which item 2 below removes the need for entirely.
+   workaround — which §3.2 (BigInt) removes the need for entirely.
 2. Close [#263](https://github.com/sidorares/dbus-native/issues/263) with a note
    explaining the current state, rather than leaving it open and ambiguous.
 3. Ship a 0.5.0 from this modernisation pass so the ecosystem sees a signal of
@@ -89,9 +89,221 @@ Landed and verified; listed here so the changelog writes itself.
 
 ---
 
-## 2. High priority
+## 2. Wire layer: audit findings
 
-### 2.1 Promise support for method calls
+The marshaller, unmarshaller and stream framing were audited on 2026-07-28
+against commit `8373dcb`. Every claim below was measured or reproduced, not
+inferred from reading; the numbers are from an M-series Mac on Node 26 and are
+meant for relative comparison, not as absolutes.
+
+Blocks are sized to be one PR each and are listed in the order they should
+land. §2.1 is security-relevant and should go first; §2.2 is the largest win
+and is independent of it.
+
+### 2.1 Harden the read loop against malformed input
+
+**Severity: high — a hostile or buggy peer can crash the process.**
+
+`lib/message.js` reads a 16-byte header, trusts the declared lengths, and calls
+`onMessage()` from inside the `'readable'` handler with no error boundary.
+Reproduced, each in a fresh process:
+
+```
+bad-header       exit=1  CRASHED: RangeError [ERR_OUT_OF_RANGE]: "size" ... <= 1GiB
+handler-throws   exit=1  CRASHED: Error: handler blew up
+truncated-tail   exit=0  survived (waiting for rest)
+```
+
+Work:
+
+- **Enforce the spec limits.** The D-Bus spec caps a message at 128 MiB and an
+  array at 64 MiB. Nothing enforces either, so a peer declaring a 900 MB body
+  makes us buffer 900 MB, and anything over 1 GiB throws out of `stream.read()`.
+  Reject oversized declarations with a protocol error and destroy the
+  connection instead of trying to satisfy them.
+- **Fix the int32 overflow at `message.js:25`.** `((fieldsLength + 7) >> 3) << 3`
+  yields `-16` for `fieldsLength = 0xfffffff0` instead of 4294967280, so
+  `fieldsAndBodyLength` can go negative. Use `Math.ceil(n / 8) * 8` or apply the
+  size cap before the arithmetic.
+- **Guard the no-body case in `message.unmarshall()`.** Line 73 calls
+  `msgBuf.read(message.signature)` unconditionally, so _every_ argument-less
+  message — `Hello`, `Ping`, `ListNames` — throws
+  `TypeError: Cannot read properties of undefined`. The streaming path at line
+  50 already guards correctly with `if (bodyLength > 0 && message.signature)`;
+  make the two agree. This is exported API and is used by `bin/dbus-dissect.js`.
+- **Make `readString` reject rather than truncate.** `buffer.toString('utf8',
+pos, pos + len)` silently clamps to the buffer end, so a corrupt length field
+  produces a short string and no error. Validate `pos + len` against the buffer
+  and check the trailing NUL.
+- **Give the parse loop an error boundary.** A throw currently escapes the
+  `'readable'` handler and becomes an uncaught exception. Catch it, emit it on
+  the connection as `'error'`, and stop parsing that connection.
+
+### 2.2 Isolate user handlers from the read loop
+
+**Severity: high — an ordinary application bug kills the process.**
+
+Distinct from §2.1 and worth its own change: message dispatch runs synchronously
+inside the read loop, so an exception in _user_ code unwinds through the parser.
+Method-call handlers are safe because `lib/bus.js` wraps them in
+`Promise.resolve().then()`, but signal delivery is a plain synchronous `emit`:
+
+```
+Error: bug inside a user signal handler
+    at EventEmitter.emit (node:events:509:20)
+    at EventEmitter.<anonymous> (lib/bus.js:144:20)     <- signals.emit
+    at index.js:110:14
+    at Socket.<anonymous> (lib/message.js:53:9)          <- readable handler
+```
+
+Dispatch should be isolated so a listener that throws surfaces as a connection
+`'error'` (or an `uncaughtException`-style hook) without taking down the parser
+or losing the rest of the read buffer. Care needed: this changes observable
+behaviour for anyone currently relying on the crash, so it wants a note in the
+changelog.
+
+### 2.3 Rewrite the marshaller onto a single-buffer cursor writer
+
+**Severity: high for throughput — up to 2000× on byte arrays.**
+
+`lib/marshall.js` and `lib/put.js` allocate a fresh `Buffer` for every scalar
+written, push it onto an array, and `Buffer.concat` at the end. Byte arrays are
+walked element-by-element, so an `ay` costs one allocation _per byte_:
+**1026 `Buffer.alloc` calls to marshal 1 KB**, and 28 for a small method call.
+
+Measured against a prototype cursor writer (grow-on-demand buffer, strings
+written via `buf.write()` + `Buffer.byteLength` with no intermediate, `ay`
+fast-pathed to a single copy). The prototype produced **byte-identical output on
+30/30 cases** including non-zero start offsets:
+
+| case                          | shipped    | prototype |           |
+| ----------------------------- | ---------- | --------- | --------- |
+| Notify-like (`susssasa{sv}i`) | 4.92 µs    | 1.18 µs   | 4.2×      |
+| single string (`s`)           | 0.41 µs    | 0.19 µs   | 2.2×      |
+| `ai`, 10k ints                | 1226 µs    | 144 µs    | 8.5×      |
+| `as`, 1k strings              | 374 µs     | 160 µs    | 2.3×      |
+| `ay` from Buffer, 1 KB        | 105.6 µs   | 0.65 µs   | **162×**  |
+| `ay` from Buffer, 64 KB       | 14 727 µs  | 10.1 µs   | **1456×** |
+| `ay` from Buffer, 1 MB        | 293 204 µs | 141.7 µs  | **2069×** |
+
+The `ay` case is the headline: **3.5 MB/s against an ~8 GB/s memcpy ceiling**.
+Reading the same array takes 0.95 µs, so writing is ~300 000× slower than
+reading for identical data. Anything moving images, audio or file contents over
+D-Bus hits this.
+
+Fold into the same PR, since they touch the same code:
+
+- **Fast-path `ay`** when the value is a `Buffer`/`Uint8Array`: one length write
+  plus one copy.
+- **Memoise `MakeSimpleMarshaller`.** `marshall.js` constructs a fresh object
+  with fresh closures for _every scalar written_; there are only 13 types.
+  Worth ~8% on its own — small, but free once the file is open.
+- **Keep the validation.** The prototype has none; the range and type checks in
+  `marshallers.js` are load-bearing (`test/unmarshall-basic.js` asserts on them)
+  and must be ported, not dropped.
+
+This obsoletes `lib/put.js`, added in #299. That was the right minimal fix for
+removing the abandoned `put` dependency, but it inherits that package's
+allocation model.
+
+Sequence with §3.2 (BigInt): both rewrite the same scalar paths. Either do
+BigInt first and rewrite once, or accept touching `x`/`t` twice.
+
+### 2.4 Cache parsed signatures
+
+**Severity: medium — pure win, small diff.**
+
+`parseSignature` is called from `readVariant` for **every variant value**, so
+unmarshalling an `a{sv}` with 500 entries parses 500 signatures and costs
+243.6 µs. On the write path it runs once per `marshall()` call plus once per
+variant, and `'yyyyuua(yv)'` is re-parsed for every message.
+
+Signatures come from a tiny set in practice. A bounded `Map` cache (capped, so a
+peer sending unique signatures cannot grow it without limit) is a few lines.
+Note the returned tree must then be treated as immutable — check no caller
+mutates it before landing this.
+
+### 2.5 `ay` buffer views retain the whole message
+
+**Severity: medium — unbounded memory growth in long-lived processes.**
+
+`dbus-buffer.js:119` returns `this.buffer.slice(start, this.pos)`, a _view_
+sharing memory with the whole message. Verified: a 4-byte `ay` pulled out of a
+4 MB message keeps the entire 4 MB `ArrayBuffer` alive. Retain a few small byte
+arrays from large messages and memory grows with traffic, not with data kept.
+
+Also `Buffer.prototype.slice` is deprecated in favour of `subarray` (identical
+semantics), so this line should change regardless.
+
+Decide deliberately: copy by default (safe, costs a memcpy) or keep the view and
+document it, ideally as an explicit `ayBuffer: 'view' | 'copy'` option. Copy is
+the better default — the current behaviour is a footgun that only shows up under
+load.
+
+### 2.6 Accept big-endian messages
+
+**Severity: low frequency, but a spec violation.**
+
+`constants.endianness.be` is defined and never read. Byte 0 of the header — the
+byte order flag — is never consulted, and every read is `readUInt32LE` /
+`readInt32LE`. Flipping a message's flag to `'B'` changes nothing: the reader
+ignores it and reads little-endian regardless.
+
+The spec requires receivers to accept both byte orders; senders may keep
+emitting little-endian. Only bites when talking to a big-endian peer (s390x,
+some MIPS/PPC), which is why it has gone unnoticed.
+
+Work: thread a byte-order flag through `DBusBuffer` and pick `*LE`/`*BE` readers
+from it. Mostly mechanical, but it touches every read method, so it deserves its
+own PR and a round-trip test against a hand-built big-endian fixture.
+
+### 2.7 Backpressure on the write path
+
+**Severity: medium for high-throughput senders.**
+
+`index.js:126` and `:132` discard the return value of `stream.write()`, so a
+producer faster than the socket grows Node's internal write buffer without
+bound. There is no `cork`/`uncork` batching either, so emitting N signals in a
+tick issues N separate writes.
+
+Work: respect the `false` return, expose `'drain'` (or return a promise from
+`connection.message()`), and consider corking within a tick.
+
+### 2.8 UNIX_FD (`h`) support
+
+**Severity: feature gap — blocks whole categories of users.**
+
+`signature.js` parses `h`, but both directions throw: `Unknown data type
+format: h` and `Unsupported type: h`. There is no SCM_RIGHTS handling anywhere.
+systemd, the XDG desktop portals and PipeWire all pass file descriptors, so
+those APIs are simply unreachable from this library.
+
+This is the largest item in this section and needs design first: Node has no
+public SCM_RIGHTS API, so it likely means a small native addon or a
+`child_process`-mediated hack — which would undo the "no native dependencies"
+property this package is valued for. Worth scoping before committing.
+
+### 2.9 Small non-canonical cleanups
+
+**Severity: low — batch them into one tidy-up PR.**
+
+- `DBusBuffer` **mutates the caller's options object**, adding `ayBuffer: true`
+  to the connection opts you passed in.
+- `new DBusBuffer(buf, 0, null)` throws, because `typeof null === 'object'`
+  slips past the guard.
+- `lib/unmarshall.js` returns `Buffer.from('')` for an empty signature where
+  every other path returns an array.
+- `marshallers.js` calls `parseInt`/`parseFloat` on values already validated as
+  numbers.
+- `lib/readline.js` reads **one byte at a time** via `stream.read(1)`.
+  Handshake-only so the impact is negligible, but it is not idiomatic.
+- `message.js` never validates the protocol version byte (`header[3]`).
+
+---
+
+## 3. High priority
+
+### 3.1 Promise support for method calls
 
 **Issues:** [#9](https://github.com/sidorares/dbus-native/issues/9),
 [#10](https://github.com/sidorares/dbus-native/pull/10),
@@ -106,7 +318,7 @@ Then go further: add a `bus.invokeAsync(msg)` (or a `promisify: true` client
 option) so the low-level API is usable with `await` too, and export the whole
 proxy surface as promise-returning. Callback style stays supported.
 
-### 2.2 Replace Long.js with BigInt
+### 3.2 Replace Long.js with BigInt
 
 **Issue:** [#248](https://github.com/sidorares/dbus-native/issues/248),
 **PR:** [#252](https://github.com/sidorares/dbus-native/pull/252)
@@ -120,7 +332,7 @@ Plan: read `x`/`t` with `readBigInt64LE`/`readBigUInt64LE`; accept
 return type behind an option (`ReturnBigInt`) for one minor release alongside
 the existing `ReturnLongjs`, then flip the default in 1.0 and drop `long`.
 
-### 2.3 TypeScript declarations
+### 3.3 TypeScript declarations
 
 **Issue:** [#276](https://github.com/sidorares/dbus-native/issues/276)
 
@@ -129,7 +341,7 @@ cannot drift). This is table stakes in 2026 and is likely the biggest single
 driver of users choosing `dbus-next`. Do it _after_ 2.1 so the promise-returning
 signatures are typed correctly the first time.
 
-### 2.4 Call timeouts and connection-death handling
+### 3.4 Call timeouts and connection-death handling
 
 **Issues:** [#137](https://github.com/sidorares/dbus-native/issues/137),
 [#20](https://github.com/sidorares/dbus-native/issues/20),
@@ -147,9 +359,9 @@ grow unboundedly today.
 
 ---
 
-## 3. Medium priority
+## 4. Medium priority
 
-### 3.1 Variant handling
+### 4.1 Variant handling
 
 **PR:** [#143](https://github.com/sidorares/dbus-native/pull/143) (mvduin, with tests)
 
@@ -165,13 +377,13 @@ Related: [#3](https://github.com/sidorares/dbus-native/issues/3),
 "how do I deal with `a{sv}`". A documented, ergonomic dict/variant story would
 close roughly a dozen issues at once.
 
-### 3.2 Marshall JS objects as `a{sv}`
+### 4.2 Marshall JS objects as `a{sv}`
 
 There is a `// TODO: serialise JS objects as a{sv}` in `lib/marshall.js` and a
 disabled test (`test/js-types.js`) waiting for it. Combined with 3.1 this is the
 "just let me pass a plain object" story users keep asking for.
 
-### 3.3 High-level client/service API
+### 4.3 High-level client/service API
 
 **PR:** [#251](https://github.com/sidorares/dbus-native/pull/251) (acrisci)
 
@@ -180,7 +392,7 @@ ones. The PR is from 2018 and will not apply cleanly, but the design is proven
 and it is additive by construction. Worth rebasing rather than redesigning —
 and it is the most credible path to reconciling the two projects.
 
-### 3.4 Properties: signals and access control
+### 4.4 Properties: signals and access control
 
 **Issues:** [#81](https://github.com/sidorares/dbus-native/issues/81),
 [#89](https://github.com/sidorares/dbus-native/issues/89),
@@ -197,7 +409,7 @@ and it is the most credible path to reconciling the two projects.
 - `GetAll` on an interface with no properties still misbehaves
   ([#102](https://github.com/sidorares/dbus-native/issues/102)).
 
-### 3.5 Finish the server/broker
+### 4.5 Finish the server/broker
 
 `lib/server.js` plus `lib/server-handshake.js` are a stub: the handshake replies
 with a hardcoded cookie and GUID copied from someone's 2014 session, and logs to
@@ -211,7 +423,7 @@ blocker.
 
 ---
 
-## 4. Lower priority / opportunistic
+## 5. Lower priority / opportunistic
 
 - **`launchd:` address family** ([#95](https://github.com/sidorares/dbus-native/issues/95))
   — how macOS actually advertises its session bus. Now that macOS is a
@@ -247,10 +459,15 @@ documentation gaps and should be converted into README sections and closed.
 
 ---
 
-## 5. Toward 1.0
+## 6. Toward 1.0
 
 A plausible 1.0 is: promises by default, BigInt for 64-bit types, shipped
 TypeScript types, call timeouts, and a variant/dict API that does not leak the
 parser's tree. That is a coherent breaking change worth a major version, and it
 would make this the obvious choice again for anyone currently picking between
 three half-maintained packages.
+
+Section 2 is mostly orthogonal to that: the read-loop hardening (§2.1, §2.2) and
+the marshaller rewrite (§2.3) are behaviour-preserving for well-formed traffic
+and should ship in patch and minor releases as they land, not wait for 1.0. Only
+the `ay` copy semantics (§2.5) and any variant change (§4.1) need a major.


### PR DESCRIPTION
Adds **ROADMAP section 2**, a measured audit of the marshaller, unmarshaller and stream framing against `8373dcb`. Nothing in it is inferred from reading — every claim was reproduced or benchmarked, and the scratch harnesses are reproducible on request.

Each subsection is scoped to be **one PR**, listed in the order they should land:

| § | block | severity |
| --- | --- | --- |
| 2.1 | Harden the read loop against malformed input | high — remote crash/DoS |
| 2.2 | Isolate user handlers from the read loop | high — app bug kills process |
| 2.3 | Rewrite the marshaller onto a cursor writer | high — 4× typical, 2069× on `ay` |
| 2.4 | Cache parsed signatures | medium |
| 2.5 | `ay` buffer views retain the whole message | medium — unbounded growth |
| 2.6 | Accept big-endian messages | spec violation, low frequency |
| 2.7 | Backpressure on the write path | medium |
| 2.8 | UNIX_FD (`h`) support | feature gap — needs design first |
| 2.9 | Small non-canonical cleanups | low |

### Headline findings

**Malformed input crashes the process.** No size limits are enforced (spec caps messages at 128 MiB), `((fieldsLength + 7) >> 3) << 3` overflows int32 to `-16`, and `onMessage()` is called inside the `readable` handler with no error boundary.

**So does an ordinary application bug.** Signal dispatch is a synchronous `emit`, so a throwing listener unwinds through the parser. Verified against a live bus.

**`message.unmarshall()` throws on every argument-less message** — `Hello`, `Ping`, `ListNames`. The streaming path guards correctly; this one does not.

**Byte-array marshalling runs at 3.5 MB/s** against an ~8 GB/s ceiling — one `Buffer.alloc` per byte, 1026 allocations to marshal 1 KB. A prototype cursor writer produced byte-identical output on 30/30 cases at 2069× on 1 MB `ay` and 4.2× on a typical method call.

### Housekeeping

Existing sections renumber 2→3, 3→4, 4→5, 5→6. `AGENTS.md` cross-references follow, and it now points at §2 for anyone touching the wire layer.

Docs only — no source changes. Implementation starts with §2.1.