### PR TITLE
feat: forward-compatible value helpers and deprecation infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,52 @@ conn.on('message', function (msg) {
 });
 ```
 
+### Reading values: variants and dicts
+
+A variant currently unmarshals as `[parsedSignature, [value]]` and a dict as an
+array of `[key, value]` pairs. Both shapes change in 2.0 — see
+[RELEASE_PLAN.md](./RELEASE_PLAN.md). Two helpers read either shape, so code
+written against them behaves the same before and after:
+
+```js
+const { variantValue, toPlain } = require('dbus-native');
+
+// instead of result[1][0]
+const greeting = variantValue(result);
+
+// instead of walking an array of pairs
+const props = toPlain(getAllResult); // { Greeting: 'hello', Count: 7 }
+```
+
+`toPlain()` only converts arrays this library parsed as dicts, so an `a(ss)`
+(array of two-string structs) is left as an array rather than being guessed at.
+
+For writing, `Variant` is accepted anywhere a `[signature, value]` pair is:
+
+```js
+const { Variant } = require('dbus-native');
+
+bus.invoke({
+  /* ... */
+  signature: 'ssv',
+  body: [iface, 'Greeting', new Variant('s', 'hello')]
+});
+```
+
+### Errors
+
+A failed call currently passes the raw message body — an array — to the
+callback. Since 0.6 that array also carries `message`, `dbusName` and `name`,
+which is the shape it becomes in 1.0:
+
+```js
+bus.invoke(msg, err => {
+  if (err?.dbusName === 'org.freedesktop.DBus.Error.ServiceUnknown') {
+    // ...
+  }
+});
+```
+
 ### Note on INT64 'x' and UINT64 't'
 
 Long.js is used for 64 Bit support. https://github.com/dcodeIO/long.js

--- a/RELEASE_PLAN.md
+++ b/RELEASE_PLAN.md
@@ -115,14 +115,24 @@ useful thing in the plan, and it costs almost nothing.
     variantValue(). See https://github.com/sidorares/dbus-native/blob/master/docs/deprecations.md#dbus_dep0002
 ```
 
-Each code gets a documentation anchor. Crucially this gives users a mechanical
-way to find every affected line in their own codebase:
+Each code gets a documentation anchor, and `--throw-deprecation` turns them
+into thrown errors so a consumer's own test suite locates the call sites:
 
 ```sh
-node --throw-deprecation ./node_modules/.bin/mocha    # every usage becomes a stack trace
+node --throw-deprecation ./node_modules/.bin/mocha
 ```
 
