### PR TITLE
fix: copy ay byte arrays instead of returning a view of the message

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,14 @@ options:
 - host - TCP host
 - busAddress - encoded bus address. Default is `DBUS_SESSION_BUS_ADDRESS` environment variable. See http://dbus.freedesktop.org/doc/dbus-specification.html#addresses
 - authMethods - array of authentication methods, which are attempted in the order provided (default:['EXTERNAL', 'DBUS_COOKIE_SHA1', 'ANONYMOUS'])
-- ayBuffer - boolean (default:true): if true 'ay' dbus fields are returned as buffers
+- ayBuffer - `true` (default), `false` or `'view'`: how `ay` (byte array) fields
+  are returned.
+  - `true` returns a `Buffer` holding its own copy of the bytes.
+  - `'view'` returns a `Buffer` that shares memory with the received message.
+    This avoids a copy, but the whole message stays in memory for as long as
+    you hold the byte array — a 4 byte `ay` taken from a 4 MB message keeps all
+    4 MB alive. Only use it if you consume the value and drop it promptly.
+  - `false` returns a plain array of numbers.
 - ReturnLongjs - boolean (default:false): if true 64 bit dbus fields (x/t) are read out as Long.js objects, otherwise they are converted to numbers (which should be good up to 53 bits)
 - ( TODO: add/document option to use address from X11 session )
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -262,7 +262,9 @@ deep-frozen rather than merely documented as immutable.
 This is the first item in §2 to speed up the **read** path, which §2.1–§2.3 left
 untouched.
 
-### 2.5 `ay` buffer views retain the whole message
+### 2.5 `ay` buffer views retain the whole message — DONE
+
+Landed in #310.
 
 **Severity: medium — unbounded memory growth in long-lived processes.**
 
@@ -278,6 +280,16 @@ Decide deliberately: copy by default (safe, costs a memcpy) or keep the view and
 document it, ideally as an explicit `ayBuffer: 'view' | 'copy'` option. Copy is
 the better default — the current behaviour is a footgun that only shows up under
 load.
+
+**Outcome (#310).** Copy by default; `ayBuffer: 'view'` opts back into the
+zero-copy view, and `ayBuffer: false` still yields a plain array. `slice` also
+became `subarray`.
+
+The copy runs at 5–8.5 GB/s, so it costs 0.18 µs on a 1 KB `ay` and 117 µs on a
+1 MB one. That is real, but small next to the socket read that delivered the
+message, and it is the difference between a 4 byte value retaining 4 bytes and
+retaining 4 MB. Throughput-sensitive callers that consume and drop the value
+promptly can set `'view'`.
 
 ### 2.6 Accept big-endian messages
 

--- a/lib/dbus-buffer.js
+++ b/lib/dbus-buffer.js
@@ -137,7 +137,14 @@ DBusBuffer.prototype.readArray = function readArray(eleType, arrayBlobSize) {
   // special case: treat ay as Buffer
   if (eleType.type === 'y' && this.options.ayBuffer) {
     this.pos += arrayBlobSize;
-    return this.buffer.slice(start, this.pos);
+    const bytes = this.buffer.subarray(start, this.pos);
+    // A subarray shares memory with the whole message, so holding on to a
+    // handful of bytes would keep the entire message alive -- a 4 byte `ay`
+    // pulled out of a 4 MB message retained all 4 MB. Copy by default and let
+    // callers opt back into the zero-copy view if they know the lifetimes are
+    // fine. The copy runs at memcpy speed and is noise next to the I/O that
+    // delivered the message in the first place.
+    return this.options.ayBuffer === 'view' ? bytes : Buffer.from(bytes);
   }
 
   // end of array is start of first element + array size

--- a/test/marshall-writer.js
+++ b/test/marshall-writer.js
@@ -45,6 +45,64 @@ describe('marshall: byte arrays', () => {
   });
 });
 
