### PR TITLE
fix: isolate message listeners from the read loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,15 @@ connection signals:
 
 - connect - emitted after successful authentication
 - message
-- error
+- error - transport or protocol failure. A protocol error (a malformed or
+  oversized message) is unrecoverable, so the connection is destroyed after it
+  is emitted.
+- handlerError - an exception thrown by one of your own `message`/signal
+  listeners. It is reported separately from `error` because it is an
+  application bug rather than a connection failure, and the connection stays
+  usable. If nothing is listening for `handlerError` the exception is re-thrown
+  asynchronously, matching Node's default behaviour for a throwing event
+  listener.
 
 example:
 

--- a/index.js
+++ b/index.js
@@ -122,6 +122,22 @@ function createConnection(opts) {
         self.emit('error', err);
         fatal = true;
         stream.destroy();
+      },
+      err => {
+        // A throw from a 'message' listener is an application bug, not a
+        // transport failure, so it does not go to 'error' -- a handler there
+        // would reasonably assume the connection is gone.
+        if (self.listenerCount('handlerError') > 0) {
+          self.emit('handlerError', err);
+          return;
+        }
+        // Nobody is listening. Preserve Node's default for an exception in an
+        // event listener (crash the process) rather than swallowing an
+        // application bug -- but do it asynchronously, so the read loop still
+        // drains the messages it has already buffered.
+        process.nextTick(() => {
+          throw err;
+        });
       }
     );
   });

--- a/lib/message.js
+++ b/lib/message.js
@@ -26,7 +26,8 @@ module.exports.unmarshalMessages = function messageParser(
   stream,
   onMessage,
   opts,
-  onError
+  onError,
+  onHandlerError
 ) {
   const maxMessageSize =
     (opts && opts.maxMessageSize) || constants.maxMessageSize;
@@ -124,9 +125,17 @@ module.exports.unmarshalMessages = function messageParser(
       } catch (err) {
         return fail(err);
       }
-      // Dispatch outside the try: a throw from application code is not a
-      // framing error and must not be reported as one.
-      onMessage(message);
+
+      // Dispatch runs application code. An exception from it is a bug in the
+      // consumer, not a framing error, so it gets its own channel -- and it
+      // must not unwind through the parser, which would abandon whatever else
+      // is already sitting in the read buffer.
+      try {
+        onMessage(message);
+      } catch (err) {
+        if (!onHandlerError) throw err;
+        onHandlerError(err);
+      }
     }
   }
 

--- a/test/message-framing.js
+++ b/test/message-framing.js
@@ -5,6 +5,7 @@
 
 const assert = require('assert');
 const { PassThrough, Duplex } = require('stream');
+const { execFile } = require('child_process');
 const dbus = require('../index');
 const message = require('../lib/message');
 const constants = require('../lib/constants');
@@ -148,11 +149,49 @@ describe('message framing', () => {
     assert.deepStrictEqual(messages, [], 'delivers nothing after the error');
   });
 
-  // Note: an exception thrown by the onMessage callback still escapes the
-  // read loop as an uncaught exception. Dispatch is deliberately called
-  // outside the framing try/catch so it is never *misreported* as a framing
-  // error, but isolating user handlers properly is a separate change
-  // (ROADMAP 2.2) and is tested there.
+  it('routes a handler exception away from the framing channel', async () => {
+    const stream = new PassThrough();
+    const framing = [];
+    const handler = [];
+    message.unmarshalMessages(
+      stream,
+      () => {
+        throw new Error('application bug');
+      },
+      {},
+      e => framing.push(e),
+      e => handler.push(e)
+    );
+    stream.write(methodCall());
+    await new Promise(setImmediate);
+    assert.deepStrictEqual(framing, [], 'not reported as a framing error');
+    assert.strictEqual(handler.length, 1);
+    assert.strictEqual(handler[0].message, 'application bug');
+  });
+
+  it('keeps parsing the read buffer after a handler throws', async () => {
+    const stream = new PassThrough();
+    const seen = [];
+    const handler = [];
+    message.unmarshalMessages(
+      stream,
+      msg => {
+        seen.push(msg.serial);
+        if (msg.serial === 1) throw new Error('application bug');
+      },
+      {},
+      () => {},
+      e => handler.push(e)
+    );
+    // Both messages arrive in a single chunk: the second used to be discarded
+    // when the first handler unwound through the parser.
+    stream.write(
+      Buffer.concat([methodCall({ serial: 1 }), methodCall({ serial: 2 })])
+    );
+    await new Promise(setImmediate);
+    assert.deepStrictEqual(seen, [1, 2], 'second message still delivered');
+    assert.strictEqual(handler.length, 1);
+  });
 });
 
 describe('connection error handling', () => {
@@ -190,6 +229,49 @@ describe('connection error handling', () => {
       toClient.write(methodCall());
     });
   });
