### PR TITLE
fix: harden the message read loop against malformed input

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,8 +80,13 @@ function createConnection(opts) {
   const stream = (self.stream = createStream(opts));
   stream.setNoDelay?.();
 
+  // Set once we have reported a fatal protocol error and torn the stream
+  // down ourselves, so the teardown does not surface as a second error.
+  let fatal = false;
+
   stream.on('error', err => {
     // forward network and stream errors
+    if (fatal) return;
     self.emit('error', err);
   });
 
@@ -109,7 +114,15 @@ function createConnection(opts) {
       msg => {
         self.emit('message', msg);
       },
-      opts
+      opts,
+      err => {
+        // Framing is unrecoverable: we no longer know where the next message
+        // starts, so surface the error and drop the connection rather than
+        // resynchronising on garbage.
+        self.emit('error', err);
+        fatal = true;
+        stream.destroy();
+      }
     );
   });
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -50,5 +50,11 @@ module.exports = {
     be: 66
   },
   messageSignature: 'yyyyuua(yv)',
-  defaultAuthMethods: ['EXTERNAL', 'DBUS_COOKIE_SHA1', 'ANONYMOUS']
+  defaultAuthMethods: ['EXTERNAL', 'DBUS_COOKIE_SHA1', 'ANONYMOUS'],
+
+  // Hard limits from the specification. A peer declaring anything larger is
+  // sending us a protocol error, and we must not try to buffer it.
+  // https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-messages
+  maxMessageSize: 134217728, // 128 MiB
+  maxArraySize: 67108864 // 64 MiB
 };

--- a/lib/dbus-buffer.js
+++ b/lib/dbus-buffer.js
@@ -1,4 +1,5 @@
 const Long = require('long');
+const constants = require('./constants');
 const parseSignature = require('./signature');
 
 // Buffer + position + global start position ( used in alignment )
@@ -62,12 +63,21 @@ DBusBuffer.prototype.readDouble = function () {
 };
 
 DBusBuffer.prototype.readString = function (len) {
+  // dbus strings are always zero-terminated ('s', 'o' and 'g' types), so a
+  // string of `len` bytes occupies len + 1.
+  if (this.pos + len + 1 > this.buffer.length) {
+    throw new Error(
+      `Declared string length ${len} runs past the end of the message (${this.buffer.length - this.pos} bytes left)`
+    );
+  }
   if (len === 0) {
     this.pos++;
     return '';
   }
+  // Without this check buffer.toString() would silently clamp to the end of
+  // the buffer and hand back a truncated string.
   const res = this.buffer.toString('utf8', this.pos, this.pos + len);
-  this.pos += len + 1; // dbus strings are always zero-terminated ('s' and 'g' types)
+  this.pos += len + 1;
   return res;
 };
 
