### PR TITLE
feat: per-call and per-client timeouts, and AbortSignal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,44 @@ Two things worth knowing:
 - Capturing the call site costs about 1.95 µs against an 85.8 µs round trip
   (~2%), and only on the promise path.
 
+### Timeouts and cancellation
+
+A call with no reply waits forever by default, which is the behaviour this
+library has always had — and the reason a long-lived process can accumulate
+pending calls that never resolve. Both a per-call and a per-client timeout are
+available:
+
+```js
+// per call
+await bus.invoke(msg, { timeout: 5000 });
+
+// default for every call on this client
+const bus = dbus.sessionBus({ timeout: 25000 });
+```
+
+A timeout rejects with a `TimeoutError` (`code: 'ETIMEDOUT'`,
+`dbusName: 'org.freedesktop.DBus.Error.NoReply'`) **and removes the pending
+call**, so nothing is left behind.
+
+`AbortSignal` cancels a call, and composes with everything else that takes one:
+
+```js
+const ac = new AbortController();
+process.on('SIGINT', () => ac.abort());
+await bus.invoke(msg, { signal: ac.signal });
+
+await bus.invoke(msg, { signal: AbortSignal.timeout(5000) });
+```
+
+Aborting rejects with an `AbortError` whose `cause` is the signal's reason. If
+the signal is already aborted the message is never written to the socket.
+
+Options work with callbacks too — `bus.invoke(msg, { timeout: 5000 }, cb)`.
+
+The default stays "wait forever" in 0.x: making calls that currently hang start
+failing is a behaviour change, and belongs in a major. See
+[RELEASE_PLAN.md](./RELEASE_PLAN.md).
+
 ### Reading values: variants and dicts
 
 A variant currently unmarshals as `[parsedSignature, [value]]` and a dict as an

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -3,6 +3,7 @@ const constants = require('./constants');
 const stdDbusIfaces = require('./stdifaces');
 const introspect = require('./introspect').introspectBus;
 const { maybePromise } = require('./promisify');
+const { TimeoutError, AbortError } = require('./errors');
 
 // A failed call currently delivers the raw message body -- an array, or `[]`
 // when the body is empty. In 1.0 that becomes a DBusError. Attaching the