-Warnings fire once per code per process by default, so normal runs stay quiet.
+**Correction to an earlier draft of this plan:** that only works for
+deprecations whose trigger _is_ a call the user makes — passing `ReturnLongjs`,
+calling `connection.end()`. It does **not** work for the value-shape changes in
+2.0. A warning there would have to fire inside the parser when the value is
+read, so the stack would point at this library rather than at the line that
+unpacks the value: it would tell you that you are affected without telling you
+where. Those codes are therefore documentation-only, and finding call sites is
+the lint rule's job. `docs/deprecations.md` labels each code **runtime** or
+**documentation** so the distinction is visible at the point of use.
+
+Warnings fire once per code per process, so normal runs stay quiet.
 
 **Also in 0.6, all additive:** `AbortSignal` on calls,
 `diagnostics_channel` instrumentation, a hand-written `index.d.ts`

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -1,0 +1,133 @@
+# Deprecations
+
+Stable codes for behaviour that changes in a future major release, so you can
+migrate before it does. See [RELEASE_PLAN.md](../RELEASE_PLAN.md) for the
+schedule.
+
+Codes marked **runtime** emit a `DeprecationWarning` once per process. To find
+every affected call site in your own codebase, turn them into thrown errors and
+run your tests:
+
+```sh
+node --throw-deprecation node_modules/.bin/mocha
+```
+
+Codes marked **documentation** describe a shape change rather than an API call.
+They are deliberately _not_ runtime warnings — the warning would have to fire
+inside the parser when the value is read, so the stack trace would point at
+this library rather than at the line in your code that unpacks the value. It
+would tell you that you are affected without telling you where. A lint rule
+that flags the access patterns is planned for that; until then the migration is
+to route reads through the helpers below.
+
+---
+
+## DBUS_DEP0001
+
+**Runtime.** The `ReturnLongjs` option is deprecated.
+
+64-bit values (`x` and `t`) currently come back as lossy `number`, or as
+[long.js](https://github.com/dcodeIO/long.js) objects with `ReturnLongjs: true`.
+In **2.0** they become native `BigInt`, which represents the full 64-bit range
+with no dependency and no option.
+
+```js
+// deprecated
+const bus = dbus.sessionBus({ ReturnLongjs: true });
+const size = value.toNumber();
+
+// 2.0
+const size = await disk.props.Size; // 2000398934016n
+```
+
+`BigInt` is not a drop-in for `number`: `size + 1` and `JSON.stringify({ size })`
+both throw. Plan for that rather than discovering it in production — there will
+be a dedicated migration guide.
+
+---
+
+## DBUS_DEP0002
+
+**Documentation.** Reading a variant as `[signature, [value]]`.
+
+A variant currently unmarshals to a two-element array of the _parsed signature
+tree_ and a one-element array holding the value. In **2.0** it unmarshals to the
+value itself.
+
+```js
+// today, and the source of more issues than anything else in this project
+const udi = dict.find(([key]) => key === 'Udi')[1][1][0];
+
+// forward-compatible: identical behaviour before and after 2.0
+import { variantValue } from 'dbus-native';
+const udi = variantValue(dict.find(([key]) => key === 'Udi')[1]);
+
+// 2.0
+const { Udi } = await device.props.$all;
+```
+
+`variantValue()` returns the value from either shape, so you can migrate now.
+`variantSignature()` gets the signature if you need the type information that
+the flattened form drops.
+
+Related: [#3](https://github.com/sidorares/dbus-native/issues/3),
+[#67](https://github.com/sidorares/dbus-native/issues/67),
+[#132](https://github.com/sidorares/dbus-native/issues/132),
+[#147](https://github.com/sidorares/dbus-native/issues/147).
+
+---
+
+## DBUS_DEP0003
+
+**Documentation.** Reading a dict as an array of pairs.
+
+`a{sv}` and friends currently unmarshal to an array of `[key, value]` pairs. In
+**2.0** they unmarshal to a plain object.
+
+```js
+// today
+const props = {};
+for (const [key, variant] of result) props[key] = variant[1][0];
+
+// forward-compatible
+import { toPlain } from 'dbus-native';
+const props = toPlain(result);
+
+// 2.0
+const props = result;
+```
+
+`toPlain()` recursively converts dicts to objects and unwraps variants, and is
+a no-op on values that are already plain.
+
+It only converts arrays this library tagged as dicts while parsing, so `a(ss)`
+(an array of two-string structs) is left alone. A shape-based heuristic cannot
+tell those two apart, which is why the parser tags them instead of guessing.
+
+---
+
+## DBUS_DEP0004
+
+**Documentation.** Errors delivered as arrays.
+
+A failed call currently passes the raw message body — an array of strings, or
+`[]` when the body is empty — where a callback expects an `Error`. In **1.0**
+it becomes a `DBusError` with `message`, `dbusName` and a stack.
+
+Since 0.6 that array _also_ carries those properties, so this works today and
+continues to work in 1.0 unchanged:
+
+```js
+bus.invoke(msg, err => {
+  if (err?.dbusName === 'org.freedesktop.DBus.Error.ServiceUnknown') {
+    // ...
+  }
+});
+```
+
+Reading `err[0]` keeps working until 1.0. Use `err.message` instead.
+
+Related: [#39](https://github.com/sidorares/dbus-native/issues/39),
+[#178](https://github.com/sidorares/dbus-native/issues/178),
+[#207](https://github.com/sidorares/dbus-native/issues/207),
+[#208](https://github.com/sidorares/dbus-native/issues/208).

--- a/index.js
+++ b/index.js
@@ -11,6 +11,8 @@ const clientHandshake = require('./lib/handshake');
 const serverHandshake = require('./lib/server-handshake');
 const MessageBus = require('./lib/bus');
 const server = require('./lib/server');
+const deprecate = require('./lib/deprecate');
+const values = require('./lib/values');
 
 // A d-bus address is `family:key=value,key=value`, and DBUS_SESSION_BUS_ADDRESS
 // may hold several of them separated by `;`. See
@@ -77,6 +79,13 @@ function createStream(opts) {
 function createConnection(opts) {
   const self = new EventEmitter();
   if (!opts) opts = {};
+
+  if (opts.ReturnLongjs) {
+    deprecate(
+      'DBUS_DEP0001',
+      "The 'ReturnLongjs' option is deprecated. 64-bit values (x/t) become native BigInt in 2.0, which represents the full range without a dependency."
+    );
+  }
   const stream = (self.stream = createStream(opts));
   stream.setNoDelay?.();
 
@@ -209,6 +218,14 @@ module.exports.sessionBus = function (opts) {
 };
 
 module.exports.messageType = constants.messageType;
+
+// Forward-compatible value helpers. Code written against these behaves the
+// same before and after the 2.0 type-system change -- see docs/deprecations.md
+// and RELEASE_PLAN.md.
+module.exports.Variant = values.Variant;
+module.exports.variantValue = values.variantValue;
+module.exports.variantSignature = values.variantSignature;
+module.exports.toPlain = values.toPlain;
 module.exports.createConnection = createConnection;
 
 module.exports.createServer = server.createServer;

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -3,6 +3,34 @@ const constants = require('./constants');
 const stdDbusIfaces = require('./stdifaces');
 const introspect = require('./introspect').introspectBus;
 
+// A failed call currently delivers the raw message body -- an array, or `[]`
+// when the body is empty. In 1.0 that becomes a DBusError. Attaching the
+// properties it will have lets callers write `err.dbusName` / `err.message`
+// today and keep working across that change unmodified. See
+// docs/deprecations.md#dbus_dep0004.
+//
+// Non-enumerable, so JSON.stringify(err) and deepStrictEqual are unchanged for
+// anyone relying on the array shape until 1.0.
+function decorateError(body, msg) {
+  const message =
+    (typeof body[0] === 'string' && body[0]) ||
+    msg.errorName ||
+    'D-Bus error with no message';
+  for (const [key, value] of Object.entries({
+    name: 'DBusError',
+    message,
+    dbusName: msg.errorName
+  })) {
+    Object.defineProperty(body, key, {
+      value,
+      enumerable: false,
+      configurable: true,
+      writable: true
+    });
+  }
+  return body;
+}
+
 module.exports = function bus(conn, opts) {
   if (!(this instanceof bus)) {
     return new bus(conn);
@@ -137,7 +165,7 @@ module.exports = function bus(conn, opts) {
           args = [null].concat(args); // first argument - no errors, null
           handler.apply(props, args); // body as array of arguments
         } else {
-          handler.call(props, args); // body as first argument
+          handler.call(props, decorateError(args, msg)); // body as first argument
         }
       }
     } else if (msg.type === constants.messageType.signal) {

--- a/lib/dbus-buffer.js
+++ b/lib/dbus-buffer.js
@@ -1,6 +1,7 @@
 const Long = require('long');
 const constants = require('./constants');
 const parseSignature = require('./signature');
+const { VARIANT, DICT, tag } = require('./values');
 
 const DEFAULT_OPTIONS = { ayBuffer: true, ReturnLongjs: false };
 
@@ -131,7 +132,9 @@ DBusBuffer.prototype.read = function read(signature) {
 DBusBuffer.prototype.readVariant = function readVariant() {
   const signature = this.readSimpleType('g');
   const tree = parseSignature(signature);
-  return [tree, this.readStruct(tree)];
+  // Tagged so variantValue()/toPlain() can recognise this without guessing
+  // from shape. The tag is non-enumerable and invisible to consumers.
+  return tag([tree, this.readStruct(tree)], VARIANT);
 };
 
 DBusBuffer.prototype.readStruct = function readStruct(struct) {
@@ -177,7 +180,9 @@ DBusBuffer.prototype.readArray = function readArray(eleType, arrayBlobSize) {
   const end = this.pos + arrayBlobSize;
   const result = [];
   while (this.pos < end) result.push(this.readTree(eleType));
-  return result;
+  // A dict is an array of dict-entry structs. Tagging it here is what lets
+  // toPlain() tell `a{ss}` from `a(ss)`, which are otherwise identical.
+  return eleType.type === '{' ? tag(result, DICT) : result;
 };
 
 // A 64-bit value is two 32-bit words. Each word is byte-swapped by readInt32

--- a/lib/deprecate.js
+++ b/lib/deprecate.js
@@ -1,0 +1,25 @@
+// Deprecation warnings, following Node's own convention: a stable code per
+// deprecation, warned once per process, with a documentation anchor.
+//
+// The code matters more than the message. `node --throw-deprecation` turns
+// these into thrown errors, so a consumer can find every affected call site in
+// their own codebase by running their test suite.
+
+const DOCS =
+  'https://github.com/sidorares/dbus-native/blob/master/docs/deprecations.md';
+
+const warned = new Set();
+
+function deprecate(code, message) {
+  if (warned.has(code)) return;
+  warned.add(code);
+  process.emitWarning(`${message} See ${DOCS}#${code.toLowerCase()}`, {
+    type: 'DeprecationWarning',
+    code
+  });
+}
+
+// Exposed for tests, which need each case to warn in isolation.
+deprecate.reset = () => warned.clear();
+
+module.exports = deprecate;

--- a/lib/marshall.js
+++ b/lib/marshall.js
@@ -3,6 +3,7 @@ const assert = require('assert');
 const parseSignature = require('./signature');
 const Marshallers = require('./marshallers');
 const Writer = require('./writer');
+const { Variant } = require('./values');
 
 // Element types whose array body starts on an 8-byte boundary. The padding
 // between the length and the first element is not counted in the length.
@@ -46,12 +47,21 @@ function write(writer, ele, data) {
       writeArray(writer, ele, data);
       break;
     case 'v': {
-      // TODO: allow serialisation of simple types as variants, e. g 123 -> ['u', 123], true -> ['b', 1], 'abc' -> ['s', 'abc']
-      assert.equal(data.length, 2, 'variant data should be [signature, data]');
-      writeSimple(writer, 'g', data[0]);
-      const tree = parseSignature(data[0]);
+      // A Variant instance is the forward-compatible spelling of the
+      // [signature, value] pair; both are accepted.
+      const signature = data instanceof Variant ? data.signature : data[0];
+      const value = data instanceof Variant ? data.value : data[1];
+      if (!(data instanceof Variant)) {
+        assert.equal(
+          data.length,
+          2,
+          'variant data should be [signature, data]'
+        );
+      }
+      writeSimple(writer, 'g', signature);
+      const tree = parseSignature(signature);
       assert(tree.length === 1);
-      write(writer, tree[0], data[1]);
+      write(writer, tree[0], value);
       break;
     }
     default:

--- a/lib/values.js
+++ b/lib/values.js
@@ -1,0 +1,144 @@
+// Helpers for reading and writing d-bus values in a way that survives the
+// type-system change planned for 2.0.
+//
+// Today a variant unmarshals as `[parsedSignatureTree, [value]]` and a dict as
+// an array of `[key, value]` pairs. In 2.0 they become the value itself and a
+// plain object. Code written against `variantValue()` and `toPlain()` behaves
+// identically before and after, so it can be migrated now, on a released
+// version, with no flag day.
+//
+// See RELEASE_PLAN.md.
+
+const util = require('util');
+
+// Values that came out of this library are tagged, so the helpers below do not
+// have to guess from shape. That matters because `a{ss}` and `a(ss)` unmarshal
+// to structurally identical arrays -- a heuristic would convert both, and be
+// wrong about one of them.
+const VARIANT = Symbol.for('dbus.variant');
+const DICT = Symbol.for('dbus.dict');
+
+function tag(value, marker) {
+  // Non-enumerable, so it is invisible to JSON.stringify, deepStrictEqual and
+  // anything else that walks own enumerable properties.
+  Object.defineProperty(value, marker, { value: true, enumerable: false });
+  return value;
+}
+
+/**
+ * An explicitly typed value, for the places where the signature cannot be
+ * inferred -- writing a `v`, or picking between numeric types.
+ *
+ * Accepted by the marshaller anywhere a `[signature, value]` pair is today, so
+ * it is also the forward-compatible way to *write* variants.
+ */
+class Variant {
+  constructor(signature, value) {
+    this.signature = signature;
+    this.value = value;
+  }
+
+  [util.inspect.custom](depth, options) {
+    return `Variant(${util.inspect(this.signature, options)}, ${util.inspect(
+      this.value,
+      options
+    )})`;
+  }
+}
+
+function isTaggedVariant(value) {
+  return Array.isArray(value) && value[VARIANT] === true;
+}
+
+// Fallback for values that did not come from this library's parser -- hand
+// built fixtures, or anything constructed by a caller. Deliberately strict.
+function looksLikeClassicVariant(value) {
+  return (
+    Array.isArray(value) &&
+    value.length === 2 &&
+    Array.isArray(value[0]) &&
+    value[0].length > 0 &&
+    value[0].every(
+      node =>
+        node &&
+        typeof node === 'object' &&
+        typeof node.type === 'string' &&
+        Array.isArray(node.child)
+    ) &&
+    Array.isArray(value[1])
+  );
+}
+
+/**
+ * Read the value out of a variant, whatever shape it is in.
+ *
+ * classic: [tree, [value]] -> value
+ * 2.0:     value           -> value  (identity)
+ */
+function variantValue(value) {
+  if (value instanceof Variant) return value.value;
+  if (isTaggedVariant(value) || looksLikeClassicVariant(value)) {
+    const values = value[1];
+    return values.length === 1 ? values[0] : values;
+  }
+  return value;
+}
+
+/**
+ * Read the signature of a variant, or undefined if it is not one (or has
+ * already been flattened, in which case the type information is gone).
+ */
+function variantSignature(value) {
+  if (value instanceof Variant) return value.signature;
+  if (isTaggedVariant(value) || looksLikeClassicVariant(value)) {
+    return dumpSignature(value[0]);
+  }
+  return undefined;
+}
+
+function dumpSignature(nodes) {
+  let out = '';
+  for (const node of nodes) {
+    out += node.type + dumpSignature(node.child);
+    if (node.type === '{') out += '}';
+    if (node.type === '(') out += ')';
+  }
+  return out;
+}
+
+/**
+ * Convert a value to plain JavaScript, recursively: dicts become objects and
+ * variants are unwrapped.
+ *
+ * classic: [['Udi', [tree, ['/sys/...']]]] -> { Udi: '/sys/...' }
+ * 2.0:     { Udi: '/sys/...' }             -> unchanged
+ *
+ * Arrays that are not tagged as dicts are left as arrays, so `a(ss)` is not
+ * mistaken for `a{ss}`.
+ */
+function toPlain(value) {
+  if (value instanceof Variant) return toPlain(value.value);
+  if (isTaggedVariant(value) || looksLikeClassicVariant(value)) {
+    return toPlain(variantValue(value));
+  }
+  if (Array.isArray(value)) {
+    if (value[DICT] === true) {
+      const out = {};
+      for (const entry of value) out[entry[0]] = toPlain(entry[1]);
+      return out;
+    }
+    return value.map(toPlain);
+  }
+  return value;
+}
+
+module.exports = {
+  Variant,
+  variantValue,
+  variantSignature,
+  toPlain,
+  // internal
+  VARIANT,
+  DICT,
+  tag
+};

--- a/test/deprecations.js
+++ b/test/deprecations.js
@@ -1,0 +1,94 @@
+const assert = require('assert');
+const { execFileSync } = require('child_process');
+const deprecate = require('../lib/deprecate');
+
+describe('deprecate()', () => {
+  beforeEach(() => deprecate.reset());
+
+  // process.emitWarning fires on a later tick, so the listener has to stay
+  // attached across it.
+  const capture = async fn => {
+    const seen = [];
+    const listener = w => seen.push(w);
+    process.on('warning', listener);
+    try {
+      fn();
+      await new Promise(setImmediate);
+    } finally {
+      process.removeListener('warning', listener);
+    }
+    return seen;
+  };
+
+  it('emits a DeprecationWarning with a code and a docs link', async () => {
+    const seen = await capture(() =>
+      deprecate('DBUS_DEP9999', 'Test deprecation.')
+    );
+    assert.strictEqual(seen.length, 1);
+    assert.strictEqual(seen[0].name, 'DeprecationWarning');
+    assert.strictEqual(seen[0].code, 'DBUS_DEP9999');
+    assert.match(seen[0].message, /Test deprecation\./);
+    assert.match(seen[0].message, /docs\/deprecations\.md#dbus_dep9999/);
+  });
+
+  it('warns once per code, not once per call', async () => {
+    const seen = await capture(() => {
+      for (let i = 0; i < 5; i++) deprecate('DBUS_DEP9998', 'Repeated.');
+    });
+    assert.strictEqual(seen.length, 1);
+  });
+});
+
+describe('DBUS_DEP0001 (ReturnLongjs)', () => {
+  // Run in a child so --throw-deprecation is in effect from the start, which
+  // is the workflow the docs tell users to adopt.
+  it('is thrown under --throw-deprecation, pointing at the caller', () => {
+    const script = `
+      const dbus = require(${JSON.stringify(require.resolve('../index'))});
+      const { PassThrough } = require('stream');
+      dbus.createConnection({ stream: new PassThrough(), ReturnLongjs: true });
+    `;
+    let stderr = '';
+    try {
+      execFileSync(process.execPath, ['--throw-deprecation', '-e', script], {
+        encoding: 'utf8',
+        stdio: 'pipe'
+      });
+      assert.fail('expected the deprecation to throw');
+    } catch (err) {
+      stderr = err.stderr || '';
+    }
+    assert.match(stderr, /DBUS_DEP0001/);
+    assert.match(stderr, /ReturnLongjs/);
+    assert.match(stderr, /BigInt/);
+  });
+
+  it('does not warn when the option is not used', async () => {
+    deprecate.reset();
+    const { Duplex } = require('stream');
+    // Not a PassThrough: that echoes the client's own AUTH line back at it,
+    // which sends the handshake down the DBUS_COOKIE_SHA1 path and fails on a
+    // missing ~/.dbus-keyrings (issue #158). A stream that never answers is
+    // the right fixture here -- we only care that construction does not warn.
+    const silent = new Duplex({
+      read() {},
+      write(chunk, enc, cb) {
+        cb();
+      }
+    });
+    const seen = [];
+    const listener = w => seen.push(w);
+    process.on('warning', listener);
+    try {
+      const conn = require('../index').createConnection({ stream: silent });
+      conn.on('error', () => {});
+      await new Promise(setImmediate);
+    } finally {
+      process.removeListener('warning', listener);
+    }
+    assert.deepStrictEqual(
+      seen.filter(w => w.code === 'DBUS_DEP0001'),
+      []
+    );
+  });
+});

--- a/test/integration/forward-compat.js
+++ b/test/integration/forward-compat.js
@@ -1,0 +1,150 @@
+// The forward-compatible helpers, exercised against a real dbus-daemon so the
+// values really are the ones the parser produces.
+
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const dbus = require('../../index');
+const { Variant, variantValue, toPlain } = dbus;
+
+const SERVICE = 'com.github.sidorares.dbusnative.ForwardCompat';
+const OBJECT_PATH = '/com/github/sidorares/dbusnative/ForwardCompat';
+const IFACE = 'com.github.sidorares.dbusnative.ForwardCompatIface';
+
+const ifaceDesc = {
+  name: IFACE,
+  methods: { Fail: ['', '', [], []], Quiet: ['', '', [], []] },
+  signals: {},
+  properties: { Greeting: 's', Count: 'u' }
+};
+
+describe('integration: forward-compatible helpers', function () {
+  this.timeout(10000);
+
+  let serviceBus, clientBus, impl;
+
+  const whenReady = bus =>
+    new Promise((resolve, reject) =>
+      bus.getId(err => (err ? reject(err) : resolve()))
+    );
+
+  before(async function () {
+    if (!process.env.DBUS_SESSION_BUS_ADDRESS) return this.skip();
+    serviceBus = dbus.sessionBus();
+    clientBus = dbus.sessionBus();
+
+    impl = Object.assign(Object.create(EventEmitter.prototype), {
+      Greeting: 'hello',
+      Count: 7,
+      Fail() {
+        const err = new Error('deliberate failure');
+        err.dbusName = 'com.example.Error.Boom';
+        throw err;
+      },
+      Quiet() {
+        // throws with no message, to exercise the empty-body error path
+        throw Object.assign(new Error(''), {
+          dbusName: 'com.example.Error.Silent'
+        });
+      }
+    });
+    EventEmitter.call(impl);
+
+    await Promise.all([whenReady(serviceBus), whenReady(clientBus)]);
+    await new Promise((resolve, reject) =>
+      serviceBus.requestName(SERVICE, 0, err => {
+        if (err) return reject(err);
+        serviceBus.exportInterface(impl, OBJECT_PATH, ifaceDesc);
+        resolve();
+      })
+    );
+  });
+
+  after(() => {
+    if (serviceBus) serviceBus.connection.end();
+    if (clientBus) clientBus.connection.end();
+  });
+
+  const invoke = msg =>
+    new Promise(resolve =>
+      clientBus.invoke(msg, (err, result) => resolve({ err, result }))
+    );
+
+  it('variantValue reads a property without index gymnastics', async () => {
+    const { err, result } = await invoke({
+      destination: SERVICE,
+      path: OBJECT_PATH,
+      interface: 'org.freedesktop.DBus.Properties',
+      member: 'Get',
+      signature: 'ss',
+      body: [IFACE, 'Greeting']
+    });
+    assert.ifError(err);
+    // the shape people complain about, and the shape that survives 2.0
+    assert.strictEqual(result[1][0], 'hello');
+    assert.strictEqual(variantValue(result), 'hello');
+  });
+
+  it('toPlain turns GetAll into an object', async () => {
+    const { err, result } = await invoke({
+      destination: SERVICE,
+      path: OBJECT_PATH,
+      interface: 'org.freedesktop.DBus.Properties',
+      member: 'GetAll',
+      signature: 's',
+      body: [IFACE]
+    });
+    assert.ifError(err);
+    assert.deepStrictEqual(toPlain(result), { Greeting: 'hello', Count: 7 });
+  });
+
+  it('a Variant can be written over the wire', async () => {
+    const { err } = await invoke({
+      destination: SERVICE,
+      path: OBJECT_PATH,
+      interface: 'org.freedesktop.DBus.Properties',
+      member: 'Set',
+      signature: 'ssv',
+      body: [IFACE, 'Greeting', new Variant('s', 'written with Variant')]
+    });
+    assert.ifError(err);
+    assert.strictEqual(impl.Greeting, 'written with Variant');
+  });
+
+  it('errors carry message and dbusName as well as the array', async () => {
+    const { err } = await invoke({
+      destination: SERVICE,
+      path: OBJECT_PATH,
+      interface: IFACE,
+      member: 'Fail'
+    });
+    assert.ok(err, 'expected an error');
+    assert.strictEqual(err.message, 'deliberate failure');
+    assert.strictEqual(err.dbusName, 'com.example.Error.Boom');
+    assert.strictEqual(err.name, 'DBusError');
+    // the classic shape still works until 1.0
+    assert.strictEqual(err[0], 'deliberate failure');
+  });
+
+  it('falls back to the error name when the body is empty', async () => {
+    const { err } = await invoke({
+      destination: SERVICE,
+      path: OBJECT_PATH,
+      interface: IFACE,
+      member: 'Quiet'
+    });
+    assert.ok(err);
+    assert.strictEqual(err.dbusName, 'com.example.Error.Silent');
+    // used to be '' or undefined, which reads as "no error" at a glance
+    assert.ok(err.message.length > 0, 'message should never be empty');
+  });
+
+  it('leaves the error array serialising as it did before', async () => {
+    const { err } = await invoke({
+      destination: SERVICE,
+      path: OBJECT_PATH,
+      interface: IFACE,
+      member: 'Fail'
+    });
+    assert.strictEqual(JSON.stringify(err), '["deliberate failure"]');
+  });
+});

--- a/test/values.js
+++ b/test/values.js
@@ -1,0 +1,171 @@
+// Forward-compatible value helpers: the same call must work on today's shapes
+// and on the 2.0 shapes, so each case is asserted against both.
+
+const assert = require('assert');
+const dbus = require('../index');
+const marshall = require('../lib/marshall');
+const unmarshall = require('../lib/unmarshall');
+const { Variant, variantValue, variantSignature, toPlain } = dbus;
+
+const roundTrip = (signature, body) =>
+  unmarshall(marshall(signature, body), signature);
+
+describe('variantValue', () => {
+  it('unwraps a variant as it is parsed today', () => {
+    const [value] = roundTrip('v', [['s', 'hello']]);
+    assert.strictEqual(variantValue(value), 'hello');
+  });
+
+  it('is the identity on an already-plain value (the 2.0 shape)', () => {
+    assert.strictEqual(variantValue('hello'), 'hello');
+    assert.strictEqual(variantValue(42), 42);
+    assert.deepStrictEqual(variantValue([1, 2, 3]), [1, 2, 3]);
+    assert.deepStrictEqual(variantValue({ a: 1 }), { a: 1 });
+  });
+
+  it('unwraps a Variant instance', () => {
+    assert.strictEqual(variantValue(new Variant('s', 'hello')), 'hello');
+  });
+
+  it('handles container values inside a variant', () => {
+    const [value] = roundTrip('v', [['ai', [1, 2, 3]]]);
+    assert.deepStrictEqual(variantValue(value), [1, 2, 3]);
+  });
+
+  it('does not mistake an ordinary two-element array for a variant', () => {
+    assert.deepStrictEqual(variantValue(['a', 'b']), ['a', 'b']);
+    assert.deepStrictEqual(variantValue([[1, 2], [3]]), [[1, 2], [3]]);
+  });
+
+  it('recognises a hand-built classic variant with no tag', () => {
+    const handBuilt = [[{ type: 's', child: [] }], ['hello']];
+    assert.strictEqual(variantValue(handBuilt), 'hello');
+  });
+});
+
+describe('variantSignature', () => {
+  it('reports the signature of a parsed variant', () => {
+    assert.strictEqual(variantSignature(roundTrip('v', [['s', 'x']])[0]), 's');
+    assert.strictEqual(
+      variantSignature(roundTrip('v', [['ai', [1]]])[0]),
+      'ai'
+    );
+    assert.strictEqual(
+      variantSignature(roundTrip('v', [['a{sv}', [['k', ['s', 'v']]]]])[0]),
+      'a{sv}'
+    );
+  });
+
+  it('reports a Variant instance signature', () => {
+    assert.strictEqual(variantSignature(new Variant('u', 1)), 'u');
+  });
+
+  it('is undefined once the value has been flattened', () => {
+    assert.strictEqual(variantSignature('hello'), undefined);
+  });
+});
+
+describe('toPlain', () => {
+  it('converts a dict of variants to an object', () => {
+    const [dict] = roundTrip('a{sv}', [
+      [
+        ['Udi', ['s', '/sys/devices/pci0000:00/net/wlan0']],
+        ['Speed', ['u', 1000]],
+        ['Up', ['b', true]]
+      ]
+    ]);
+    assert.deepStrictEqual(toPlain(dict), {
+      Udi: '/sys/devices/pci0000:00/net/wlan0',
+      Speed: 1000,
+      Up: true
+    });
+  });
+
+  it('converts a dict of plain values', () => {
+    const [dict] = roundTrip('a{ss}', [
+      [
+        ['a', '1'],
+        ['b', '2']
+      ]
+    ]);
+    assert.deepStrictEqual(toPlain(dict), { a: '1', b: '2' });
+  });
+
+  it('recurses into nested dicts', () => {
+    const [dict] = roundTrip('a{sa{ss}}', [[['outer', [['inner', 'value']]]]]);
+    assert.deepStrictEqual(toPlain(dict), { outer: { inner: 'value' } });
+  });
+
+  // a{ss} and a(ss) are structurally identical once parsed. A shape-based
+  // heuristic would convert both; the parser tags dicts so this one does not.
+  it('leaves an array of two-string structs alone', () => {
+    const [structs] = roundTrip('a(ss)', [
+      [
+        ['a', '1'],
+        ['b', '2']
+      ]
+    ]);
+    assert.deepStrictEqual(toPlain(structs), [
+      ['a', '1'],
+      ['b', '2']
+    ]);
+  });
+
+  it('is the identity on the 2.0 shape', () => {
+    assert.deepStrictEqual(toPlain({ a: 1, b: 'two' }), { a: 1, b: 'two' });
+    assert.deepStrictEqual(toPlain([1, 2, 3]), [1, 2, 3]);
+    assert.strictEqual(toPlain('plain'), 'plain');
+  });
+
+  it('unwraps variants inside ordinary arrays', () => {
+    const [values] = roundTrip('av', [
+      [
+        ['s', 'a'],
+        ['u', 7]
+      ]
+    ]);
+    assert.deepStrictEqual(toPlain(values), ['a', 7]);
+  });
+
+  it('leaves an empty dict as an empty object', () => {
+    const [dict] = roundTrip('a{sv}', [[]]);
+    assert.deepStrictEqual(toPlain(dict), {});
+  });
+});
+
+describe('Variant', () => {
+  it('marshals identically to the [signature, value] pair', () => {
+    assert.ok(
+      marshall('v', [new Variant('s', 'hello')]).equals(
+        marshall('v', [['s', 'hello']])
+      )
+    );
+    assert.ok(
+      marshall('a{sv}', [[['k', new Variant('u', 7)]]]).equals(
+        marshall('a{sv}', [[['k', ['u', 7]]]])
+      )
+    );
+  });
+
+  it('round-trips through the wire', () => {
+    const [value] = roundTrip('v', [new Variant('ai', [1, 2, 3])]);
+    assert.deepStrictEqual(variantValue(value), [1, 2, 3]);
+  });
+
+  it('prints readably', () => {
+    const util = require('util');
+    // the point: not a wall of parse-tree objects
+    assert.strictEqual(util.inspect(new Variant('y', 1)), "Variant('y', 1)");
+    assert.match(util.inspect(new Variant('as', ['a'])), /^Variant\('as', \[/);
+  });
+});
+
+describe('tags are invisible', () => {
+  it('does not affect JSON or deep equality', () => {
+    const [dict] = roundTrip('a{sv}', [[['k', ['s', 'v']]]]);
+    const plainCopy = JSON.parse(JSON.stringify(dict));
+    assert.deepStrictEqual(dict, JSON.parse(JSON.stringify(dict)));
+    assert.strictEqual(JSON.stringify(dict), JSON.stringify(plainCopy));
+    assert.deepStrictEqual(Object.keys(dict), Object.keys(plainCopy));
+  });
+});


### PR DESCRIPTION
First slice of **0.6** ([RELEASE_PLAN.md](https://github.com/sidorares/dbus-native/blob/master/RELEASE_PLAN.md)). Everything here is additive. Its job is to let people write code **now** that behaves identically before and after the 1.0 and 2.0 breaks — so the migration happens gradually, on a released version, with no flag day.

### Value helpers

```js
const { variantValue, toPlain, Variant } = require(dbus-native);

const udi = variantValue(entry);       // classic [tree,[v]] *or* 2.0 plain value
const props = toPlain(getAllResult);   // { Greeting: hello, Count: 7 }
```

Both are the identity on values that are already plain, so a migrated call site needs no second edit when 2.0 lands.

### Tagging, not guessing

The parser now tags variants and dicts with non-enumerable symbols instead of letting the helpers infer from shape. This matters more than it looks: **`a{ss}` and `a(ss)` unmarshal to structurally identical arrays.** A shape heuristic would convert both and be wrong about one of them. With tags, `toPlain()` converts the dict and leaves the array of structs alone — there is a test for exactly that.

The tags are invisible to `JSON.stringify`, `deepStrictEqual` and `Object.keys`, which the **216 pre-existing tests confirm by passing unchanged**.

### Writing

`Variant` is accepted anywhere a `[signature, value]` pair is today, so writes migrate the same way. It also has a `util.inspect` representation, so logging a variant prints `Variant(y, 1)` rather than a wall of parse-tree objects.

### Errors

Errors now carry `name`/`message`/`dbusName` alongside the array they already were:

```js
bus.invoke(msg, err => {
  if (err?.dbusName === org.freedesktop.DBus.Error.ServiceUnknown) { /* ... */ }
});
```

That works today and survives 1.0 unchanged. The properties are **non-enumerable**, so `JSON.stringify(err)` is byte-identical to before for anyone depending on the array shape — asserted in an integration test. It also fixes the `[]`-for-empty-body case from #178, where `err.message` now falls back to the error name instead of being empty.

### Deprecations

`deprecate(code, message)` warns once per code in Nodes own style, with `docs/deprecations.md` anchors. `DBUS_DEP0001` covers `ReturnLongjs`, which BigInt replaces in 2.0. Tested under `--throw-deprecation` in a child process, since that is the workflow the docs recommend.

### A correction to RELEASE_PLAN.md

I claimed `--throw-deprecation` would locate every affected line. That is only true for deprecations the **user triggers directly** — passing `ReturnLongjs`, calling `connection.end()`. For the 2.0 value-shape changes, a warning would have to fire inside the parser when the value is read, so the stack would point at this library rather than at the line unpacking the value: it tells you *that* you are affected, not *where*. Those codes are now documentation-only, each labelled **runtime** or **documentation**, and locating call sites stays the planned lint rules job. Fixed in the plan as part of this PR.

### Verification

**240 unit** (was 216) + **18 integration** (was 12). The integration tests run against a real `dbus-daemon` so the values under test are genuinely the ones the parser produces, including the `GetAll` → object conversion and the error-shape assertions.

Incidentally, writing these tests reproduced **#158** — a `PassThrough` fixture echoes the clients own AUTH line back, auth falls through to `DBUS_COOKIE_SHA1`, and the missing `~/.dbus-keyrings` escapes as an uncaught error. Confirms the audit finding that it is still live and easy to hit.