### PR TITLE
perf: cache parsed signatures

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -231,7 +231,9 @@ prototype (2.18 µs vs 1.18 µs on the Notify case) is signature parsing, which
 Sequence with §3.2 (BigInt): both rewrite the same scalar paths. Either do
 BigInt first and rewrite once, or accept touching `x`/`t` twice.
 
-### 2.4 Cache parsed signatures
+### 2.4 Cache parsed signatures — DONE
+
+Landed in #308.
 
 **Severity: medium — pure win, small diff.**
 
@@ -244,6 +246,21 @@ Signatures come from a tiny set in practice. A bounded `Map` cache (capped, so a
 peer sending unique signatures cannot grow it without limit) is a few lines.
 Note the returned tree must then be treated as immutable — check no caller
 mutates it before landing this.
+
+**Outcome (#308).** Cached in `lib/signature.js`, capped at 1000 entries with
+oldest-first eviction. No caller mutates a tree, but `DBusBuffer.readVariant`
+_returns_ one to application code as `variant[0]`, so cached trees are
+deep-frozen rather than merely documented as immutable.
+
+| case                            | before   | after    |      |
+| ------------------------------- | -------- | -------- | ---- |
+| unmarshall `a{sv}`, 500 entries | 243.6 µs | 124.2 µs | 2.0× |
+| unmarshall Notify-like          | 1.33 µs  | 1.03 µs  | 1.3× |
+| marshall Notify-like            | 2.18 µs  | 1.86 µs  | 1.2× |
+| `message.marshall` (full call)  | 5.28 µs  | 4.13 µs  | 1.3× |
+
+This is the first item in §2 to speed up the **read** path, which §2.1–§2.3 left
+untouched.
 
 ### 2.5 `ay` buffer views retain the whole message
 

--- a/lib/signature.js
+++ b/lib/signature.js
@@ -10,7 +10,7 @@ const knownTypes = {};
   knownTypes[c] = true;
 });
 
