### PR TITLE
feat: read big-endian messages

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -291,7 +291,9 @@ message, and it is the difference between a 4 byte value retaining 4 bytes and
 retaining 4 MB. Throughput-sensitive callers that consume and drop the value
 promptly can set `'view'`.
 
-### 2.6 Accept big-endian messages
+### 2.6 Accept big-endian messages — DONE
+
+Landed in #311.
 
 **Severity: low frequency, but a spec violation.**
 
@@ -307,6 +309,19 @@ some MIPS/PPC), which is why it has gone unnoticed.
 Work: thread a byte-order flag through `DBusBuffer` and pick `*LE`/`*BE` readers
 from it. Mostly mechanical, but it touches every read method, so it deserves its
 own PR and a round-trip test against a hand-built big-endian fixture.
+
+**Outcome (#311).** Byte order is read from header byte 0 and threaded into
+`DBusBuffer`, which selects `*LE`/`*BE` accessors per read. The 64-bit types
+needed care: both the bytes within each 32-bit word _and_ the order of the two
+words flip. Anything that is neither `'l'` nor `'B'` is still a protocol error.
+
+Senders still emit little-endian, which the spec permits. No measurable cost to
+the read path (1.09 µs vs 1.03 µs on the Notify case, within run-to-run noise).
+
+Fixtures are assembled by hand with Node's own `writeUInt32BE`, not by
+round-tripping through this library, so a writer and reader sharing the same
+mistake cannot make the tests pass. That caught a bug in the fixture itself:
+`g` (signature) values take a one-byte length and no alignment, unlike `s`.
 
 ### 2.7 Backpressure on the write path
 

--- a/lib/dbus-buffer.js
+++ b/lib/dbus-buffer.js
@@ -3,7 +3,13 @@ const constants = require('./constants');
 const parseSignature = require('./signature');
 
 // Buffer + position + global start position ( used in alignment )
-function DBusBuffer(buffer, startPos, options) {
+//
+// `endianness` is the byte order the message declared in its first header
+// byte. Senders may choose either, and receivers have to cope with both, so
+// every multi-byte read below picks its accessor from it. Defaults to
+// little-endian, which is what this library emits and what essentially every
+// mainstream peer sends.
+function DBusBuffer(buffer, startPos, options, endianness) {
   if (typeof options !== 'object') {
     options = { ayBuffer: true, ReturnLongjs: false };
   } else if (options.ayBuffer === undefined) {
@@ -14,6 +20,7 @@ function DBusBuffer(buffer, startPos, options) {
   this.buffer = buffer;
   this.startPos = startPos ? startPos : 0;
   this.pos = 0;
+  this.le = endianness === undefined || endianness === constants.endianness.le;
 }
 
 DBusBuffer.prototype.align = function (power) {
@@ -29,35 +36,45 @@ DBusBuffer.prototype.readInt8 = function () {
 
 DBusBuffer.prototype.readSInt16 = function () {
   this.align(1);
-  const res = this.buffer.readInt16LE(this.pos);
+  const res = this.le
+    ? this.buffer.readInt16LE(this.pos)
+    : this.buffer.readInt16BE(this.pos);
   this.pos += 2;
   return res;
 };
 
 DBusBuffer.prototype.readInt16 = function () {
   this.align(1);
-  const res = this.buffer.readUInt16LE(this.pos);
+  const res = this.le
+    ? this.buffer.readUInt16LE(this.pos)
+    : this.buffer.readUInt16BE(this.pos);
   this.pos += 2;
   return res;
 };
 
 DBusBuffer.prototype.readSInt32 = function () {
   this.align(2);
-  const res = this.buffer.readInt32LE(this.pos);
+  const res = this.le
+    ? this.buffer.readInt32LE(this.pos)
+    : this.buffer.readInt32BE(this.pos);
   this.pos += 4;
   return res;
 };
 
 DBusBuffer.prototype.readInt32 = function () {
   this.align(2);
-  const res = this.buffer.readUInt32LE(this.pos);
+  const res = this.le
+    ? this.buffer.readUInt32LE(this.pos)
+    : this.buffer.readUInt32BE(this.pos);
   this.pos += 4;
   return res;
 };
 
 DBusBuffer.prototype.readDouble = function () {
   this.align(3);
-  const res = this.buffer.readDoubleLE(this.pos);
+  const res = this.le
+    ? this.buffer.readDoubleLE(this.pos)
+    : this.buffer.readDoubleBE(this.pos);
   this.pos += 8;
   return res;
 };
@@ -158,8 +175,20 @@ DBusBuffer.prototype.readArray = function readArray(eleType, arrayBlobSize) {
   return result;
 };
 
+// A 64-bit value is two 32-bit words. Each word is byte-swapped by readInt32
+// according to the message's byte order, and the *order of the words* flips
+// too: little-endian puts the low word first, big-endian the high word.
+DBusBuffer.prototype.readLong = function readLong(unsigned) {
+  this.align(3);
+  const first = this.readInt32();
+  const second = this.readInt32();
+  return this.le
+    ? Long.fromBits(first, second, unsigned)
+    : Long.fromBits(second, first, unsigned);
+};
+
 DBusBuffer.prototype.readSimpleType = function readSimpleType(t) {
-  let data, len, word0, word1;
+  let data, len;
   switch (t) {
     case 'y':
       return this.readInt8();
@@ -187,18 +216,12 @@ DBusBuffer.prototype.readSimpleType = function readSimpleType(t) {
     //  throw new Error('string is not a valid object path'));
     case 'x':
       //signed
-      this.align(3);
-      word0 = this.readInt32();
-      word1 = this.readInt32();
-      data = Long.fromBits(word0, word1, false);
+      data = this.readLong(false);
       if (this.options.ReturnLongjs) return data;
       return data.toNumber(); // convert to number (good up to 53 bits)
     case 't':
       //unsigned
-      this.align(3);
-      word0 = this.readInt32();
-      word1 = this.readInt32();
-      data = Long.fromBits(word0, word1, true);
+      data = this.readLong(true);
       if (this.options.ReturnLongjs) return data;
       return data.toNumber(); // convert to number (good up to 53 bits)
     case 'd':

--- a/lib/message.js
+++ b/lib/message.js
@@ -33,7 +33,7 @@ module.exports.unmarshalMessages = function messageParser(
     (opts && opts.maxMessageSize) || constants.maxMessageSize;
 
   let state = 0; // 0: header, 1: fields + body
-  let header, fieldsAndBody;
+  let header, fieldsAndBody, endianness;
   let fieldsLength, fieldsLengthPadded;
   let fieldsAndBodyLength = 0;
   let bodyLength = 0;
@@ -53,16 +53,19 @@ module.exports.unmarshalMessages = function messageParser(
     header = stream.read(16);
     if (!header) return false;
 
-    if (header[0] !== constants.endianness.le) {
-      // Big-endian senders are legal but unimplemented. Fail loudly rather
-      // than reading the whole message little-endian and yielding garbage.
+    endianness = header[0];
+    if (
+      endianness !== constants.endianness.le &&
+      endianness !== constants.endianness.be
+    ) {
       throw new ProtocolError(
-        `Unsupported byte order '${String.fromCharCode(header[0])}'. Only little-endian ('l') messages can be read.`
+        `Invalid byte order '${String.fromCharCode(endianness)}' (0x${endianness.toString(16)}), expected 'l' or 'B'`
       );
     }
+    const le = endianness === constants.endianness.le;
 
-    bodyLength = header.readUInt32LE(4);
-    fieldsLength = header.readUInt32LE(12);
+    bodyLength = le ? header.readUInt32LE(4) : header.readUInt32BE(4);
+    fieldsLength = le ? header.readUInt32LE(12) : header.readUInt32BE(12);
 
     // Validate before doing any arithmetic on, or allocating for, these.
     if (bodyLength > maxMessageSize || fieldsLength > maxMessageSize) {
@@ -87,14 +90,22 @@ module.exports.unmarshalMessages = function messageParser(
       fieldsAndBodyLength === 0 ? EMPTY : stream.read(fieldsAndBodyLength);
     if (!fieldsAndBody) return null;
 
-    const messageBuffer = new DBusBuffer(fieldsAndBody, undefined, opts);
+    const messageBuffer = new DBusBuffer(
+      fieldsAndBody,
+      undefined,
+      opts,
+      endianness
+    );
     const unmarshalledHeader = messageBuffer.readArray(
       headerSignature[0].child[0],
       fieldsLength
     );
     messageBuffer.align(3);
     const message = {};
-    message.serial = header.readUInt32LE(8);
+    message.serial =
+      endianness === constants.endianness.le
+        ? header.readUInt32LE(8)
+        : header.readUInt32BE(8);
 
     for (const field of unmarshalledHeader) {
       const headerName = constants.headerTypeName[field[0]];
@@ -145,7 +156,18 @@ module.exports.unmarshalMessages = function messageParser(
 // given buffer which contains entire message deserialise it
 // TODO: factor out common code
 module.exports.unmarshall = function unmarshall(buff, opts) {
-  const msgBuf = new DBusBuffer(buff, undefined, opts);
+  // The byte order flag is the first byte and is itself order-independent, so
+  // it can be read before deciding how to read everything after it.
+  const endianness = buff[0];
+  if (
+    endianness !== constants.endianness.le &&
+    endianness !== constants.endianness.be
+  ) {
+    throw new ProtocolError(
+      `Invalid byte order '${String.fromCharCode(endianness)}' (0x${(endianness ?? 0).toString(16)}), expected 'l' or 'B'`
+    );
+  }
+  const msgBuf = new DBusBuffer(buff, undefined, opts, endianness);
   const headers = msgBuf.read('yyyyuua(yv)');
   const message = {};
   for (let i = 0; i < headers[6].length; ++i) {

--- a/test/big-endian.js
+++ b/test/big-endian.js
@@ -1,0 +1,219 @@
+// Reading big-endian messages.
+//
+// The fixtures here are assembled by hand with Node's own writeUInt32BE etc.
+// rather than by round-tripping through this library, so the test cannot pass
+// just because a writer and a reader share the same mistake.
+
+const assert = require('assert');
+const { PassThrough } = require('stream');
+const message = require('../lib/message');
+const constants = require('../lib/constants');
+const DBusBuffer = require('../lib/dbus-buffer');
+
+const BE = constants.endianness.be;
+const LE = constants.endianness.le;
+
+describe('DBusBuffer: big-endian scalars', () => {
+  const read = (bytes, signature, endianness) =>
+    new DBusBuffer(Buffer.from(bytes), 0, {}, endianness).read(signature)[0];
+
+  it('reads uint32', () => {
+    assert.strictEqual(read([0x00, 0x00, 0x00, 0x01], 'u', BE), 1);
+    assert.strictEqual(read([0x00, 0x00, 0x00, 0x01], 'u', LE), 0x01000000);
+    assert.strictEqual(read([0x12, 0x34, 0x56, 0x78], 'u', BE), 0x12345678);
+  });
+
+  it('reads int32', () => {
+    assert.strictEqual(read([0xff, 0xff, 0xff, 0xff], 'i', BE), -1);
+    assert.strictEqual(read([0x80, 0x00, 0x00, 0x00], 'i', BE), -2147483648);
+  });
+
+  it('reads uint16 and int16', () => {
+    assert.strictEqual(read([0x01, 0x02], 'q', BE), 0x0102);
+    assert.strictEqual(read([0x01, 0x02], 'q', LE), 0x0201);
+    assert.strictEqual(read([0xff, 0xfe], 'n', BE), -2);
+  });
+
+  it('reads a double', () => {
+    const bytes = Buffer.alloc(8);
+    bytes.writeDoubleBE(3.141592653589793, 0);
+    assert.strictEqual(read([...bytes], 'd', BE), 3.141592653589793);
+  });
+
+  it('reads a boolean', () => {
+    assert.strictEqual(read([0x00, 0x00, 0x00, 0x01], 'b', BE), true);
+    assert.strictEqual(read([0x00, 0x00, 0x00, 0x00], 'b', BE), false);
+  });
+
+  // Both the bytes within each 32-bit word and the order of the two words
+  // flip, which is easy to get half right.
+  it('reads 64-bit values with the correct word order', () => {
+    const bytes = Buffer.alloc(8);
+    bytes.writeBigInt64BE(0x0000000100000002n, 0);
+    assert.strictEqual(read([...bytes], 'x', BE), 0x0000000100000002);
+
+    const big = Buffer.alloc(8);
+    big.writeBigUInt64BE(9007199254740991n, 0);
+    assert.strictEqual(read([...big], 't', BE), 9007199254740991);
+
+    const negative = Buffer.alloc(8);
+    negative.writeBigInt64BE(-42n, 0);
+    assert.strictEqual(read([...negative], 'x', BE), -42);
+  });
+
+  it('reads a string, whose length field is byte-order sensitive', () => {
+    // length 5 big-endian, then "hello\0"
+    const bytes = [0, 0, 0, 5, ...Buffer.from('hello'), 0];
+    assert.strictEqual(read(bytes, 's', BE), 'hello');
+  });
+
+  it('reads an array, whose length field is byte-order sensitive', () => {
+    // 8 bytes of body big-endian, then two uint32 elements
+    const bytes = [0, 0, 0, 8, 0, 0, 0, 1, 0, 0, 0, 2];
+    assert.deepStrictEqual(read(bytes, 'au', BE), [1, 2]);
+  });
+});
+
+// Build a complete big-endian method call by hand.
+//
+//   'B', type=1, flags=0, version=1, bodyLength, serial, fieldsLength
+//   then a(yv) header fields, padded to 8, then the body.
+function bigEndianMethodCall() {
+  const fields = [];
+
+  // one a(yv) entry: struct, 8-aligned, a byte code then a variant
+  const field = (code, sigChar, value) => {
+    while (fields.length % 8 !== 0) fields.push(0); // struct alignment
+    fields.push(code);
+    fields.push(1, sigChar.charCodeAt(0), 0); // variant signature: len, char, NUL
+    const bytes = Buffer.from(value, 'utf8');
+    if (sigChar === 'g') {
+      // a signature is length-prefixed with a single byte and is not aligned
+      fields.push(bytes.length, ...bytes, 0);
+      return;
+    }
+    // 's' and 'o' take a 4-byte length, aligned to 4 within the message
+    while ((fields.length + 16) % 4 !== 0) fields.push(0);
+    const len = Buffer.alloc(4);
+    len.writeUInt32BE(bytes.length, 0); // <- big-endian length
+    fields.push(...len, ...bytes, 0);
+  };
+
+  field(1, 'o', '/com/example/Path'); // PATH
+  field(2, 's', 'com.example.Iface'); // INTERFACE
+  field(3, 's', 'BigEndianPing'); // MEMBER
+  field(8, 'g', 's'); // SIGNATURE
+
+  const fieldsLength = fields.length;
+  while (fields.length % 8 !== 0) fields.push(0); // pad before the body
+
+  const bodyText = Buffer.from('sent big-endian', 'utf8');
+  const body = Buffer.alloc(4 + bodyText.length + 1);
+  body.writeUInt32BE(bodyText.length, 0); // <- big-endian length
+  bodyText.copy(body, 4);
+
+  const header = Buffer.alloc(16);
+  header[0] = BE;
+  header[1] = constants.messageType.methodCall;
+  header[2] = 0;
+  header[3] = constants.protocolVersion;
+  header.writeUInt32BE(body.length, 4);
+  header.writeUInt32BE(0x11223344, 8); // serial, deliberately asymmetric
+  header.writeUInt32BE(fieldsLength, 12);
+
+  return Buffer.concat([header, Buffer.from(fields), body]);
+}
+
+describe('big-endian messages', () => {
+  const expected = {
+    path: '/com/example/Path',
+    interface: 'com.example.Iface',
+    member: 'BigEndianPing',
+    signature: 's',
+    serial: 0x11223344,
+    body: ['sent big-endian']
+  };
+
+  it('message.unmarshall reads one', () => {
+    const msg = message.unmarshall(bigEndianMethodCall());
+    assert.strictEqual(msg.path, expected.path);
+    assert.strictEqual(msg.interface, expected.interface);
+    assert.strictEqual(msg.member, expected.member);
+    assert.strictEqual(msg.serial, expected.serial);
+    assert.deepStrictEqual(msg.body, expected.body);
+    assert.strictEqual(msg.type, constants.messageType.methodCall);
+  });
+
+  it('the streaming parser reads one', done => {
+    const stream = new PassThrough();
+    message.unmarshalMessages(
+      stream,
+      msg => {
+        assert.strictEqual(msg.member, expected.member);
+        assert.strictEqual(msg.serial, expected.serial);
+        assert.deepStrictEqual(msg.body, expected.body);
+        done();
+      },
+      {},
+      done
+    );
+    stream.write(bigEndianMethodCall());
+  });
+
+  it('reads one split across chunk boundaries', done => {
+    const buf = bigEndianMethodCall();
+    const stream = new PassThrough();
+    message.unmarshalMessages(
+      stream,
+      msg => {
+        assert.strictEqual(msg.member, expected.member);
+        done();
+      },
+      {},
+      done
+    );
+    stream.write(buf.subarray(0, 7));
+    stream.write(buf.subarray(7, 19));
+    stream.write(buf.subarray(19));
+  });
+
+  it('interleaves with little-endian messages on the same connection', done => {
+    const le = message.marshall({
+      serial: 7,
+      type: constants.messageType.methodCall,
+      path: '/le',
+      destination: 'a.b',
+      interface: 'a.b',
+      member: 'LittleEndianPing',
+      signature: 's',
+      body: ['sent little-endian']
+    });
+    const seen = [];
+    const stream = new PassThrough();
+    message.unmarshalMessages(
+      stream,
+      msg => {
+        seen.push([msg.member, msg.body[0]]);
+        if (seen.length === 3) {
+          assert.deepStrictEqual(seen, [
+            ['BigEndianPing', 'sent big-endian'],
+            ['LittleEndianPing', 'sent little-endian'],
+            ['BigEndianPing', 'sent big-endian']
+          ]);
+          done();
+        }
+      },
+      {},
+      done
+    );
+    stream.write(
+      Buffer.concat([bigEndianMethodCall(), le, bigEndianMethodCall()])
+    );
+  });
+
+  it('still rejects a byte order that is neither', () => {
+    const bad = bigEndianMethodCall();
+    bad[0] = 0x41; // 'A'
+    assert.throws(() => message.unmarshall(bad), /Invalid byte order/);
+  });
+});

--- a/test/message-framing.js
+++ b/test/message-framing.js
@@ -131,13 +131,18 @@ describe('message framing', () => {
     assert.strictEqual(errors[0].code, 'EPROTO');
   });
 
-  it('rejects big-endian messages instead of misreading them', async () => {
-    const be = methodCall();
-    be[0] = constants.endianness.be;
-    const { messages, errors } = await parse([be]);
-    assert.deepStrictEqual(messages, []);
-    assert.strictEqual(errors.length, 1);
-    assert.match(errors[0].message, /byte order/);
+  // Big-endian is now read properly (see test/big-endian.js); anything that is
+  // neither 'l' nor 'B' is still a protocol error.
+  it('rejects an invalid byte order flag', async () => {
+    for (const flag of [0x00, 0x41, 0xff]) {
+      const bad = methodCall();
+      bad[0] = flag;
+      const { messages, errors } = await parse([bad]);
+      assert.deepStrictEqual(messages, [], `flag 0x${flag.toString(16)}`);
+      assert.strictEqual(errors.length, 1);
+      assert.strictEqual(errors[0].code, 'EPROTO');
+      assert.match(errors[0].message, /byte order/);
+    }
   });
 
   it('stops parsing after a framing error', async () => {


### PR DESCRIPTION
Implements **ROADMAP §2.6**, the last correctness gap in the wire-layer audit.

The byte order flag in header byte 0 was never consulted — every read was `*LE` regardless, so a big-endian peers messages decoded as garbage. #303 made that fail loudly; this reads them properly.

The spec lets a sender pick either byte order and **requires receivers to accept both**. Only big-endian hardware (s390x, some MIPS/PPC) actually sends `B`, which is why it went unnoticed for so long.

### What changed

Byte order is parsed from the header and threaded into `DBusBuffer`, which selects `*LE`/`*BE` accessors per read. Senders still emit little-endian, which the spec permits. Anything that is neither `l` nor `B` is still a protocol error.

The 64-bit types were the one place needing real care — **both** the bytes within each 32-bit word **and** the order of the two words flip:

```js
return this.le
  ? Long.fromBits(first, second, unsigned)
  : Long.fromBits(second, first, unsigned);
```

Getting half of that right would produce plausible-looking wrong numbers, so it has its own test using `writeBigInt64BE`.

### Testing approach

The message fixtures are **assembled by hand with Nodes own `writeUInt32BE`**, not by round-tripping through this library — otherwise a writer and reader sharing the same mistake would make the tests pass. That paid off immediately: it caught a bug in my fixture where I encoded a `g` (signature) value with a 4-byte aligned length, when signatures take a one-byte length and no alignment.

13 new tests: every scalar type from explicit byte arrays, a full method call end to end, split across chunk boundaries, and **interleaved with little-endian messages on the same connection** — since byte order is per-message, not per-connection.

The test from #303 asserting big-endian is *rejected* is replaced by one asserting an invalid flag (`0x00`, `A`, `0xff`) is.

### Cost

None measurable: 1.09 µs/op vs 1.03 µs/op on a Notify-sized message, inside run-to-run noise. **194 unit** (was 181) + 12 integration.

Remaining in §2: 2.7 backpressure, 2.8 UNIX_FD (needs design), 2.9 cleanups.