+
+  it("reports a throwing listener on 'handlerError', not 'error'", done => {
+    connect((conn, toClient) => {
+      conn.on('error', () => done(new Error("went to 'error'")));
+      conn.on('message', () => {
+        throw new Error('bug in a message listener');
+      });
+      conn.on('handlerError', err => {
+        assert.strictEqual(err.message, 'bug in a message listener');
+        done();
+      });
+      toClient.write(methodCall());
+    });
+  });
+
+  // With no 'handlerError' listener we must not silently swallow an
+  // application bug -- Node's default for a throwing listener is to crash.
+  // Run it in a child process so the crash is observable.
+  it('still crashes by default when nothing listens for handlerError', done => {
+    const script = `
+      const { PassThrough, Duplex } = require('stream');
+      const dbus = require(${JSON.stringify(require.resolve('../index'))});
+      const message = require(${JSON.stringify(require.resolve('../lib/message'))});
+      const toClient = new PassThrough();
+      const fromClient = new PassThrough();
+      const socket = Duplex.from({ readable: toClient, writable: fromClient });
+      const conn = dbus.createConnection({ stream: socket, direct: true });
+      fromClient.once('data', () => toClient.write('OK 0123456789abcdef\\r\\n'));
+      conn.once('connect', () => {
+        conn.on('message', () => { throw new Error('unhandled listener bug'); });
+        toClient.write(message.marshall({
+          serial: 1, type: 1, path: '/p', destination: 'a.b',
+          interface: 'a.b', member: 'Hello'
+        }));
+      });
+      setTimeout(() => process.exit(0), 1000);
+    `;
+    execFile(process.execPath, ['-e', script], (err, stdout, stderr) => {
+      assert.ok(err, 'expected a non-zero exit');
+      assert.match(stderr, /unhandled listener bug/);
+      done();
+    });
+  }).timeout(10000);
 });
 
 describe('message.unmarshall', () => {


### PR DESCRIPTION
Implements **ROADMAP §2.2**, the second of the two crash paths found in the wire-layer audit. #303 stopped a malformed *message* killing the process; this stops an ordinary bug in *your own code* doing it.

Method-call handlers were already safe — `bus.js` wraps them in `Promise.resolve().then()`. But reply callbacks and signal delivery run synchronously, so a throwing listener unwound straight through the parser:

```
Error: bug inside a user signal handler
    at EventEmitter.emit (node:events)
    at EventEmitter.<anonymous> (lib/bus.js:144)   <- signals.emit
    at index.js:110
    at Socket.<anonymous> (lib/message.js:53)      <- readable handler
```

Two things were wrong with that: the process died, and everything still sitting in the read buffer behind the failing message was discarded.

### What changed

Dispatch gets its own error channel, distinct from framing:

- The parse loop catches exceptions from `onMessage` and **keeps going**, so messages buffered behind the failing one are still delivered.
- They surface as **`handlerError`** on the connection, not `error`. A listener on `error` would reasonably assume the transport had failed and tear things down — but the connection is still perfectly usable here.
- With no `handlerError` listener, the exception is re-thrown on `nextTick`. Application bugs are **not** silently swallowed, Node’s default for a throwing event listener is preserved, and the read loop drains first.

### Verification

The exact scenario that exited with code 1 before, run against a real `dbus-daemon`:

```
handlerError: bug inside a user signal handler
still alive after signal delivery
process exited with code 0
```

Four new tests: that a handler exception does not reach the framing channel, that a second message in the same chunk is still delivered after the first handler throws, that it arrives on `handlerError` rather than `error` over a real connection, and — in a child process — that the default still crashes when nothing is listening.

**141 unit** (was 137) + 12 integration. `handlerError` is documented in the README.

Next up is §2.3, the marshaller rewrite.