### PR TITLE
feat: return promises when no callback is given

### DIFF
--- a/BIG_FUTURE_PLANS.md
+++ b/BIG_FUTURE_PLANS.md
@@ -338,10 +338,15 @@ Named subclasses for the errors people actually branch on —
 `ServiceUnknownError`, `NoReplyError`, `AccessDeniedError`, `TimeoutError` —
 so `err instanceof NoReplyError` works without string comparison.
 
-**Async stack traces are the real prize.** Today a failed call gives you a
+**Locatable stack traces are the real prize.** Today a failed call gives you a
 stack rooted in the socket read handler, with no trace of your own code.
-Promise rejections carry the caller's frames, so the stack points at the line
-that made the call.
+
+Worth correcting an assumption in an earlier draft: promises do **not** fix
+this for free. V8 stitches async frames only along an unbroken await chain, and
+a reply arriving on a socket is a fresh I/O callback with no link back to the
+caller. The frames have to be captured deliberately at call time and attached
+to the rejection — which is what `lib/promisify.js` now does, measured at
+1.95 µs against an 85.8 µs round trip, so about 2% of a call.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,55 @@ conn.on('message', function (msg) {
 });
 ```
 
+### Promises
+
+Every callback-taking method returns a promise when you omit the callback. The
+callback form is unchanged.
+
+```js
+const bus = dbus.sessionBus();
+
+const iface = await bus
+  .getService('org.freedesktop.Notifications')
+  .getInterface(
+    '/org/freedesktop/Notifications',
+    'org.freedesktop.Notifications'
+  );
+
+const id = await iface.Notify('app', 0, '', 'summary', 'body', [], [], 5000);
+const names = await bus.listNames();
+```
+
+Resolution follows the number of values in the reply: none resolves to
+`undefined`, one resolves to the value, and several resolve to an array.
+
+Rejections are always a `DBusError` with `message`, `dbusName`, `body` and
+`reply`, plus the frames of the call site appended to the stack — a reply
+arrives on the socket, so without that a failed call would only ever point at
+this library's internals.
+
+```js
+try {
+  await iface.Notify(/* ... */);
+} catch (err) {
+  if (err.dbusName === 'org.freedesktop.DBus.Error.ServiceUnknown') {
+    // ...
+  }
+}
+```
+
+Two things worth knowing:
+
+- Omitting the callback has always meant fire-and-forget, and a lot of code
+  does `bus.invoke({ member: 'AddMatch', ... })` without one. So the returned
+  value is a **thenable that only creates its promise when you `await` or
+  `.then()` it** — ignore it and a failure is dropped exactly as it was before,
+  rather than becoming an unhandled rejection that terminates the process. It
+  is not an `instanceof Promise`, though it works with `await`, `Promise.all`
+  and `.catch`/`.finally`.
+- Capturing the call site costs about 1.95 µs against an 85.8 µs round trip
+  (~2%), and only on the promise path.
+
 ### Reading values: variants and dicts
 
 A variant currently unmarshals as `[parsedSignature, [value]]` and a dict as an

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -20,7 +20,8 @@ function decorateError(body, msg) {
   for (const [key, value] of Object.entries({
     name: 'DBusError',
     message,
-    dbusName: msg.errorName
+    dbusName: msg.errorName,
+    reply: msg
   })) {
     Object.defineProperty(body, key, {
       value,

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -2,6 +2,7 @@ const EventEmitter = require('events').EventEmitter;
 const constants = require('./constants');
 const stdDbusIfaces = require('./stdifaces');
 const introspect = require('./introspect').introspectBus;
+const { maybePromise } = require('./promisify');
 
 // A failed call currently delivers the raw message body -- an array, or `[]`
 // when the body is empty. In 1.0 that becomes a DBusError. Attaching the
@@ -45,18 +46,22 @@ module.exports = function bus(conn, opts) {
   this.signals = new EventEmitter();
   this.exportedObjects = {};
 
+  // Returns a promise when no callback is given; the callback path is
+  // unchanged. See lib/promisify.js.
   this.invoke = function (msg, callback) {
-    if (!msg.type) msg.type = constants.messageType.methodCall;
-    msg.serial = self.serial++;
-    this.cookies[msg.serial] = callback;
-    self.connection.message(msg);
+    return maybePromise(callback, cb => {
+      if (!msg.type) msg.type = constants.messageType.methodCall;
+      msg.serial = self.serial++;
+      self.cookies[msg.serial] = cb;
+      self.connection.message(msg);
+    });
   };
 
   this.invokeDbus = function (msg, callback) {
     if (!msg.path) msg.path = '/org/freedesktop/DBus';
     if (!msg.destination) msg.destination = 'org.freedesktop.DBus';
     if (!msg['interface']) msg['interface'] = 'org.freedesktop.DBus';
-    self.invoke(msg, callback);
+    return self.invoke(msg, callback);
   };
 
   this.mangle = function (path, iface, member) {
@@ -288,21 +293,25 @@ module.exports = function bus(conn, opts) {
     this.name = name;
     this.bus = bus;
     this.getObject = function (name, callback) {
-      if (name === undefined)
-        return callback(new Error('Object name is null or undefined'));
-      const obj = new DBusObject(name, this);
-      introspect(obj, (err, ifaces, nodes) => {
-        if (err) return callback(err);
-        obj.proxy = ifaces;
-        obj.nodes = nodes;
-        callback(null, obj);
+      return maybePromise(callback, cb => {
+        if (name === undefined)
+          return cb(new Error('Object name is null or undefined'));
+        const obj = new DBusObject(name, this);
+        introspect(obj, (err, ifaces, nodes) => {
+          if (err) return cb(err);
+          obj.proxy = ifaces;
+          obj.nodes = nodes;
+          cb(null, obj);
+        });
       });
     };
 
     this.getInterface = function (objName, ifaceName, callback) {
-      this.getObject(objName, (err, obj) => {
-        if (err) return callback(err);
-        callback(null, obj.as(ifaceName));
+      return maybePromise(callback, cb => {
+        this.getObject(objName, (err, obj) => {
+          if (err) return cb(err);
+          cb(null, obj.as(ifaceName));
+        });
       });
     };
   }
@@ -317,9 +326,11 @@ module.exports = function bus(conn, opts) {
   };
 
   this.getInterface = function (path, objname, name, callback) {
-    return this.getObject(path, objname, (err, obj) => {
-      if (err) return callback(err);
-      callback(null, obj.as(name));
+    return maybePromise(callback, cb => {
+      this.getObject(path, objname, (err, obj) => {
+        if (err) return cb(err);
+        cb(null, obj.as(name));
+      });
     });
   };
 
@@ -327,49 +338,47 @@ module.exports = function bus(conn, opts) {
 
   // bus meta functions
   this.addMatch = function (match, callback) {
-    this.invokeDbus(
+    return this.invokeDbus(
       { member: 'AddMatch', signature: 's', body: [match] },
       callback
     );
   };
 
   this.removeMatch = function (match, callback) {
-    this.invokeDbus(
+    return this.invokeDbus(
       { member: 'RemoveMatch', signature: 's', body: [match] },
       callback
     );
   };
 
   this.getId = function (callback) {
-    this.invokeDbus({ member: 'GetId' }, callback);
+    return this.invokeDbus({ member: 'GetId' }, callback);
   };
 
   this.requestName = function (name, flags, callback) {
-    this.invokeDbus(
+    return this.invokeDbus(
       { member: 'RequestName', signature: 'su', body: [name, flags] },
-      (err, name) => {
-        if (callback) callback(err, name);
-      }
+      callback
     );
   };
 
   this.releaseName = function (name, callback) {
-    this.invokeDbus(
+    return this.invokeDbus(
       { member: 'ReleaseName', signature: 's', body: [name] },
       callback
     );
   };
 
   this.listNames = function (callback) {
-    this.invokeDbus({ member: 'ListNames' }, callback);
+    return this.invokeDbus({ member: 'ListNames' }, callback);
   };
 
   this.listActivatableNames = function (callback) {
-    this.invokeDbus({ member: 'ListActivatableNames' }, callback);
+    return this.invokeDbus({ member: 'ListActivatableNames' }, callback);
   };
 
   this.updateActivationEnvironment = function (env, callback) {
-    this.invokeDbus(
+    return this.invokeDbus(
       {
         member: 'UpdateActivationEnvironment',
         signature: 'a{ss}',
@@ -380,35 +389,35 @@ module.exports = function bus(conn, opts) {
   };
 
   this.startServiceByName = function (name, flags, callback) {
-    this.invokeDbus(
+    return this.invokeDbus(
       { member: 'StartServiceByName', signature: 'su', body: [name, flags] },
       callback
     );
   };
 
   this.getConnectionUnixUser = function (name, callback) {
-    this.invokeDbus(
+    return this.invokeDbus(
       { member: 'GetConnectionUnixUser', signature: 's', body: [name] },
       callback
     );
   };
 
   this.getConnectionUnixProcessId = function (name, callback) {
-    this.invokeDbus(
+    return this.invokeDbus(
       { member: 'GetConnectionUnixProcessID', signature: 's', body: [name] },
       callback
     );
   };
 
   this.getNameOwner = function (name, callback) {
-    this.invokeDbus(
+    return this.invokeDbus(
       { member: 'GetNameOwner', signature: 's', body: [name] },
       callback
     );
   };
 
   this.nameHasOwner = function (name, callback) {
-    this.invokeDbus(
+    return this.invokeDbus(
       { member: 'NameHasOwner', signature: 's', body: [name] },
       callback
     );

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,41 @@
+/**
+ * A D-Bus method call that returned an error reply.
+ *
+ * The callback API still receives the raw message body (an array) until 1.0,
+ * for compatibility -- see docs/deprecations.md#dbus_dep0004. The promise API
+ * is new in 0.6, so nothing depends on the old shape there and it rejects with
+ * a real Error from the start.
+ */
+class DBusError extends Error {
+  constructor(message, dbusName, body, reply) {
+    super(message);
+    this.name = 'DBusError';
+    /** The D-Bus error name, e.g. 'org.freedesktop.DBus.Error.ServiceUnknown' */
+    this.dbusName = dbusName;
+    /** The raw message body, for the rare caller that wants the arguments */
+    this.body = body;
+    /** The full reply message */
+    this.reply = reply;
+  }
+}
+
+/**
+ * Build a DBusError from whatever the callback layer produced.
+ *
+ * In 0.6 that is the message body array carrying non-enumerable `message`,
+ * `dbusName` and `reply` properties; in 1.0 it will already be a DBusError and
+ * this becomes a pass-through.
+ */
+function toDBusError(err) {
+  if (err instanceof DBusError) return err;
+  if (err instanceof Error) return err;
+  const body = Array.isArray(err) ? Array.from(err) : err;
+  const message =
+    (err && err.message) ||
+    (Array.isArray(err) && typeof err[0] === 'string' && err[0]) ||
+    (err && err.dbusName) ||
+    'D-Bus error with no message';
+  return new DBusError(message, err && err.dbusName, body, err && err.reply);
+}
+
+module.exports = { DBusError, toDBusError };

--- a/lib/introspect.js
+++ b/lib/introspect.js
@@ -1,4 +1,5 @@
 const xml2js = require('xml2js');
+const { maybePromise } = require('./promisify');
 
 module.exports.introspectBus = function (obj, callback) {
   const bus = obj.service.bus;
@@ -133,14 +134,16 @@ DBusInterface.prototype.removeListener = DBusInterface.prototype.off =
 DBusInterface.prototype.$createMethod = function (mName, signature) {
   this.$methods[mName] = signature;
   this[mName] = function () {
-    this.$callMethod(mName, arguments);
+    return this.$callMethod(mName, arguments);
   };
 };
 DBusInterface.prototype.$callMethod = function (mName, args) {
   const bus = this.$parent.service.bus;
   if (!Array.isArray(args)) args = Array.from(args); // Array.prototype.slice.apply(args)
+  // A trailing function is the callback; without one the call returns a
+  // promise. This is #295, extended to the rest of the surface.
   const callback =
-    typeof args[args.length - 1] === 'function' ? args.pop() : function () {};
+    typeof args[args.length - 1] === 'function' ? args.pop() : undefined;
   const msg = {
     destination: this.$parent.service.name,
     path: this.$parent.name,
@@ -151,7 +154,7 @@ DBusInterface.prototype.$callMethod = function (mName, args) {
     msg.signature = this.$methods[mName];
     msg.body = args;
   }
-  bus.invoke(msg, callback);
+  return bus.invoke(msg, callback);
 };
 DBusInterface.prototype.$createProp = function (
   propName,
@@ -161,47 +164,49 @@ DBusInterface.prototype.$createProp = function (
   this.$properties[propName] = { type: propType, access: propAccess };
   Object.defineProperty(this, propName, {
     enumerable: true,
+    // iface.Prop(cb) keeps working; iface.Prop() now returns a promise.
     get: () => callback => this.$readProp(propName, callback),
     set: function (val) {
-      this.$writeProp(propName, val);
+      // Assignment cannot be awaited, so a failure has nowhere to go. Pass a
+      // callback to keep this fire-and-forget exactly as it was; call
+      // $writeProp(name, value) directly if you want to await the result.
+      this.$writeProp(propName, val, () => {});
     }
   });
 };
 DBusInterface.prototype.$readProp = function (propName, callback) {
   const bus = this.$parent.service.bus;
-  bus.invoke(
+  return maybePromise(callback, cb =>
+    bus.invoke(
+      {
+        destination: this.$parent.service.name,
+        path: this.$parent.name,
+        interface: 'org.freedesktop.DBus.Properties',
+        member: 'Get',
+        signature: 'ss',
+        body: [this.$name, propName]
+      },
+      (err, val) => {
+        if (err) return cb(err);
+        const signature = val[0];
+        cb(err, signature.length === 1 ? val[1][0] : val[1]);
+      }
+    )
+  );
+};
+DBusInterface.prototype.$writeProp = function (propName, val, callback) {
+  const bus = this.$parent.service.bus;
+  return bus.invoke(
     {
       destination: this.$parent.service.name,
       path: this.$parent.name,
       interface: 'org.freedesktop.DBus.Properties',
-      member: 'Get',
-      signature: 'ss',
-      body: [this.$name, propName]
+      member: 'Set',
+      signature: 'ssv',
+      body: [this.$name, propName, [this.$properties[propName].type, val]]
     },
-    (err, val) => {
-      if (err) {
-        callback(err);
-      } else {
-        const signature = val[0];
-        if (signature.length === 1) {
-          callback(err, val[1][0]);
-        } else {
-          callback(err, val[1]);
-        }
-      }
-    }
+    callback
   );
-};
-DBusInterface.prototype.$writeProp = function (propName, val) {
-  const bus = this.$parent.service.bus;
-  bus.invoke({
-    destination: this.$parent.service.name,
-    path: this.$parent.name,
-    interface: 'org.freedesktop.DBus.Properties',
-    member: 'Set',
-    signature: 'ssv',
-    body: [this.$name, propName, [this.$properties[propName].type, val]]
-  });
 };
 
 function getMatchRule(objName, ifName, signame) {

--- a/lib/promisify.js
+++ b/lib/promisify.js
@@ -33,8 +33,28 @@ const { toDBusError } = require('./errors');
  * The operation itself always runs immediately -- laziness applies only to
  * observing the outcome.
  */
+/**
+ * Append the frames captured where the call was made.
+ *
+ * A reply arrives on the socket, so the error is constructed inside the read
+ * handler and its own stack points at this library. Without this, a rejected
+ * call tells you nothing about which of your call sites produced it.
+ */
+function withCallSite(err, callSite) {
+  if (!callSite.stack) return err;
+  const frames = callSite.stack.split('\n').slice(1).join('\n');
+  if (frames)
+    err.stack = `${err.stack}\n    --- d-bus call made at ---\n${frames}`;
+  return err;
+}
+
 function maybePromise(callback, run) {
   if (typeof callback === 'function') return run(callback);
+
+  // Captured synchronously, before the call goes async. Only the promise path
+  // pays for this; the callback path returned above.
+  const callSite = {};
+  Error.captureStackTrace(callSite, maybePromise);
 
   let outcome = null; // { err } | { value } once the call has completed
   let settle = null; // set once someone is actually waiting
@@ -44,10 +64,10 @@ function maybePromise(callback, run) {
     return values.length === 1 ? values[0] : values;
   };
 
-  run(function (err, ...values) {
+  run((err, ...values) => {
     if (settle)
       return err
-        ? settle.reject(toDBusError(err))
+        ? settle.reject(withCallSite(toDBusError(err), callSite))
         : settle.resolve(value(values));
     outcome = err ? { err } : { value: value(values) };
   });
@@ -58,7 +78,7 @@ function maybePromise(callback, run) {
     promise = new Promise((resolve, reject) => {
       if (outcome) {
         return outcome.err
-          ? reject(toDBusError(outcome.err))
+          ? reject(withCallSite(toDBusError(outcome.err), callSite))
           : resolve(outcome.value);
       }
       settle = { resolve, reject };

--- a/lib/promisify.js
+++ b/lib/promisify.js
@@ -1,0 +1,80 @@
+const { toDBusError } = require('./errors');
+
+/**
+ * Run a callback-style operation, returning a thenable when the caller did not
+ * supply a callback.
+ *
+ * The callback path is untouched: same arguments, same timing. Only the
+ * no-callback case is new, so adding this to an existing method is additive.
+ *
+ * Resolution follows the number of values in the reply body, because most
+ * D-Bus methods return zero or one:
+ *
+ *   0 values  -> undefined
+ *   1 value   -> the value
+ *   2 or more -> an array of values
+ *
+ * Rejection is always a `DBusError`, even though the callback path still
+ * receives the raw body array until 1.0.
+ *
+ * ## Why a thenable rather than a Promise
+ *
+ * Calling without a callback has always meant fire-and-forget -- this repo's
+ * own examples do `bus.invoke({ member: 'AddMatch', ... })` and ignore the
+ * result. A failure there used to be silently dropped. If we returned a real
+ * Promise, that same code would now produce an unhandled rejection and, on
+ * Node 15+, terminate the process: a breaking change smuggled into a minor.
+ *
+ * So the underlying Promise is constructed lazily, on first `then`/`catch`/
+ * `finally`. Await it and you get full promise semantics; ignore it and
+ * nothing is ever constructed, so there is nothing to go unhandled and the
+ * behaviour is exactly what it was before.
+ *
+ * The operation itself always runs immediately -- laziness applies only to
+ * observing the outcome.
+ */
+function maybePromise(callback, run) {
+  if (typeof callback === 'function') return run(callback);
+
+  let outcome = null; // { err } | { value } once the call has completed
+  let settle = null; // set once someone is actually waiting
+
+  const value = values => {
+    if (values.length === 0) return undefined;
+    return values.length === 1 ? values[0] : values;
+  };
+
+  run(function (err, ...values) {
+    if (settle)
+      return err
+        ? settle.reject(toDBusError(err))
+        : settle.resolve(value(values));
+    outcome = err ? { err } : { value: value(values) };
+  });
+
+  let promise = null;
+  const materialise = () => {
+    if (promise) return promise;
+    promise = new Promise((resolve, reject) => {
+      if (outcome) {
+        return outcome.err
+          ? reject(toDBusError(outcome.err))
+          : resolve(outcome.value);
+      }
+      settle = { resolve, reject };
+    });
+    return promise;
+  };
+
+  return {
+    then: (onFulfilled, onRejected) =>
+      materialise().then(onFulfilled, onRejected),
+    catch: onRejected => materialise().catch(onRejected),
+    finally: onFinally => materialise().finally(onFinally),
+    get [Symbol.toStringTag]() {
+      return 'Promise';
+    }
+  };
+}
+
+module.exports = { maybePromise };

--- a/test/integration/promises.js
+++ b/test/integration/promises.js
@@ -1,0 +1,198 @@
+// The promise API, end to end against a real dbus-daemon. Each case also
+// asserts the callback form still behaves, since 0.6 must not break it.
+
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const dbus = require('../../index');
+const { DBusError } = require('../../lib/errors');
+
+const SERVICE = 'com.github.sidorares.dbusnative.Promises';
+const OBJECT_PATH = '/com/github/sidorares/dbusnative/Promises';
+const IFACE = 'com.github.sidorares.dbusnative.PromisesIface';
+
+const ifaceDesc = {
+  name: IFACE,
+  methods: {
+    Echo: ['s', 's', ['input'], ['output']],
+    Add: ['ii', 'i', ['a', 'b'], ['sum']],
+    Nothing: ['', '', [], []],
+    Fail: ['', '', [], []]
+  },
+  signals: {},
+  properties: { Greeting: 's' }
+};
+
+describe('integration: promises', function () {
+  this.timeout(10000);
+
+  let serviceBus, clientBus, impl;
+
+  before(async function () {
+    if (!process.env.DBUS_SESSION_BUS_ADDRESS) return this.skip();
+    serviceBus = dbus.sessionBus();
+    clientBus = dbus.sessionBus();
+
+    impl = Object.assign(Object.create(EventEmitter.prototype), {
+      Greeting: 'hello',
+      Echo: input => input,
+      Add: (a, b) => a + b,
+      Nothing: () => null,
+      Fail: () => {
+        const err = new Error('deliberate failure');
+        err.dbusName = 'com.example.Error.Boom';
+        throw err;
+      }
+    });
+    EventEmitter.call(impl);
+
+    // getId() with no callback is itself a promise now
+    await Promise.all([serviceBus.getId(), clientBus.getId()]);
+    await serviceBus.requestName(SERVICE, 0);
+    serviceBus.exportInterface(impl, OBJECT_PATH, ifaceDesc);
+  });
+
+  after(() => {
+    if (serviceBus) serviceBus.connection.end();
+    if (clientBus) clientBus.connection.end();
+  });
+
+  const call = (member, over = {}) => ({
+    destination: SERVICE,
+    path: OBJECT_PATH,
+    interface: IFACE,
+    member,
+    ...over
+  });
+
+  describe('bus.invoke', () => {
+    it('resolves with the reply value', async () => {
+      const result = await clientBus.invoke(
+        call('Echo', { signature: 's', body: ['round trip'] })
+      );
+      assert.strictEqual(result, 'round trip');
+    });
+
+    it('resolves with undefined when there is no reply body', async () => {
+      assert.strictEqual(await clientBus.invoke(call('Nothing')), undefined);
+    });
+
+    it('rejects with a DBusError carrying dbusName and a stack', async () => {
+      await assert.rejects(
+        () => clientBus.invoke(call('Fail')),
+        err => {
+          assert.ok(err instanceof DBusError);
+          assert.strictEqual(err.message, 'deliberate failure');
+          assert.strictEqual(err.dbusName, 'com.example.Error.Boom');
+          assert.ok(err.stack.includes('promises.js'), 'stack reaches caller');
+          return true;
+        }
+      );
+    });
+
+    it('still supports the callback form unchanged', done => {
+      clientBus.invoke(
+        call('Echo', { signature: 's', body: ['callback'] }),
+        (err, result) => {
+          assert.ifError(err);
+          assert.strictEqual(result, 'callback');
+          done();
+        }
+      );
+    });
+
+    it('still delivers the raw array to callbacks on error', done => {
+      clientBus.invoke(call('Fail'), err => {
+        assert.ok(Array.isArray(err), 'callback error is still the body array');
+        assert.strictEqual(err[0], 'deliberate failure');
+        assert.strictEqual(err.dbusName, 'com.example.Error.Boom');
+        done();
+      });
+    });
+  });
+
+  describe('bus meta methods', () => {
+    it('getId resolves', async () => {
+      assert.match(await clientBus.getId(), /^[0-9a-f]{32}$/);
+    });
+
+    it('listNames resolves with the well-known name', async () => {
+      assert.ok((await clientBus.listNames()).includes(SERVICE));
+    });
+
+    it('nameHasOwner resolves', async () => {
+      assert.strictEqual(await clientBus.nameHasOwner(SERVICE), true);
+    });
+
+    it('addMatch and removeMatch resolve', async () => {
+      const rule = `type='signal',interface='${IFACE}'`;
+      await clientBus.addMatch(rule);
+      await clientBus.removeMatch(rule);
+    });
+  });
+
+  describe('proxy objects', () => {
+    it('getInterface resolves', async () => {
+      const iface = await clientBus
+        .getService(SERVICE)
+        .getInterface(OBJECT_PATH, IFACE);
+      assert.ok(iface);
+    });
+
+    it('method calls resolve', async () => {
+      const iface = await clientBus
+        .getService(SERVICE)
+        .getInterface(OBJECT_PATH, IFACE);
+      assert.strictEqual(await iface.Echo('via proxy'), 'via proxy');
+      assert.strictEqual(await iface.Add(40, 2), 42);
+    });
+
+    it('method calls reject with a DBusError', async () => {
+      const iface = await clientBus
+        .getService(SERVICE)
+        .getInterface(OBJECT_PATH, IFACE);
+      await assert.rejects(() => iface.Fail(), { name: 'DBusError' });
+    });
+
+    it('property reads resolve', async () => {
+      const iface = await clientBus
+        .getService(SERVICE)
+        .getInterface(OBJECT_PATH, IFACE);
+      assert.strictEqual(await iface.Greeting(), 'hello');
+    });
+
+    it('property writes can be awaited via $writeProp', async () => {
+      const iface = await clientBus
+        .getService(SERVICE)
+        .getInterface(OBJECT_PATH, IFACE);
+      await iface.$writeProp('Greeting', 'written');
+      assert.strictEqual(impl.Greeting, 'written');
+    });
+
+    it('still supports the callback form on methods', done => {
+      clientBus
+        .getService(SERVICE)
+        .getInterface(OBJECT_PATH, IFACE, (err, iface) => {
+          assert.ifError(err);
+          iface.Echo('cb', (err, result) => {
+            assert.ifError(err);
+            assert.strictEqual(result, 'cb');
+            done();
+          });
+        });
+    });
+  });
+
+  it('reads like ordinary async code end to end', async () => {
+    const iface = await clientBus
+      .getService(SERVICE)
+      .getInterface(OBJECT_PATH, IFACE);
+    const [echoed, sum, names] = await Promise.all([
+      iface.Echo('parallel'),
+      iface.Add(1, 2),
+      clientBus.listNames()
+    ]);
+    assert.strictEqual(echoed, 'parallel');
+    assert.strictEqual(sum, 3);
+    assert.ok(names.includes(SERVICE));
+  });
+});

--- a/test/integration/promises.js
+++ b/test/integration/promises.js
@@ -83,7 +83,15 @@ describe('integration: promises', function () {
           assert.ok(err instanceof DBusError);
           assert.strictEqual(err.message, 'deliberate failure');
           assert.strictEqual(err.dbusName, 'com.example.Error.Boom');
-          assert.ok(err.stack.includes('promises.js'), 'stack reaches caller');
+          // The error is built in the socket read handler, so its own frames
+          // are all library internals. The caller's frames are stitched on.
+          assert.match(err.stack, /--- d-bus call made at ---/);
+          assert.ok(
+            err.stack
+              .split('--- d-bus call made at ---')[1]
+              .includes('integration/promises.js'),
+            'stitched frames should name the calling file'
+          );
           return true;
         }
       );

--- a/test/promises.js
+++ b/test/promises.js
@@ -1,0 +1,138 @@
+const assert = require('assert');
+const { execFileSync } = require('child_process');
+const { maybePromise } = require('../lib/promisify');
+const { DBusError, toDBusError } = require('../lib/errors');
+
+// Stand-in for an operation that calls back asynchronously. Returns undefined,
+// like the real ones do.
+const op =
+  (err, ...values) =>
+  cb => {
+    setImmediate(() => cb(err, ...values));
+  };
+
+describe('maybePromise', () => {
+  it('uses the callback when one is given, and returns nothing new', done => {
+    const ret = maybePromise(
+      (err, value) => {
+        assert.strictEqual(err, null);
+        assert.strictEqual(value, 42);
+        done();
+      },
+      op(null, 42)
+    );
+    assert.strictEqual(ret, undefined);
+  });
+
+  it('resolves with the single value when no callback is given', async () => {
+    assert.strictEqual(await maybePromise(undefined, op(null, 42)), 42);
+  });
+
+  it('resolves with undefined when the reply carries no values', async () => {
+    assert.strictEqual(await maybePromise(undefined, op(null)), undefined);
+  });
+
+  it('resolves with an array when the reply carries several values', async () => {
+    assert.deepStrictEqual(
+      await maybePromise(undefined, op(null, 1, 2, 3)),
+      [1, 2, 3]
+    );
+  });
+
+  it('rejects with a DBusError', async () => {
+    const body = Object.assign(['boom'], {
+      message: 'boom',
+      dbusName: 'com.example.Error.Boom'
+    });
+    await assert.rejects(
+      () => maybePromise(undefined, op(body)),
+      err => {
+        assert.ok(err instanceof DBusError);
+        assert.ok(err instanceof Error);
+        assert.strictEqual(err.message, 'boom');
+        assert.strictEqual(err.dbusName, 'com.example.Error.Boom');
+        assert.deepStrictEqual(err.body, ['boom']);
+        return true;
+      }
+    );
+  });
+
+  it('works when awaited after the call already completed', async () => {
+    const pending = maybePromise(undefined, op(null, 'late'));
+    await new Promise(setImmediate); // let it settle first
+    assert.strictEqual(await pending, 'late');
+  });
+
+  it('is awaited the same way twice', async () => {
+    const pending = maybePromise(undefined, op(null, 'twice'));
+    assert.strictEqual(await pending, 'twice');
+    assert.strictEqual(await pending, 'twice');
+  });
+
+  it('composes with Promise.all', async () => {
+    const results = await Promise.all([
+      maybePromise(undefined, op(null, 1)),
+      maybePromise(undefined, op(null, 2))
+    ]);
+    assert.deepStrictEqual(results, [1, 2]);
+  });
+
+  it('supports .catch and .finally', async () => {
+    let ranFinally = false;
+    const message = await maybePromise(undefined, op(['nope']))
+      .catch(err => err.message)
+      .finally(() => {
+        ranFinally = true;
+      });
+    assert.strictEqual(message, 'nope');
+    assert.ok(ranFinally);
+  });
+
+  // The reason this is a thenable rather than a Promise. Calling without a
+  // callback has always been fire-and-forget; a real Promise would turn a
+  // silently-dropped failure into a process-terminating unhandled rejection.
+  it('does not produce an unhandled rejection when the result is ignored', () => {
+    const script = `
+      const { maybePromise } = require(${JSON.stringify(require.resolve('../lib/promisify'))});
+      process.on('unhandledRejection', e => {
+        console.error('UNHANDLED');
+        process.exit(3);
+      });
+      // fire and forget, exactly as examples/monitor1.js does
+      maybePromise(undefined, cb => setImmediate(() => cb(['it failed'])));
+      setTimeout(() => { console.log('survived'); process.exit(0); }, 300);
+    `;
+    const out = execFileSync(process.execPath, ['-e', script], {
+      encoding: 'utf8'
+    });
+    assert.match(out, /survived/);
+  });
+
+  it('still rejects normally when the result is observed', async () => {
+    await assert.rejects(() => maybePromise(undefined, op(['observed'])), {
+      message: 'observed'
+    });
+  });
+});
+
+describe('toDBusError', () => {
+  it('passes an Error through untouched', () => {
+    const err = new Error('already');
+    assert.strictEqual(toDBusError(err), err);
+  });
+
+  it('falls back to the dbus name when the body is empty', () => {
+    const body = Object.assign([], {
+      dbusName: 'org.freedesktop.DBus.Error.Failed'
+    });
+    assert.strictEqual(
+      toDBusError(body).message,
+      'org.freedesktop.DBus.Error.Failed'
+    );
+  });
+
+  it('never produces an empty message', () => {
+    assert.ok(toDBusError([]).message.length > 0);
+    assert.ok(toDBusError(undefined).message.length > 0);
+  });
+});


### PR DESCRIPTION
> **Stacked on #316** — targets that branch, not `master`. Merge #316 first and this retargets automatically.

Second slice of **0.6**. Closes #9 (opened 2013) and #10, and lands #295s idea across the whole surface rather than just proxy methods: `bus.invoke`, the bus meta functions, `getService`/`getObject`/`getInterface`, proxy method calls and property reads.

```js
const iface = await bus
  .getService(org.freedesktop.Notifications)
  .getInterface(/org/freedesktop/Notifications, org.freedesktop.Notifications);

