### PR TITLE
feat: respect write backpressure and batch writes within a tick

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,20 @@ options:
 
 connection has only one method, `message(msg)`
 
+`message(msg)` returns `false` when the underlying socket's buffer is full,
+following the same convention as [`stream.write()`](https://nodejs.org/api/stream.html#writablewritechunk-encoding-callback).
+A fast producer should stop writing when it sees `false` and resume on the
+connection's `drain` event, otherwise messages queue in memory without bound:
+
+```js
+if (!connection.message(msg)) {
+  await new Promise(resolve => connection.once('drain', resolve));
+}
+```
+
+Messages written during the same tick of the event loop are batched into a
+single write to the socket.
+
 message fields:
 
 - type - methodCall, methodReturn, error or signal
@@ -108,6 +122,8 @@ connection signals:
 
 - connect - emitted after successful authentication
 - message
+- drain - the socket's write buffer has emptied; safe to resume writing after
+  `message()` returned `false`
 - error - transport or protocol failure. A protocol error (a malformed or
   oversized message) is unrecoverable, so the connection is destroyed after it
   is emitted.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -323,7 +323,9 @@ round-tripping through this library, so a writer and reader sharing the same
 mistake cannot make the tests pass. That caught a bug in the fixture itself:
 `g` (signature) values take a one-byte length and no alignment, unlike `s`.
 
-### 2.7 Backpressure on the write path
+### 2.7 Backpressure on the write path — DONE
+
+Landed in #313.
 
 **Severity: medium for high-throughput senders.**
 
@@ -334,6 +336,16 @@ tick issues N separate writes.
 
 Work: respect the `false` return, expose `'drain'` (or return a promise from
 `connection.message()`), and consider corking within a tick.
+
+**Outcome (#313).** `connection.message()` now returns the writable's boolean,
+and the connection re-emits `'drain'` — the same contract as `stream.write()`,
+so the idiom is the one Node users already know. Messages written in the same
+tick are corked into a single flush: ten messages in one turn of the event loop
+went from ten `_write` calls to one `_writev`.
+
+Deliberately _not_ returning a promise from `message()`. §3.1 will make the
+proxy layer promise-returning, and having the low-level method already resolve
+to something unrelated would collide with it.
 
 ### 2.8 UNIX_FD (`h`) support
 

--- a/index.js
+++ b/index.js
@@ -94,8 +94,36 @@ function createConnection(opts) {
     self.emit('end');
     self.message = () => {
       console.warn("Didn't write bytes to closed stream");
+      return false;
     };
   });
+
+  // Forwarded so callers that stopped writing on a `false` from message()
+  // know when it is safe to resume.
+  stream.on('drain', () => self.emit('drain'));
+
+  // Messages written in the same tick are batched into a single flush. Without
+  // this, emitting N signals in one turn of the event loop issues N separate
+  // writes to the socket.
+  const canCork =
+    typeof stream.cork === 'function' && typeof stream.uncork === 'function';
+  let corked = false;
+
+  function writeMessage(msg) {
+    const buffer = message.marshall(msg);
+    if (canCork && !corked) {
+      corked = true;
+      stream.cork();
+      process.nextTick(() => {
+        corked = false;
+        // The stream may have been destroyed between cork and uncork.
+        if (!stream.destroyed) stream.uncork();
+      });
+    }
+    // Propagate the writable's backpressure signal: false means its buffer is
+    // over the high water mark and the caller should wait for 'drain'.
+    return stream.write(buffer);
+  }
 
   self.end = () => {
     stream.end();
@@ -145,21 +173,19 @@ function createConnection(opts) {
   self._messages = [];
 
   // pre-connect version, buffers all messages. replaced after connect
+  // Reports no backpressure: nothing has reached the socket yet.
   self.message = msg => {
     self._messages.push(msg);
+    return true;
   };
 
   self.once('connect', () => {
     self.state = 'connected';
-    for (const msg of self._messages) {
-      stream.write(message.marshall(msg));
-    }
+    for (const msg of self._messages) writeMessage(msg);
     self._messages.length = 0;
 
     // no need to buffer once connected
-    self.message = msg => {
-      stream.write(message.marshall(msg));
-    };
+    self.message = writeMessage;
   });
 
   return self;

--- a/test/write-backpressure.js
+++ b/test/write-backpressure.js
@@ -1,0 +1,160 @@
+// The write path: does message() report backpressure, and are writes issued
+// in the same tick batched into one flush?
+
+const assert = require('assert');
+const { Duplex } = require('stream');
+const dbus = require('../index');
+const constants = require('../lib/constants');
+
+// A socket stand-in that records how many times the stream layer handed it
+// data, and can be told to stall so its buffer fills up.
+class FakeSocket extends Duplex {
+  constructor(options = {}) {
+    super({ highWaterMark: options.highWaterMark });
+    this.writeCalls = 0;
+    this.writevCalls = 0;
+    this.written = [];
+    this.stalled = options.stalled === true;
+    this.pending = [];
+  }
+  _write(chunk, enc, cb) {
+    this.writeCalls++;
+    this.written.push(chunk);
+    if (this.stalled) this.pending.push(cb);
+    else cb();
+  }
+  _writev(chunks, cb) {
+    this.writevCalls++;
+    for (const c of chunks) this.written.push(c.chunk);
+    if (this.stalled) this.pending.push(cb);
+    else cb();
+  }
+  _read() {}
+  // let the queued writes complete, which triggers 'drain'
+  release() {
+    this.stalled = false;
+    const cbs = this.pending.splice(0);
+    for (const cb of cbs) cb();
+  }
+  bytesWritten() {
+    return this.written.reduce((n, c) => n + c.length, 0);
+  }
+}
+
+// Complete the SASL handshake by hand so the connection reaches 'connect'.
+function connect(socket) {
+  return new Promise(resolve => {
+    const conn = dbus.createConnection({ stream: socket, direct: true });
+    // The client opens with "\0AUTH EXTERNAL <hex>\r\n"; any OK completes it.
+    setImmediate(() => socket.push('OK 0123456789abcdef\r\n'));
+    conn.once('connect', () => resolve(conn));
+  });
+}
+
+const call = serial => ({
+  serial,
+  type: constants.messageType.methodCall,
+  path: '/p',
+  destination: 'a.b',
+  interface: 'a.b',
+  member: 'M',
+  signature: 's',
+  body: ['payload']
+});
+
+describe('write backpressure', () => {
+  it('returns true while the socket keeps up', async () => {
+    const socket = new FakeSocket();
+    const conn = await connect(socket);
+    assert.strictEqual(conn.message(call(1)), true);
+  });
+
+  it('returns false once the socket buffer is over the high water mark', async () => {
+    const socket = new FakeSocket({ highWaterMark: 256, stalled: true });
+    const conn = await connect(socket);
+
+    let sawFalse = false;
+    for (let i = 1; i <= 50 && !sawFalse; i++) {
+      sawFalse = conn.message(call(i)) === false;
+    }
+    assert.ok(sawFalse, 'message() never reported backpressure');
+  });
+
+  it("emits 'drain' when the socket catches up", async () => {
+    const socket = new FakeSocket({ highWaterMark: 256, stalled: true });
+    const conn = await connect(socket);
+
+    const drained = new Promise(resolve => conn.once('drain', resolve));
+    for (let i = 1; i <= 50; i++) conn.message(call(i));
+    await new Promise(setImmediate); // let the cork flush
+    socket.release();
+    await drained; // times out the test if never emitted
+  });
+
+  it('batches messages written in the same tick into one flush', async () => {
+    const socket = new FakeSocket();
+    const conn = await connect(socket);
+    socket.writeCalls = 0;
+    socket.writevCalls = 0;
+
+    for (let i = 1; i <= 10; i++) conn.message(call(i));
+    await new Promise(setImmediate);
+
+    assert.strictEqual(
+      socket.writevCalls,
+      1,
+      `expected one batched flush, got ${socket.writevCalls} writev + ${socket.writeCalls} write`
+    );
+    assert.strictEqual(socket.writeCalls, 0);
+  });
+
+  it('writes messages in separate ticks separately', async () => {
+    const socket = new FakeSocket();
+    const conn = await connect(socket);
+    socket.writeCalls = 0;
+    socket.writevCalls = 0;
+
+    conn.message(call(1));
+    await new Promise(setImmediate);
+    conn.message(call(2));
+    await new Promise(setImmediate);
+
+    assert.strictEqual(socket.writeCalls + socket.writevCalls, 2);
+  });
+
+  it('delivers every byte despite the batching', async () => {
+    const socket = new FakeSocket();
+    const conn = await connect(socket);
+    socket.written.length = 0;
+
+    const expected = [];
+    for (let i = 1; i <= 5; i++) {
+      const msg = call(i);
+      expected.push(require('../lib/message').marshall(msg));
+      conn.message(msg);
+    }
+    await new Promise(setImmediate);
+
+    assert.ok(
+      Buffer.concat(socket.written).equals(Buffer.concat(expected)),
+      'bytes on the wire differ from the marshalled messages'
+    );
+  });
+
+  it('does not throw if the stream is destroyed before the flush', async () => {
+    const socket = new FakeSocket();
+    const conn = await connect(socket);
+    conn.message(call(1));
+    socket.destroy();
+    await new Promise(setImmediate);
+    // reaching here without an uncork-after-destroy throw is the assertion
+  });
+
+  it('reports false after the stream has ended', async () => {
+    const socket = new FakeSocket();
+    const conn = await connect(socket);
+    socket.push(null);
+    await new Promise(resolve => conn.once('end', resolve));
+    assert.strictEqual(conn.message(call(1)), false);
+  });
+});


### PR DESCRIPTION
Implements **ROADMAP §2.7**.

`connection.message()` discarded the return value of `stream.write()`, so a producer faster than the socket grew Nodes internal write buffer without bound — and had no way to find out.

### Backpressure

`message()` now returns the writables boolean and the connection re-emits `drain`. That is deliberately the same contract as `stream.write()`, so the handling idiom is the one Node users already know:

```js
if (!connection.message(msg)) {
  await new Promise(resolve => connection.once(drain, resolve));
}
```

**Not** returning a promise from `message()`, which was the other option the roadmap floated: §3.1 will make the proxy layer promise-returning, and having the low-level method already resolve to something unrelated would collide with it.

### Batching

Messages written during the same tick are corked into a single flush. Ten signals emitted in one turn of the event loop previously issued ten separate socket writes; now they issue one. Asserted directly by counting `_write` vs `_writev` on a fake socket:

```
✔ batches messages written in the same tick into one flush   (1 writev, 0 write)
✔ writes messages in separate ticks separately               (2 calls)
```

The uncork is guarded against the stream being destroyed in between, which has its own test.

### Verification

Eight new tests: the boolean under a deliberately stalled socket, `drain` firing once it catches up, batching, **byte-for-byte delivery despite the batching** (the bytes on the wire are compared against the marshalled messages), destroy-before-flush, and reporting `false` after `end`.

**202 unit** + 12 integration against a real `dbus-daemon` — the integration run is what confirms corking does not break request/response latency in practice.

That leaves only **§2.8 (UNIX_FD)** open in section 2, and that one needs a decision before any code: FD passing requires `SCM_RIGHTS`, Node exposes no public API for it, so the realistic options are a native addon — undoing the zero-native-dependency property established in #299 — or documenting it as unsupported.