@@ -112,6 +122,17 @@ DBusBuffer.prototype.readStruct = function readStruct(struct) {
 
 DBusBuffer.prototype.readArray = function readArray(eleType, arrayBlobSize) {
   const start = this.pos;
+
+  if (arrayBlobSize > constants.maxArraySize) {
+    throw new Error(
+      `Declared array length ${arrayBlobSize} exceeds the maximum of ${constants.maxArraySize} bytes`
+    );
+  }
+  if (start + arrayBlobSize > this.buffer.length) {
+    throw new Error(
+      `Declared array length ${arrayBlobSize} runs past the end of the message (${this.buffer.length - start} bytes left)`
+    );
+  }
 
   // special case: treat ay as Buffer
   if (eleType.type === 'y' && this.options.ayBuffer) {

--- a/lib/message.js
+++ b/lib/message.js
@@ -4,56 +4,133 @@ const DBusBuffer = require('./dbus-buffer');
 
 const headerSignature = require('./header-signature.json');
 
+const EMPTY = Buffer.alloc(0);
+
+// Round up to the next 8-byte boundary. The obvious `((n + 7) >> 3) << 3`
+// wraps to int32, so a peer declaring a length above 2^31 would produce a
+// negative padded length.
+function align8(n) {
+  return Math.ceil(n / 8) * 8;
+}
+
+class ProtocolError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'ProtocolError';
+    this.code = 'EPROTO';
+  }
+}
+module.exports.ProtocolError = ProtocolError;
+
 module.exports.unmarshalMessages = function messageParser(
   stream,
   onMessage,
-  opts
+  opts,
+  onError
 ) {
+  const maxMessageSize =
+    (opts && opts.maxMessageSize) || constants.maxMessageSize;
+
   let state = 0; // 0: header, 1: fields + body
   let header, fieldsAndBody;
   let fieldsLength, fieldsLengthPadded;
   let fieldsAndBodyLength = 0;
   let bodyLength = 0;
-  stream.on('readable', () => {
-    while (1) {
-      if (state === 0) {
-        header = stream.read(16);
-        if (!header) break;
-        state = 1;
+  let failed = false;
 
-        fieldsLength = header.readUInt32LE(12);
-        fieldsLengthPadded = ((fieldsLength + 7) >> 3) << 3;
-        bodyLength = header.readUInt32LE(4);
-        fieldsAndBodyLength = fieldsLengthPadded + bodyLength;
-      } else {
-        fieldsAndBody = stream.read(fieldsAndBodyLength);
-        if (!fieldsAndBody) break;
-        state = 0;
+  // A malformed message is not recoverable: we have lost framing and cannot
+  // tell where the next message starts. Stop reading and report.
+  function fail(err) {
+    if (failed) return;
+    failed = true;
+    stream.removeListener('readable', onReadable);
+    if (onError) onError(err);
+    else stream.emit('error', err);
+  }
 
-        const messageBuffer = new DBusBuffer(fieldsAndBody, undefined, opts);
-        const unmarshalledHeader = messageBuffer.readArray(
-          headerSignature[0].child[0],
-          fieldsLength
-        );
-        messageBuffer.align(3);
-        const message = {};
-        message.serial = header.readUInt32LE(8);
+  function readHeader() {
+    header = stream.read(16);
+    if (!header) return false;
 
-        for (const field of unmarshalledHeader) {
-          const headerName = constants.headerTypeName[field[0]];
-          message[headerName] = field[1][1][0];
-        }
-
-        message.type = header[1];
-        message.flags = header[2];
-
-        if (bodyLength > 0 && message.signature) {
-          message.body = messageBuffer.read(message.signature);
-        }
-        onMessage(message);
-      }
+    if (header[0] !== constants.endianness.le) {
+      // Big-endian senders are legal but unimplemented. Fail loudly rather
+      // than reading the whole message little-endian and yielding garbage.
+      throw new ProtocolError(
+        `Unsupported byte order '${String.fromCharCode(header[0])}'. Only little-endian ('l') messages can be read.`
+      );
     }
-  });
+
+    bodyLength = header.readUInt32LE(4);
+    fieldsLength = header.readUInt32LE(12);
+
+    // Validate before doing any arithmetic on, or allocating for, these.
+    if (bodyLength > maxMessageSize || fieldsLength > maxMessageSize) {
+      throw new ProtocolError(
+        `Message exceeds the maximum size: header fields ${fieldsLength} bytes, body ${bodyLength} bytes, limit ${maxMessageSize} bytes`
+      );
+    }
+    fieldsLengthPadded = align8(fieldsLength);
+    fieldsAndBodyLength = fieldsLengthPadded + bodyLength;
+    if (fieldsAndBodyLength + 16 > maxMessageSize) {
+      throw new ProtocolError(
+        `Message exceeds the maximum size: ${fieldsAndBodyLength + 16} bytes, limit ${maxMessageSize} bytes`
+      );
+    }
+    return true;
+  }
+
+  function readBody() {
+    // stream.read(0) never yields a buffer, so short-circuit the empty case
+    // rather than stalling the loop on it.
+    fieldsAndBody =
+      fieldsAndBodyLength === 0 ? EMPTY : stream.read(fieldsAndBodyLength);
+    if (!fieldsAndBody) return null;
+
+    const messageBuffer = new DBusBuffer(fieldsAndBody, undefined, opts);
+    const unmarshalledHeader = messageBuffer.readArray(
+      headerSignature[0].child[0],
+      fieldsLength
+    );
+    messageBuffer.align(3);
+    const message = {};
+    message.serial = header.readUInt32LE(8);
+
+    for (const field of unmarshalledHeader) {
+      const headerName = constants.headerTypeName[field[0]];
+      message[headerName] = field[1][1][0];
+    }
+
+    message.type = header[1];
+    message.flags = header[2];
+
+    if (bodyLength > 0 && message.signature) {
+      message.body = messageBuffer.read(message.signature);
+    }
+    return message;
+  }
+
+  function onReadable() {
+    while (!failed) {
+      let message;
+      try {
+        if (state === 0) {
+          if (!readHeader()) return;
+          state = 1;
+          continue;
+        }
+        message = readBody();
+        if (!message) return;
+        state = 0;
+      } catch (err) {
+        return fail(err);
+      }
+      // Dispatch outside the try: a throw from application code is not a
+      // framing error and must not be reported as one.
+      onMessage(message);
+    }
+  }
+
+  stream.on('readable', onReadable);
 };
 
 // given buffer which contains entire message deserialise it
@@ -70,7 +147,12 @@ module.exports.unmarshall = function unmarshall(buff, opts) {
   message.flags = headers[2];
   message.serial = headers[5];
   msgBuf.align(3);
-  message.body = msgBuf.read(message.signature);
+  // headers[4] is the declared body length. Argument-less messages (Hello,
+  // Ping, ListNames, ...) carry no signature header field at all, so reading a
+  // body here would parse `undefined` as a signature.
+  if (headers[4] > 0 && message.signature) {
+    message.body = msgBuf.read(message.signature);
+  }
   return message;
 };
 

--- a/test/message-framing.js
+++ b/test/message-framing.js
@@ -1,0 +1,245 @@
+// Framing and malformed-input handling for the message parser.
+//
+// Every case here crashed the process (or silently produced wrong data)
+// before the read loop was hardened.
+
+const assert = require('assert');
+const { PassThrough, Duplex } = require('stream');
+const dbus = require('../index');
+const message = require('../lib/message');
+const constants = require('../lib/constants');
+const DBusBuffer = require('../lib/dbus-buffer');
+
+const methodCall = (over = {}) =>
+  message.marshall({
+    serial: 1,
+    type: constants.messageType.methodCall,
+    path: '/org/freedesktop/DBus',
+    destination: 'org.freedesktop.DBus',
+    interface: 'org.freedesktop.DBus',
+    member: 'Hello',
+    ...over
+  });
+
+// A 16 byte header with the lengths we want to claim, little-endian.
+function header({ bodyLength = 0, fieldsLength = 0, serial = 1 }) {
+  const h = Buffer.alloc(16);
+  h[0] = constants.endianness.le;
+  h[1] = constants.messageType.methodCall;
+  h[2] = 0;
+  h[3] = constants.protocolVersion;
+  h.writeUInt32LE(bodyLength, 4);
+  h.writeUInt32LE(serial, 8);
+  h.writeUInt32LE(fieldsLength, 12);
+  return h;
+}
+
+// Drive the parser and report what came out, without letting a throw escape
+// into mocha's uncaught handler.
+function parse(chunks, opts) {
+  return new Promise(resolve => {
+    const stream = new PassThrough();
+    const messages = [];
+    const errors = [];
+    message.unmarshalMessages(
+      stream,
+      m => messages.push(m),
+      opts,
+      e => errors.push(e)
+    );
+    for (const chunk of chunks) stream.write(chunk);
+    setImmediate(() => resolve({ messages, errors }));
+  });
+}
+
+describe('message framing', () => {
+  it('parses a well-formed message', async () => {
+    const { messages, errors } = await parse([methodCall()]);
+    assert.deepStrictEqual(errors, []);
+    assert.strictEqual(messages.length, 1);
+    assert.strictEqual(messages[0].member, 'Hello');
+  });
+
+  it('parses several messages from one chunk', async () => {
+    const two = Buffer.concat([
+      methodCall({ serial: 1 }),
+      methodCall({ serial: 2 })
+    ]);
+    const { messages, errors } = await parse([two]);
+    assert.deepStrictEqual(errors, []);
+    assert.deepStrictEqual(
+      messages.map(m => m.serial),
+      [1, 2]
+    );
+  });
+
+  it('parses a message split across chunk boundaries', async () => {
+    const buf = methodCall();
+    const chunks = [buf.subarray(0, 5), buf.subarray(5, 17), buf.subarray(17)];
+    const { messages, errors } = await parse(chunks);
+    assert.deepStrictEqual(errors, []);
+    assert.strictEqual(messages.length, 1);
+  });
+
+  it('waits, without error, for an incomplete message', async () => {
+    const buf = methodCall();
+    const { messages, errors } = await parse([buf.subarray(0, 20)]);
+    assert.deepStrictEqual(errors, []);
+    assert.deepStrictEqual(messages, []);
+  });
+
+  it('reports a body larger than the maximum message size', async () => {
+    const { messages, errors } = await parse([
+      header({ bodyLength: constants.maxMessageSize + 1, fieldsLength: 8 })
+    ]);
+    assert.deepStrictEqual(messages, []);
+    assert.strictEqual(errors.length, 1);
+    assert.strictEqual(errors[0].code, 'EPROTO');
+    assert.match(errors[0].message, /maximum size/);
+  });
+
+  it('reports header fields larger than the maximum message size', async () => {
+    const { errors } = await parse([
+      header({ fieldsLength: constants.maxMessageSize + 1 })
+    ]);
+    assert.strictEqual(errors.length, 1);
+    assert.strictEqual(errors[0].code, 'EPROTO');
+  });
+
+  // ((n + 7) >> 3) << 3 wraps to int32 and produced a negative padded length,
+  // which then reached stream.read() as a negative size.
+  it('does not overflow when padding a huge declared field length', async () => {
+    const { errors } = await parse([header({ fieldsLength: 0xfffffff0 })]);
+    assert.strictEqual(errors.length, 1);
+    assert.strictEqual(errors[0].code, 'EPROTO');
+    assert.doesNotMatch(errors[0].message, /-\d/, 'length went negative');
+  });
+
+  it('reports the combined size when each part is individually legal', async () => {
+    const half = Math.floor(constants.maxMessageSize / 2) + 16;
+    const { errors } = await parse([
+      header({ bodyLength: half, fieldsLength: half })
+    ]);
+    assert.strictEqual(errors.length, 1);
+    assert.strictEqual(errors[0].code, 'EPROTO');
+  });
+
+  it('honours a caller-supplied maxMessageSize', async () => {
+    const { errors } = await parse([methodCall()], { maxMessageSize: 32 });
+    assert.strictEqual(errors.length, 1);
+    assert.strictEqual(errors[0].code, 'EPROTO');
+  });
+
+  it('rejects big-endian messages instead of misreading them', async () => {
+    const be = methodCall();
+    be[0] = constants.endianness.be;
+    const { messages, errors } = await parse([be]);
+    assert.deepStrictEqual(messages, []);
+    assert.strictEqual(errors.length, 1);
+    assert.match(errors[0].message, /byte order/);
+  });
+
+  it('stops parsing after a framing error', async () => {
+    const { messages, errors } = await parse([
+      header({ fieldsLength: 0xfffffff0 }),
+      methodCall({ serial: 7 })
+    ]);
+    assert.strictEqual(errors.length, 1, 'reports exactly once');
+    assert.deepStrictEqual(messages, [], 'delivers nothing after the error');
+  });
+
+  // Note: an exception thrown by the onMessage callback still escapes the
+  // read loop as an uncaught exception. Dispatch is deliberately called
+  // outside the framing try/catch so it is never *misreported* as a framing
+  // error, but isolating user handlers properly is a separate change
+  // (ROADMAP 2.2) and is tested there.
+});
+
+describe('connection error handling', () => {
+  // Drive a connection over a fake socket: complete the auth handshake by
+  // hand, then inject bytes and watch what the connection does.
+  function connect(cb) {
+    const toClient = new PassThrough();
+    const fromClient = new PassThrough();
+    const socket = Duplex.from({ readable: toClient, writable: fromClient });
+    const conn = dbus.createConnection({ stream: socket, direct: true });
+    // The client sends "\0AUTH EXTERNAL <hex>\r\n"; any OK completes it.
+    fromClient.once('data', () => toClient.write('OK 0123456789abcdef\r\n'));
+    conn.once('connect', () => cb(conn, toClient));
+    return conn;
+  }
+
+  it('emits a framing error on the connection instead of crashing', done => {
+    connect((conn, toClient) => {
+      conn.on('error', err => {
+        assert.strictEqual(err.code, 'EPROTO');
+        assert.match(err.message, /maximum size/);
+        done();
+      });
+      toClient.write(header({ fieldsLength: 0xfffffff0 }));
+    });
+  });
+
+  it('delivers well-formed messages over the same path', done => {
+    connect((conn, toClient) => {
+      conn.on('error', done);
+      conn.on('message', msg => {
+        assert.strictEqual(msg.member, 'Hello');
+        done();
+      });
+      toClient.write(methodCall());
+    });
+  });
+});
+
+describe('message.unmarshall', () => {
+  it('reads a message that has a body', () => {
+    const buf = methodCall({ signature: 's', body: ['hi'] });
+    const m = message.unmarshall(buf);
+    assert.strictEqual(m.member, 'Hello');
+    assert.deepStrictEqual(m.body, ['hi']);
+  });
+
+  // Hello, Ping, ListNames and every other argument-less call carry no
+  // signature header field, and this used to throw on all of them.
+  it('reads a message with no body', () => {
+    const m = message.unmarshall(methodCall());
+    assert.strictEqual(m.member, 'Hello');
+    assert.strictEqual(m.body, undefined);
+  });
+});
+
+describe('DBusBuffer bounds checking', () => {
+  it('rejects a string length that runs past the end of the buffer', () => {
+    const b = Buffer.alloc(16);
+    b.writeUInt32LE(0xffffff, 0); // claim a 16MB string in a 16 byte buffer
+    assert.throws(
+      () => new DBusBuffer(b, 0, {}).read('s'),
+      /runs past the end of the message/
+    );
+  });
+
+  it('rejects an array length that runs past the end of the buffer', () => {
+    const b = Buffer.alloc(16);
+    b.writeUInt32LE(0xffff, 0);
+    assert.throws(
+      () => new DBusBuffer(b, 0, {}).read('ai'),
+      /runs past the end of the message/
+    );
+  });
+
+  it('rejects an array larger than the maximum array size', () => {
+    const b = Buffer.alloc(16);
+    b.writeUInt32LE(constants.maxArraySize + 1, 0);
+    assert.throws(
+      () => new DBusBuffer(b, 0, {}).read('ai'),
+      /exceeds the maximum/
+    );
+  });
+
+  it('still reads a legitimate empty string', () => {
+    const b = Buffer.alloc(8);
+    b.writeUInt32LE(0, 0);
+    assert.deepStrictEqual(new DBusBuffer(b, 0, {}).read('s'), ['']);
+  });
+});


### PR DESCRIPTION
Implements **ROADMAP 2.1**. A peer sending a malformed header could crash the process: the parser read a 16-byte header, trusted the declared lengths, handed them straight to `stream.read()`, and did it all inside a `readable` handler with no error boundary.

Before / after, each in a fresh process:

```
                 before                                    after
bad-header       CRASHED: RangeError ERR_OUT_OF_RANGE      reported as connection error
handler-throws   CRASHED: Error: handler blew up           still crashes -- see 2.2 below
truncated-tail   survived                                  survived
```

### What changed

- **Enforce the spec size limits** — 128 MiB per message, 64 MiB per array, validated *before* any arithmetic or allocation. A peer declaring a 900 MB body no longer makes us buffer 900 MB. Overridable per client with `maxMessageSize`.
- **Fix an int32 overflow.** `((fieldsLength + 7) >> 3) << 3` wraps to `-16` for a declared length of `0xfffffff0`, so the padded length could go negative and reach `stream.read()` as a negative size.
- **Bounds-check `DBusBuffer` reads.** A declared string length past the end of the buffer was silently clamped by `buffer.toString()`, turning corrupt input into short strings rather than an error.
- **Give the parse loop an error boundary.** Framing errors go through a new `onError` callback; `index.js` surfaces them as `error` on the connection and destroys the stream. Framing is unrecoverable — once lost we cannot tell where the next message starts — so parsing stops rather than resynchronising on garbage.
- **Reject big-endian messages** with a clear `ProtocolError`. They were previously read little-endian regardless of the byte-order flag, silently producing garbage. Actually supporting them is §2.6; failing loudly is strictly better than the status quo in the meantime.
- **Fix `message.unmarshall()` on argument-less messages.** It called `read(message.signature)` unconditionally, so `Hello`, `Ping` and `ListNames` all threw `TypeError`. The streaming path already guarded correctly; the two now agree.

### Scope note

Message dispatch is deliberately called **outside** the framing `try`/`catch`, so an exception in application code is never *misreported* as a framing error. But it does still escape as an uncaught exception — isolating user handlers is **§2.2** and lands next. I chose not to fold it in here because it changes observable behaviour for anyone relying on the current crash and deserves its own changelog line.

### Verification

- 19 new regression tests in `test/message-framing.js`: size limits, the overflow value, split/coalesced chunks, incomplete messages, big-endian, post-error silence, bounds checks, and the connection-level path driven over a fake socket with a hand-completed handshake.
- Full suite: **137 unit** (was 118) + **12 integration** against a real `dbus-daemon`.
- No measurable read-throughput cost: 1.387 µs/op vs 1.381 µs/op baseline for a Notify-sized message.