const id = await iface.Notify(app, 0, , summary, body, [], [], 5000);
```

The callback path is untouched, so this is additive. Every promise test has a callback-form sibling asserting the old path still behaves.

## Two things needed more than "wrap it in a Promise"

**Fire-and-forget.** Omitting the callback has always meant *do not tell me what happened* — this repos own `examples/monitor1.js` does `bus.invoke({ member: AddMatch, ... })` with no callback. A real Promise would turn a silently-dropped failure into an **unhandled rejection, which terminates the process on Node 15+**: a breaking change smuggled into a minor.

So the return value is a thenable whose Promise is constructed lazily on first `then`/`catch`/`finally`. Await it and you get full promise semantics; ignore it and nothing is ever constructed, so the behaviour is exactly what it was. There is a child-process test asserting an ignored *failing* call still exits 0.

Trade-off, stated in the README: it is not `instanceof Promise`, though `await`, `Promise.all`, `.catch` and `.finally` all work.

**Stack traces.** I assumed promises would fix these for free. They do not — V8 stitches async frames only along an unbroken `await` chain, and a reply arriving on a socket is a fresh I/O callback with no link back to the caller. Before:

```
DBusError: The name com.example.Nope was not provided by any .service files
    at toDBusError (lib/errors.js:38:10)
    at lib/promisify.js:70:38
    at EventEmitter.<anonymous> (lib/bus.js:174:19)
    at Socket.onReadable (lib/message.js:153:9)
```

— every frame is this library. The call site is now captured synchronously and appended, so a failed call names the line that made it. Cost measured rather than guessed:

```
real d-bus round trip:      85.8 us/call
call-site capture overhead: 1.95 us => 2.3% of a call
```

Only on the promise path. I think 2% is clearly worth an error you can locate, but it is a deliberate trade and easy to reverse.

## Errors

Rejections are always a `DBusError` (`message`, `dbusName`, `body`, `reply`) even though the callback path still receives the raw array until 1.0. Nothing depends on the promise path yet, so it can start out correct rather than inheriting the shape #207 complains about.

The property **setter** stays strictly fire-and-forget — assignment cannot be awaited, so a rejection there would have nowhere to go. `$writeProp(name, value)` can be called directly and awaited.

## Also

Corrects the claim in BIG_FUTURE_PLANS that promise rejections carry the callers frames automatically.

**254 unit** + **34 integration**.