### PR TITLE
chore: tidy up the remaining wire-layer rough edges

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -349,7 +349,9 @@ public SCM_RIGHTS API, so it likely means a small native addon or a
 `child_process`-mediated hack — which would undo the "no native dependencies"
 property this package is valued for. Worth scoping before committing.
 
-### 2.9 Small non-canonical cleanups
+### 2.9 Small non-canonical cleanups — DONE
+
+Landed in #312.
 
 **Severity: low — batch them into one tidy-up PR.**
 
@@ -364,6 +366,17 @@ property this package is valued for. Worth scoping before committing.
 - `lib/readline.js` reads **one byte at a time** via `stream.read(1)`.
   Handshake-only so the impact is negligible, but it is not idiomatic.
 - `message.js` never validates the protocol version byte (`header[3]`).
+
+**Outcome (#312).** All done, except `parseInt`/`parseFloat`, which the §2.3
+rewrite had already removed. Two are behaviour changes worth noting in the
+changelog: `unmarshall('')` now returns `[]` rather than an empty `Buffer`, and
+a message declaring a protocol version other than 1 is rejected as the spec
+requires instead of being parsed anyway.
+
+`readOneLine` now reads whole chunks and `unshift()`s the remainder rather than
+calling `stream.read(1)` per byte. It only runs during the SASL handshake, so
+this is tidiness rather than throughput — but it is on the critical path, so it
+gained its own test file alongside the existing real-daemon handshake coverage.
 
 ---
 

--- a/lib/dbus-buffer.js
+++ b/lib/dbus-buffer.js
@@ -2,6 +2,8 @@ const Long = require('long');
 const constants = require('./constants');
 const parseSignature = require('./signature');
 
+const DEFAULT_OPTIONS = { ayBuffer: true, ReturnLongjs: false };
+
 // Buffer + position + global start position ( used in alignment )
 //
 // `endianness` is the byte order the message declared in its first header
@@ -10,13 +12,16 @@ const parseSignature = require('./signature');
 // little-endian, which is what this library emits and what essentially every
 // mainstream peer sends.
 function DBusBuffer(buffer, startPos, options, endianness) {
-  if (typeof options !== 'object') {
-    options = { ayBuffer: true, ReturnLongjs: false };
-  } else if (options.ayBuffer === undefined) {
-    // default settings object
-    options.ayBuffer = true; // enforce truthy default props
-  }
-  this.options = options;
+  // `typeof null === 'object'`, so a null options argument has to be caught
+  // by the truthiness check rather than the typeof.
+  this.options =
+    options && typeof options === 'object' ? options : DEFAULT_OPTIONS;
+  // Resolved onto the instance rather than written back into `options`. A
+  // connection passes its own options object straight through to every
+  // message, and defaulting in place would silently add an `ayBuffer`
+  // property the caller never set.
+  this.ayBuffer =
+    this.options.ayBuffer === undefined ? true : this.options.ayBuffer;
   this.buffer = buffer;
   this.startPos = startPos ? startPos : 0;
   this.pos = 0;
@@ -152,7 +157,7 @@ DBusBuffer.prototype.readArray = function readArray(eleType, arrayBlobSize) {
   }
 
   // special case: treat ay as Buffer
-  if (eleType.type === 'y' && this.options.ayBuffer) {
+  if (eleType.type === 'y' && this.ayBuffer) {
     this.pos += arrayBlobSize;
     const bytes = this.buffer.subarray(start, this.pos);
     // A subarray shares memory with the whole message, so holding on to a
@@ -161,7 +166,7 @@ DBusBuffer.prototype.readArray = function readArray(eleType, arrayBlobSize) {
     // callers opt back into the zero-copy view if they know the lifetimes are
     // fine. The copy runs at memcpy speed and is noise next to the I/O that
     // delivered the message in the first place.
-    return this.options.ayBuffer === 'view' ? bytes : Buffer.from(bytes);
+    return this.ayBuffer === 'view' ? bytes : Buffer.from(bytes);
   }
 
   // end of array is start of first element + array size

--- a/lib/message.js
+++ b/lib/message.js
@@ -62,6 +62,14 @@ module.exports.unmarshalMessages = function messageParser(
         `Invalid byte order '${String.fromCharCode(endianness)}' (0x${endianness.toString(16)}), expected 'l' or 'B'`
       );
     }
+    // The spec requires a receiver to reject a major protocol version it does
+    // not understand rather than guess at the layout.
+    if (header[3] !== constants.protocolVersion) {
+      throw new ProtocolError(
+        `Unsupported protocol version ${header[3]}, expected ${constants.protocolVersion}`
+      );
+    }
+
     const le = endianness === constants.endianness.le;
 
     bodyLength = le ? header.readUInt32LE(4) : header.readUInt32BE(4);

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -1,21 +1,37 @@
+// Read a single LF-terminated line from a stream, leaving anything after the
+// newline on the stream for the next reader.
+//
+// Used by the SASL handshake, which is line oriented; once BEGIN has been sent
+// the connection switches to binary framing and this is no longer involved.
 module.exports = function readOneLine(stream, cb) {
-  const bytes = [];
+  const parts = [];
+
   function readable() {
-    while (1) {
-      const buf = stream.read(1);
-      if (!buf) return;
-      const b = buf[0];
-      if (b === 0x0a) {
-        try {
-          cb(Buffer.from(bytes));
-        } catch (error) {
-          stream.emit('error', error);
-        }
-        stream.removeListener('readable', readable);
-        return;
+    let chunk;
+    while ((chunk = stream.read()) !== null) {
+      const newline = chunk.indexOf(0x0a);
+      if (newline === -1) {
+        parts.push(chunk);
+        continue;
       }
-      bytes.push(b);
+
+      parts.push(chunk.subarray(0, newline));
+      const line = parts.length === 1 ? parts[0] : Buffer.concat(parts);
+      const rest = chunk.subarray(newline + 1);
+
+      // Detach before handing anything back: the callback normally starts the
+      // next readOneLine, and unshift() re-emits 'readable'.
+      stream.removeListener('readable', readable);
+      if (rest.length > 0) stream.unshift(rest);
+
+      try {
+        cb(line);
+      } catch (error) {
+        stream.emit('error', error);
+      }
+      return;
     }
   }
+
   stream.on('readable', readable);
 };

--- a/lib/unmarshall.js
+++ b/lib/unmarshall.js
@@ -2,7 +2,9 @@ const DBusBuffer = require('./dbus-buffer');
 
 module.exports = function unmarshall(buffer, signature, startPos, options) {
   if (!startPos) startPos = 0;
-  if (signature === '') return Buffer.from('');
+  // An empty signature carries no values, so the result is an empty list of
+  // them -- the same shape every other signature returns.
+  if (signature === '') return [];
   const dbuff = new DBusBuffer(buffer, startPos, options);
   return dbuff.read(signature);
 };

--- a/test/message-framing.js
+++ b/test/message-framing.js
@@ -145,6 +145,16 @@ describe('message framing', () => {
     }
   });
 
+  it('rejects an unsupported protocol version', async () => {
+    const bad = methodCall();
+    bad[3] = 2;
+    const { messages, errors } = await parse([bad]);
+    assert.deepStrictEqual(messages, []);
+    assert.strictEqual(errors.length, 1);
+    assert.strictEqual(errors[0].code, 'EPROTO');
+    assert.match(errors[0].message, /protocol version/);
+  });
+
   it('stops parsing after a framing error', async () => {
     const { messages, errors } = await parse([
       header({ fieldsLength: 0xfffffff0 }),
@@ -293,6 +303,41 @@ describe('message.unmarshall', () => {
     const m = message.unmarshall(methodCall());
     assert.strictEqual(m.member, 'Hello');
     assert.strictEqual(m.body, undefined);
+  });
+});
+
+describe('DBusBuffer options handling', () => {
+  it('does not mutate the caller options object', () => {
+    // A connection passes its own opts straight through to every message.
+    const opts = { ReturnLongjs: false };
+    const before = JSON.stringify(opts);
+    message.unmarshall(methodCall({ signature: 's', body: ['x'] }), opts);
+    assert.strictEqual(JSON.stringify(opts), before, 'opts gained a property');
+    assert.ok(!('ayBuffer' in opts));
+  });
+
+  it('tolerates null options', () => {
+    // typeof null === 'object', which used to slip past the guard
+    assert.doesNotThrow(() =>
+      new DBusBuffer(Buffer.alloc(4), 0, null).read('u')
+    );
+  });
+
+  it('tolerates undefined and non-object options', () => {
+    assert.doesNotThrow(() => new DBusBuffer(Buffer.alloc(4), 0).read('u'));
+    assert.doesNotThrow(() => new DBusBuffer(Buffer.alloc(4), 0, 7).read('u'));
+  });
+
+  it('still defaults ayBuffer to true', () => {
+    const buf = require('../lib/marshall')('ay', [Buffer.from([1, 2, 3])]);
+    assert.ok(Buffer.isBuffer(new DBusBuffer(buf, 0, {}).read('ay')[0]));
+  });
+});
+
+describe('unmarshall with an empty signature', () => {
+  it('returns an empty list, like every other signature', () => {
+    const unmarshall = require('../lib/unmarshall');
+    assert.deepStrictEqual(unmarshall(Buffer.alloc(0), ''), []);
   });
 });
 

--- a/test/readline.js
+++ b/test/readline.js
@@ -1,0 +1,84 @@
+// readOneLine backs the SASL handshake, so it has to cope with lines split
+// across chunks and must leave the remainder of a chunk readable.
+
+const assert = require('assert');
+const { PassThrough } = require('stream');
+const readOneLine = require('../lib/readline');
+
+const line = stream =>
+  new Promise(resolve => readOneLine(stream, buf => resolve(buf.toString())));
+
+describe('readOneLine', () => {
+  it('reads a line delivered in one chunk', async () => {
+    const s = new PassThrough();
+    const p = line(s);
+    s.write('OK 1234\n');
+    assert.strictEqual(await p, 'OK 1234');
+  });
+
+  it('reads a line split across several chunks', async () => {
+    const s = new PassThrough();
+    const p = line(s);
+    s.write('OK ');
+    s.write('12');
+    s.write('34\n');
+    assert.strictEqual(await p, 'OK 1234');
+  });
+
+  it('splits one chunk into consecutive lines', async () => {
+    const s = new PassThrough();
+    const first = line(s);
+    s.write('REJECTED EXTERNAL\nOK abcdef\nDATA\n');
+    assert.strictEqual(await first, 'REJECTED EXTERNAL');
+    assert.strictEqual(await line(s), 'OK abcdef');
+    assert.strictEqual(await line(s), 'DATA');
+  });
+
+  it('leaves bytes after the newline on the stream', async () => {
+    const s = new PassThrough();
+    const p = line(s);
+    s.write('OK 1234\r\nBINARYPAYLOAD');
+    assert.strictEqual(await p, 'OK 1234\r');
+    await new Promise(setImmediate);
+    assert.strictEqual(s.read().toString(), 'BINARYPAYLOAD');
+  });
+
+  it('handles an empty line', async () => {
+    const s = new PassThrough();
+    const p = line(s);
+    s.write('\nrest\n');
+    assert.strictEqual(await p, '');
+    assert.strictEqual(await line(s), 'rest');
+  });
+
+  it('handles a newline arriving in its own chunk', async () => {
+    const s = new PassThrough();
+    const p = line(s);
+    s.write('AUTH EXTERNAL');
+    s.write('\n');
+    assert.strictEqual(await p, 'AUTH EXTERNAL');
+  });
+
+  it('reports a throwing callback on the stream', done => {
+    const s = new PassThrough();
+    s.on('error', err => {
+      assert.strictEqual(err.message, 'boom');
+      done();
+    });
+    readOneLine(s, () => {
+      throw new Error('boom');
+    });
+    s.write('line\n');
+  });
+
+  it('does not consume anything before a newline arrives', async () => {
+    const s = new PassThrough();
+    let called = false;
+    readOneLine(s, () => {
+      called = true;
+    });
+    s.write('no newline yet');
+    await new Promise(setImmediate);
+    assert.strictEqual(called, false);
+  });
+});


### PR DESCRIPTION
Implements **ROADMAP §2.9**, the batch of small non-canonical things from the audit.

- **`DBusBuffer` no longer mutates the callers options object.** A connection passes its own opts straight through to every message, so defaulting in place quietly gave the caller an `ayBuffer` property they never set. The resolved value lives on the instance instead — which also avoids allocating a merged options object per message, since this is on the hot read path.
- **`new DBusBuffer(buf, 0, null)` no longer throws.** `typeof null === object`, so null slipped past the guard and then failed on property access.
- **`readOneLine` reads whole chunks** and `unshift()`s the remainder, instead of `stream.read(1)` once per byte.
- **The protocol version byte is validated.** The spec requires a receiver to reject a major version it does not understand rather than guess at the layout.

`parseInt`/`parseFloat` on already-validated numbers were on the list too, but the §2.3 rewrite had already removed them.

### Two behaviour changes worth a changelog line

1. `unmarshall()` returns `[]` rather than an empty `Buffer`. Every other signature returns a list of values; this was the odd one out.
2. A message declaring a protocol version other than 1 is now rejected rather than parsed anyway.

### On the readline rewrite

This is the only change here with real risk attached — it is handshake-only, so the win is tidiness rather than throughput, but it sits on the critical auth path. It gets its own test file (split across chunks, several lines in one chunk, remainder left readable via `unshift`, empty lines, newline in its own chunk, throwing callback), and the integration suite exercises it against a real `dbus-daemon` on every run, which is the coverage I actually trust here.

**208 unit** (was 194) + 12 integration. The #307 differential test still reports 1157/1157 byte-identical.

That completes every §2 item except **2.7** (write backpressure) and **2.8** (UNIX_FD), which needs a design decision before any code.