### PR TITLE
chore: add a dependabot cooldown for npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,13 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # Don't adopt a version the week it is published. Compromised releases are
+    # typically caught and yanked within days, and this project has already had
+    # to remove one dependency (event-stream) over exactly that failure mode.
+    # Security updates ignore cooldown, so genuine CVE fixes are not delayed.
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
     open-pull-requests-limit: 10
     groups:
       # Keep lint/test tooling churn to a single PR a week.


### PR DESCRIPTION
Re-applies the substance of #304 under a `chore:` prefix so it does not trigger a release on its own.

Waits 7 days before proposing a newly published version (14 for majors). Compromised npm releases are typically caught and yanked within days, and this project already had to drop `event-stream` over exactly that failure mode. Security updates ignore cooldown, so genuine CVE fixes are not delayed.

**Scoped to the npm ecosystem only.** #304 also added it to `github-actions`; I left that out deliberately. Our actions are pinned first-party ones where the benefit is marginal, and the GitHub docs give conflicting answers about whether `cooldown` is accepted for that ecosystem — one section says it is unsupported, another lists it under "supports `default-days`". An unrecognised key stops Dependabot processing the file at all, which would silently disable updates entirely. Not worth the risk for the upside.

Verified the result parses and that `cooldown` lands only where intended:

```
YAML OK
  npm: cooldown={"default-days"=>7, "semver-major-days"=>14}
  github-actions: cooldown=nil
```