-module.exports = function parseSignature(signature) {
+function parseSignature(signature) {
   let index = 0;
   function next() {
     if (index < signature.length) {
@@ -52,7 +52,50 @@ module.exports = function parseSignature(signature) {
   let c;
   while ((c = next()) !== null) ret.push(parseOne(c));
   return ret;
-};
+}
+
+// Signatures repeat constantly -- the same handful appear on every message,
+// and a variant re-parses its signature for every single value -- so parsed
+// trees are memoised.
+//
+// Two things make sharing a tree safe:
+//
+//  - it is deep-frozen, because DBusBuffer.readVariant hands the tree to
+//    application code as `variant[0]`, where a caller could otherwise mutate
+//    an entry that the rest of the process is relying on;
+//  - the cache is bounded, because signatures arrive from the peer, and an
+//    unbounded map keyed on remote input is a memory-growth vector.
+const MAX_CACHE_ENTRIES = 1000;
+const cache = new Map();
+
+function deepFreeze(nodes) {
+  for (const node of nodes) {
+    deepFreeze(node.child);
+    Object.freeze(node);
+  }
+  return Object.freeze(nodes);
+}
+
+function parseSignatureCached(signature) {
+  const hit = cache.get(signature);
+  if (hit !== undefined) return hit;
+
+  // Invalid signatures throw and are deliberately not cached.
+  const tree = deepFreeze(parseSignature(signature));
+
+  if (cache.size >= MAX_CACHE_ENTRIES) {
+    // Map iterates in insertion order, so this drops the oldest entry.
+    cache.delete(cache.keys().next().value);
+  }
+  cache.set(signature, tree);
+  return tree;
+}
+
+module.exports = parseSignatureCached;
+
+// Returns a fresh, mutable tree, bypassing the cache.
+module.exports.uncached = parseSignature;
+module.exports.cacheSize = () => cache.size;
 
 // command-line test
 //console.log(JSON.stringify(module.exports(process.argv[2]), null, 4));

--- a/test/signature.js
+++ b/test/signature.js
@@ -1,10 +1,116 @@
+const assert = require('assert');
+const parseSignature = require('../lib/signature');
+const unmarshall = require('../lib/unmarshall');
+const marshall = require('../lib/marshall');
+
 describe('Signature parser', () => {
-  //beforeEach(function(done) {
-  //});
-  //afterEach(function(done) {
-  //});
-  //it('parses simple sequence', function(done) {
-  //  var res = parse('yvsgu');
-  //  // TODO: wip
-  //});
+  it('parses a simple sequence', () => {
+    assert.deepStrictEqual(parseSignature('yu'), [
+      { type: 'y', child: [] },
+      { type: 'u', child: [] }
+    ]);
+  });
+
+  it('parses an empty signature', () => {
+    assert.deepStrictEqual(parseSignature(''), []);
+  });
+
+  it('parses arrays, structs and dict entries', () => {
+    assert.deepStrictEqual(parseSignature('a{sv}'), [
+      {
+        type: 'a',
+        child: [
+          {
+            type: '{',
+            child: [
+              { type: 's', child: [] },
+              { type: 'v', child: [] }
+            ]
+          }
+        ]
+      }
+    ]);
+    assert.deepStrictEqual(parseSignature('(ii)'), [
+      {
+        type: '(',
+        child: [
+          { type: 'i', child: [] },
+          { type: 'i', child: [] }
+        ]
+      }
+    ]);
+  });
+
+  it('rejects an unknown type', () => {
+    assert.throws(() => parseSignature('z'), /Unknown type/);
+  });
+
+  it('rejects an unterminated container', () => {
+    assert.throws(() => parseSignature('(ii'), /unexpected end/);
+    assert.throws(() => parseSignature('a'), /unexpected end/);
+  });
+});
+
+describe('Signature cache', () => {
+  it('returns the same tree for the same signature', () => {
+    assert.strictEqual(parseSignature('a{sv}'), parseSignature('a{sv}'));
+  });
+
+  it('returns different trees for different signatures', () => {
+    assert.notStrictEqual(parseSignature('ai'), parseSignature('as'));
+  });
+
+  // readVariant hands the tree to application code, so a shared entry must
+  // not be mutable or one caller could corrupt every other user of it.
+  it('deep-freezes cached trees', () => {
+    const tree = parseSignature('a(is)');
+    assert.ok(Object.isFrozen(tree), 'top level frozen');
+    assert.ok(Object.isFrozen(tree[0]), 'node frozen');
+    assert.ok(Object.isFrozen(tree[0].child), 'child array frozen');
+    assert.ok(Object.isFrozen(tree[0].child[0].child[0]), 'leaf frozen');
+  });
+
+  it('survives an attempt to mutate a returned tree', () => {
+    const tree = parseSignature('ai');
+    try {
+      tree[0].type = 'X';
+      tree.push({ type: 'q', child: [] });
+    } catch {
+      // strict-mode callers get a TypeError; either way nothing changes
+    }
+    assert.strictEqual(parseSignature('ai')[0].type, 'a');
+    assert.strictEqual(parseSignature('ai').length, 1);
+  });
+
+  it('does not cache signatures that fail to parse', () => {
+    assert.throws(() => parseSignature('a{sv'), /unexpected end/);
+    assert.throws(() => parseSignature('a{sv'), /unexpected end/);
+  });
+
+  it('exposes an uncached parser returning a fresh mutable tree', () => {
+    const a = parseSignature.uncached('ai');
+    const b = parseSignature.uncached('ai');
+    assert.notStrictEqual(a, b);
+    assert.ok(!Object.isFrozen(a));
+    assert.deepStrictEqual(a, b);
+  });
+
+  // Signatures come from the peer, so the cache must not grow without bound.
+  it('bounds the cache', () => {
+    const before = parseSignature.cacheSize();
+    for (let i = 0; i < 1500; i++) {
+      // each distinct, and each a valid signature
+      parseSignature(
+        `(${'i'.repeat((i % 40) + 1)}${'u'.repeat((i % 7) + 1)})${'y'.repeat((i % 11) + 1)}`
+      );
+    }
+    const after = parseSignature.cacheSize();
+    assert.ok(after <= 1000, `cache grew to ${after}`);
+    assert.ok(after >= before, 'cache is still populated');
+  });
+
+  it('still round-trips correctly after eviction churn', () => {
+    const buf = marshall('a{sv}', [[['k', ['s', 'v']]]]);
+    assert.deepStrictEqual(unmarshall(buf, 'a{sv}')[0][0][0], 'k');
+  });
 });


### PR DESCRIPTION
Implements **ROADMAP §2.4**, and the first item in section 2 to speed up the **read** path — §2.1–§2.3 only touched writes.

`parseSignature` ran on every `marshall()` call, on every message header, and worst of all **once per variant value**. Unmarshalling an `a{sv}` with 500 entries parsed 500 signatures.

| case | before | after | |
| --- | --- | --- | --- |
| unmarshall `a{sv}`, 500 entries | 243.6 µs | 124.2 µs | 2.0× |
| unmarshall Notify-like | 1.33 µs | 1.03 µs | 1.3× |
| marshall Notify-like | 2.18 µs | 1.86 µs | 1.2× |
| `message.marshall` (full call) | 5.28 µs | 4.13 µs | 1.3× |

### The bit that needed care

The roadmap flagged that cached trees must be immutable, so I checked every call site. No caller mutates one — but `DBusBuffer.readVariant` **returns** the tree to application code as `variant[0]`:

```js
DBusBuffer.prototype.readVariant = function readVariant() {
  const signature = this.readSimpleType(g);
  const tree = parseSignature(signature);
  return [tree, this.readStruct(tree)];   // <- escapes the library
};
```

Today each variant gets a fresh tree, so a caller poking at `variant[0]` harms nobody. Share it and one caller could corrupt an entry the whole process depends on. So cached trees are **deep-frozen** rather than just documented as immutable — the escape becomes harmless instead of a latent footgun. Mutation attempts throw for strict-mode callers and are ignored otherwise; either way the cache is intact, which is covered by a test.

The cache is **bounded at 1000 entries** with oldest-first eviction. Signatures arrive from the peer, so an unbounded map keyed on remote input is a memory-growth vector. Signatures that fail to parse throw and are not cached. `parseSignature.uncached()` still returns a fresh mutable tree if anything ever needs one.

### Verification

- Re-ran the differential test from #307 against the pre-rewrite marshaller: still **1157/1157 byte-identical**.
- `test/signature.js` was an empty placeholder with commented-out TODOs; it now has real parser coverage plus cache tests (identity, freezing, mutation resistance, bounded growth, no caching of parse failures).
- **176 unit** (was 163) + 12 integration.

That closes out the high-priority half of §2. Remaining: §2.5 (`ay` views retaining the whole message), §2.6 (big-endian), §2.7 (backpressure), §2.8 (UNIX_FD, needs design), §2.9 (cleanups).