+describe('unmarshall: ay buffer ownership', () => {
+  const message = require('../lib/message');
+
+  // A small ay carried in a large message used to be returned as a view, so
+  // holding four bytes kept the whole message reachable.
+  const wire = message.marshall({
+    serial: 1,
+    type: 1,
+    path: '/p',
+    destination: 'a.b',
+    interface: 'a.b',
+    member: 'M',
+    signature: 'ayay',
+    body: [Buffer.alloc(512 * 1024, 7), Buffer.from([1, 2, 3, 4])]
+  });
+
+  it('does not retain the message buffer by default', () => {
+    const small = message.unmarshall(wire, {}).body[1];
+    assert.strictEqual(small.length, 4);
+    assert.notStrictEqual(
+      small.buffer,
+      wire.buffer,
+      'byte array still aliases the message'
+    );
+    assert.ok(
+      small.buffer.byteLength < wire.length,
+      `retained ${small.buffer.byteLength} bytes for 4 bytes of data`
+    );
+  });
+
+  it("returns a zero-copy view when ayBuffer is 'view'", () => {
+    const small = message.unmarshall(wire, { ayBuffer: 'view' }).body[1];
+    assert.strictEqual(small.buffer, wire.buffer);
+  });
+
+  it('produces identical bytes either way', () => {
+    const copied = message.unmarshall(wire, {}).body[0];
+    const viewed = message.unmarshall(wire, { ayBuffer: 'view' }).body[0];
+    assert.ok(copied.equals(viewed));
+    assert.strictEqual(copied.length, 512 * 1024);
+  });
+
+  it('still returns a plain array when ayBuffer is false', () => {
+    const small = message.unmarshall(wire, { ayBuffer: false }).body[1];
+    assert.ok(Array.isArray(small));
+    assert.deepStrictEqual(small, [1, 2, 3, 4]);
+  });
+
+  it('handles an empty ay in both modes', () => {
+    const empty = marshall('ay', [Buffer.alloc(0)]);
+    assert.strictEqual(unmarshall(empty, 'ay', 0, {})[0].length, 0);
+    assert.strictEqual(
+      unmarshall(empty, 'ay', 0, { ayBuffer: 'view' })[0].length,
+      0
+    );
+  });
+});
+
 describe('marshall: array arguments', () => {
   // The old marshaller iterated `data.length` blindly, so a non-array silently
   // serialised as an empty array instead of raising.


### PR DESCRIPTION
Implements **ROADMAP §2.5**.

`DBusBuffer` returned `ay` fields as a subarray of the received message, so holding the byte array kept the whole message reachable:

```
message on the wire  : 4.00 MB
small ay length      : 4
shares message memory: true
retained ArrayBuffer : 4.00 MB to hold 4 bytes
```

In a long-lived process that pulls byte arrays out of large messages, memory grows with **traffic** rather than with data actually kept — and it only shows up under load, which is the worst way to find it.

### The change

Byte arrays are copied by default. Two escape hatches, both tested:

| `ayBuffer` | result |
| --- | --- |
| `true` (default) | `Buffer` owning its own copy |
| `view` | `Buffer` sharing memory with the message — the old behaviour |
| `false` | plain array of numbers (unchanged) |

`Buffer.prototype.slice` (deprecated in favour of `subarray`) is also gone, which was the other half of this roadmap item.

### The cost, honestly

The copy runs at 5–8.5 GB/s:

| size | view | copy | delta |
| --- | --- | --- | --- |
| 1 KB | 0.120 µs | 0.302 µs | +0.18 µs |
| 64 KB | 0.138 µs | 8.54 µs | +8.4 µs |
| 1 MB | 0.088 µs | 117.0 µs | +117 µs |

That is a genuine regression for large payloads, and I want it visible rather than buried. I still think copy is the right default: it is a memcpy against a message that just came off a socket — the I/O to deliver 1 MB dwarfs 117 µs — and the alternative is unbounded retention that most users will never think to look for. Anyone streaming large `ay` payloads who consumes and drops them promptly can set `view` and get the old numbers back exactly.

### Verification

Five new tests: default does not alias the message, `view` does, both produce identical bytes, `false` still gives an array, and the empty case works in both modes. **181 unit** (was 176) + 12 integration.