@@ -40,6 +41,8 @@ module.exports = function bus(conn, opts) {
   if (!opts) opts = {};
 
   const self = this;
+  // Opt-in per-client default; undefined means wait forever, as before.
+  const defaultTimeout = opts.timeout;
   this.connection = conn;
   this.serial = 1;
   this.cookies = {}; // TODO: rename to methodReturnHandlers
@@ -49,20 +52,77 @@ module.exports = function bus(conn, opts) {
 
   // Returns a promise when no callback is given; the callback path is
   // unchanged. See lib/promisify.js.
-  this.invoke = function (msg, callback) {
+  // invoke(msg, callback)
+  // invoke(msg, { signal, timeout })            -> promise
+  // invoke(msg, { signal, timeout }, callback)
+  this.invoke = function (msg, options, callback) {
+    if (typeof options === 'function') {
+      callback = options;
+      options = undefined;
+    }
+    const opts = options || {};
+    const signal = opts.signal;
+    // No default timeout unless the client asked for one. Making calls that
+    // currently hang start failing is a behaviour change, and belongs in a
+    // major -- see RELEASE_PLAN.md.
+    const timeout = opts.timeout !== undefined ? opts.timeout : defaultTimeout;
+
     return maybePromise(callback, cb => {
+      if (signal && signal.aborted) {
+        // Never put it on the wire in the first place.
+        return cb(new AbortError(signal, msg));
+      }
+
       if (!msg.type) msg.type = constants.messageType.methodCall;
       msg.serial = self.serial++;
-      self.cookies[msg.serial] = cb;
+      const serial = msg.serial;
+
+      let timer = null;
+      let onAbort = null;
+      let settled = false;
+
+      const cleanup = () => {
+        if (timer) clearTimeout(timer);
+        if (onAbort && signal) signal.removeEventListener('abort', onAbort);
+        delete self.cookies[serial];
+      };
+
+      // Whichever of reply, timeout or abort happens first wins; the rest are
+      // torn down. Removing the cookie is what stops `bus.cookies` growing for
+      // every call that never gets an answer.
+      function settle(err, ...values) {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        cb.apply(this, [err, ...values]);
+      }
+
+      self.cookies[serial] = settle;
+
+      if (timeout > 0) {
+        timer = setTimeout(
+          () => settle(new TimeoutError(timeout, msg)),
+          timeout
+        );
+        // A pending call should not hold the process open on its own; the
+        // connection's socket already does that while it is alive.
+        if (typeof timer.unref === 'function') timer.unref();
+      }
+
+      if (signal) {
+        onAbort = () => settle(new AbortError(signal, msg));
+        signal.addEventListener('abort', onAbort, { once: true });
+      }
+
       self.connection.message(msg);
     });
   };
 
-  this.invokeDbus = function (msg, callback) {
+  this.invokeDbus = function (msg, options, callback) {
     if (!msg.path) msg.path = '/org/freedesktop/DBus';
     if (!msg.destination) msg.destination = 'org.freedesktop.DBus';
     if (!msg['interface']) msg['interface'] = 'org.freedesktop.DBus';
-    return self.invoke(msg, callback);
+    return self.invoke(msg, options, callback);
   };
 
   this.mangle = function (path, iface, member) {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -38,4 +38,45 @@ function toDBusError(err) {
   return new DBusError(message, err && err.dbusName, body, err && err.reply);
 }
 
-module.exports = { DBusError, toDBusError };
+/**
+ * A call that was given a timeout and did not get a reply in time.
+ *
+ * Carries the D-Bus name the spec uses for this condition, so code that
+ * switches on `dbusName` handles a local timeout and a remote NoReply the same
+ * way.
+ */
+class TimeoutError extends DBusError {
+  constructor(timeout, msg) {
+    super(
+      `No reply within ${timeout}ms to ${msg.interface || '?'}.${msg.member || '?'} on ${msg.destination || '?'}`,
+      'org.freedesktop.DBus.Error.NoReply',
+      undefined,
+      undefined
+    );
+    this.name = 'TimeoutError';
+    this.code = 'ETIMEDOUT';
+    this.timeout = timeout;
+  }
+}
+
+/**
+ * A call cancelled through an AbortSignal.
+ *
+ * Uses the signal's own `reason` as the cause, so `AbortSignal.timeout()` and a
+ * user's `AbortController.abort(reason)` both surface what they meant.
+ */
+class AbortError extends DBusError {
+  constructor(signal, msg) {
+    super(
+      `Aborted call to ${msg.interface || '?'}.${msg.member || '?'} on ${msg.destination || '?'}`,
+      'org.freedesktop.DBus.Error.NoReply',
+      undefined,
+      undefined
+    );
+    this.name = 'AbortError';
+    this.code = 'ABORT_ERR';
+    this.cause = signal && signal.reason;
+  }
+}
+
+module.exports = { DBusError, TimeoutError, AbortError, toDBusError };

--- a/test/integration/timeouts.js
+++ b/test/integration/timeouts.js
@@ -1,0 +1,127 @@
+// Timeouts and cancellation against a real dbus-daemon, including a service
+// method that deliberately never replies.
+
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const dbus = require('../../index');
+
+const SERVICE = 'com.github.sidorares.dbusnative.Timeouts';
+const OBJECT_PATH = '/com/github/sidorares/dbusnative/Timeouts';
+const IFACE = 'com.github.sidorares.dbusnative.TimeoutsIface';
+
+const ifaceDesc = {
+  name: IFACE,
+  methods: {
+    Quick: ['', 's', [], ['out']],
+    NeverReplies: ['', 's', [], ['out']]
+  },
+  signals: {},
+  properties: {}
+};
+
+describe('integration: timeouts and cancellation', function () {
+  this.timeout(15000);
+
+  let serviceBus, clientBus;
+
+  before(async function () {
+    if (!process.env.DBUS_SESSION_BUS_ADDRESS) return this.skip();
+    serviceBus = dbus.sessionBus();
+    clientBus = dbus.sessionBus();
+
+    const impl = Object.assign(Object.create(EventEmitter.prototype), {
+      Quick: () => 'here',
+      // returning a promise that never settles means no reply is ever sent
+      NeverReplies: () => new Promise(() => {})
+    });
+    EventEmitter.call(impl);
+
+    await Promise.all([serviceBus.getId(), clientBus.getId()]);
+    await serviceBus.requestName(SERVICE, 0);
+    serviceBus.exportInterface(impl, OBJECT_PATH, ifaceDesc);
+  });
+
+  after(() => {
+    if (serviceBus) serviceBus.connection.end();
+    if (clientBus) clientBus.connection.end();
+  });
+
+  const call = member => ({
+    destination: SERVICE,
+    path: OBJECT_PATH,
+    interface: IFACE,
+    member
+  });
+
+  it('a call that gets a reply is unaffected by a timeout', async () => {
+    const result = await clientBus.invoke(call('Quick'), { timeout: 5000 });
+    assert.strictEqual(result, 'here');
+  });
+
+  it('times out a call that never gets a reply', async () => {
+    const started = Date.now();
+    await assert.rejects(
+      () => clientBus.invoke(call('NeverReplies'), { timeout: 150 }),
+      { name: 'TimeoutError', code: 'ETIMEDOUT' }
+    );
+    const elapsed = Date.now() - started;
+    assert.ok(elapsed >= 140, `returned too early: ${elapsed}ms`);
+    assert.ok(elapsed < 2000, `returned too late: ${elapsed}ms`);
+  });
+
+  it('does not leak the pending call after a timeout', async () => {
+    const before = Object.keys(clientBus.cookies).length;
+    await assert.rejects(() =>
+      clientBus.invoke(call('NeverReplies'), { timeout: 100 })
+    );
+    assert.strictEqual(Object.keys(clientBus.cookies).length, before);
+  });
+
+  it('cancels an in-flight call through an AbortController', async () => {
+    const ac = new AbortController();
+    const pending = clientBus.invoke(call('NeverReplies'), {
+      signal: ac.signal
+    });
+    setTimeout(() => ac.abort(new Error('changed my mind')), 50);
+    await assert.rejects(
+      () => pending,
+      err => {
+        assert.strictEqual(err.name, 'AbortError');
+        assert.strictEqual(err.cause.message, 'changed my mind');
+        return true;
+      }
+    );
+  });
+
+  it('works with AbortSignal.timeout()', async () => {
+    await assert.rejects(
+      () =>
+        clientBus.invoke(call('NeverReplies'), {
+          signal: AbortSignal.timeout(120)
+        }),
+      { name: 'AbortError' }
+    );
+  });
+
+  it('honours a client-wide default timeout', async () => {
+    const impatient = dbus.sessionBus({ timeout: 120 });
+    try {
+      await impatient.getId();
+      await assert.rejects(() => impatient.invoke(call('NeverReplies')), {
+        name: 'TimeoutError'
+      });
+    } finally {
+      impatient.connection.end();
+    }
+  });
+
+  it('leaves the connection usable after a timeout', async () => {
+    await assert.rejects(() =>
+      clientBus.invoke(call('NeverReplies'), { timeout: 80 })
+    );
+    assert.strictEqual(
+      await clientBus.invoke(call('Quick'), { timeout: 5000 }),
+      'here'
+    );
+  });
+});

--- a/test/timeouts.js
+++ b/test/timeouts.js
@@ -1,0 +1,167 @@
+// Call timeouts and AbortSignal support, and the pending-call bookkeeping
+// that goes with them.
+
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const MessageBus = require('../lib/bus');
+const constants = require('../lib/constants');
+
+// A connection that records what was sent and lets a test reply by hand.
+function fakeBus(opts = {}) {
+  const sent = [];
+  const conn = new EventEmitter();
+  conn.message = msg => sent.push(msg);
+  const bus = new MessageBus(conn, { direct: true, ...opts });
+  return {
+    bus,
+    sent,
+    reply(serial, body = []) {
+      conn.emit('message', {
+        type: constants.messageType.methodReturn,
+        replySerial: serial,
+        body
+      });
+    }
+  };
+}
+
+const call = { destination: 'a.b', path: '/p', interface: 'a.b', member: 'M' };
+
+describe('call timeouts', () => {
+  it('rejects with a TimeoutError when no reply arrives', async () => {
+    const { bus } = fakeBus();
+    await assert.rejects(
+      () => bus.invoke({ ...call }, { timeout: 30 }),
+      err => {
+        assert.strictEqual(err.name, 'TimeoutError');
+        assert.strictEqual(err.code, 'ETIMEDOUT');
+        assert.strictEqual(err.dbusName, 'org.freedesktop.DBus.Error.NoReply');
+        assert.strictEqual(err.timeout, 30);
+        assert.match(err.message, /a\.b\.M/);
+        return true;
+      }
+    );
+  });
+
+  // Without this, every call that never gets an answer leaves an entry behind.
+  it('removes the pending entry when it times out', async () => {
+    const { bus } = fakeBus();
+    assert.strictEqual(Object.keys(bus.cookies).length, 0);
+    const pending = bus.invoke({ ...call }, { timeout: 20 });
+    assert.strictEqual(Object.keys(bus.cookies).length, 1);
+    await assert.rejects(() => pending);
+    assert.strictEqual(
+      Object.keys(bus.cookies).length,
+      0,
+      'pending call leaked'
+    );
+  });
+
+  it('does not fire once the reply has arrived', async () => {
+    const { bus, sent, reply } = fakeBus();
+    const pending = bus.invoke({ ...call }, { timeout: 50 });
+    reply(sent[0].serial, ['ok']);
+    assert.strictEqual(await pending, 'ok');
+    await new Promise(resolve => setTimeout(resolve, 80)); // past the timeout
+    assert.strictEqual(Object.keys(bus.cookies).length, 0);
+  });
+
+  it('applies a client-wide default timeout', async () => {
+    const { bus } = fakeBus({ timeout: 25 });
+    await assert.rejects(() => bus.invoke({ ...call }), {
+      name: 'TimeoutError'
+    });
+  });
+
+  it('lets a per-call timeout override the client default', async () => {
+    const { bus, sent, reply } = fakeBus({ timeout: 10 });
+    const pending = bus.invoke({ ...call }, { timeout: 0 }); // 0 disables
+    setTimeout(() => reply(sent[0].serial, ['slow but fine']), 40);
+    assert.strictEqual(await pending, 'slow but fine');
+  });
+
+  it('waits forever by default, as it always has', async () => {
+    const { bus, sent, reply } = fakeBus();
+    const pending = bus.invoke({ ...call });
+    setTimeout(() => reply(sent[0].serial, ['eventually']), 60);
+    assert.strictEqual(await pending, 'eventually');
+  });
+
+  it('reports the timeout through a callback too', done => {
+    const { bus } = fakeBus();
+    bus.invoke({ ...call }, { timeout: 20 }, err => {
+      assert.strictEqual(err.name, 'TimeoutError');
+      done();
+    });
+  });
+});
+
+describe('AbortSignal', () => {
+  it('rejects when aborted in flight', async () => {
+    const { bus } = fakeBus();
+    const ac = new AbortController();
+    const pending = bus.invoke({ ...call }, { signal: ac.signal });
+    setImmediate(() => ac.abort());
+    await assert.rejects(
+      () => pending,
+      err => {
+        assert.strictEqual(err.name, 'AbortError');
+        assert.strictEqual(err.code, 'ABORT_ERR');
+        return true;
+      }
+    );
+  });
+
+  it('does not send the message when the signal is already aborted', async () => {
+    const { bus, sent } = fakeBus();
+    await assert.rejects(
+      () => bus.invoke({ ...call }, { signal: AbortSignal.abort() }),
+      { name: 'AbortError' }
+    );
+    assert.deepStrictEqual(sent, [], 'nothing should have been written');
+  });
+
+  it('removes the pending entry when aborted', async () => {
+    const { bus } = fakeBus();
+    const ac = new AbortController();
+    const pending = bus.invoke({ ...call }, { signal: ac.signal });
+    assert.strictEqual(Object.keys(bus.cookies).length, 1);
+    ac.abort();
+    await assert.rejects(() => pending);
+    assert.strictEqual(Object.keys(bus.cookies).length, 0);
+  });
+
+  it('surfaces the abort reason as the cause', async () => {
+    const { bus } = fakeBus();
+    const ac = new AbortController();
+    const reason = new Error('user cancelled');
+    const pending = bus.invoke({ ...call }, { signal: ac.signal });
+    ac.abort(reason);
+    await assert.rejects(
+      () => pending,
+      err => {
+        assert.strictEqual(err.cause, reason);
+        return true;
+      }
+    );
+  });
+
+  it('works with AbortSignal.timeout()', async () => {
+    const { bus } = fakeBus();
+    await assert.rejects(
+      () => bus.invoke({ ...call }, { signal: AbortSignal.timeout(20) }),
+      { name: 'AbortError' }
+    );
+  });
+
+  it('stops listening to the signal once the reply arrives', async () => {
+    const { bus, sent, reply } = fakeBus();
+    const ac = new AbortController();
+    const pending = bus.invoke({ ...call }, { signal: ac.signal });
+    reply(sent[0].serial, ['done']);
+    assert.strictEqual(await pending, 'done');
+    // aborting afterwards must not produce an unhandled rejection
+    ac.abort();
+    await new Promise(setImmediate);
+  });
+});


### PR DESCRIPTION
Third slice of **0.6**, and the first half of #137.

```js
await bus.invoke(msg, { timeout: 5000 });
await bus.invoke(msg, { signal: AbortSignal.timeout(5000) });
const bus = dbus.sessionBus({ timeout: 25000 });   // client-wide default
```

Both are **opt-in**. The default stays "wait forever", because making calls that currently hang start failing is a behaviour change and belongs in a major — RELEASE_PLAN puts it in 3.0. Options work with callbacks too: `bus.invoke(msg, { timeout: 5000 }, cb)`.

## The bookkeeping matters as much as the feature

This is the leak behind #137. Today **every call that never gets an answer leaves an entry in `bus.cookies` forever**, so a long-lived daemon grows in proportion to how often its peers misbehave.

Whichever of reply, timeout or abort happens first wins; the losers are torn down — timer cleared, abort listener removed, cookie deleted. Asserted directly, both in unit tests and against a real daemon:

```
✔ removes the pending entry when it times out
✔ removes the pending entry when aborted
✔ does not fire once the reply has arrived
✔ does not leak the pending call after a timeout   (integration)
```

An already-aborted signal short-circuits **before the message is written**, so a cancelled call costs nothing on the wire — there is a test asserting the fake connection received nothing.

## Error shapes

`TimeoutError` and `AbortError` both extend `DBusError` and carry `org.freedesktop.DBus.Error.NoReply` as their `dbusName`, so code that switches on `dbusName` treats a local timeout and a remote NoReply alike. `AbortError` takes the signals `reason` as its `cause`, so `AbortSignal.timeout()` and a users `abort(reason)` each explain themselves.

## One detail worth noting

The timeout timer is `unref`d. A pending call should not hold the process open by itself — the connections socket already does that while it is alive — otherwise a 25-second default timeout would delay exit by up to 25 seconds.

## Verification

**267 unit** (was 254) + **41 integration** (was 34). The integration suite exports a method returning a never-settling promise, so the timeout path runs against a real `dbus-daemon` rather than only a fake connection, and one test confirms the connection is still usable afterwards.