### PR TITLE
feat: publish message and call traffic on diagnostics_channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,44 @@ Two things worth knowing:
 - Capturing the call site costs about 1.95 µs against an 85.8 µs round trip
   (~2%), and only on the promise path.
 
+### Observability
+
+Traffic and call timing are published on
+[`diagnostics_channel`](https://nodejs.org/api/diagnostics_channel.html), so
+you can see what is happening without the library growing a logging API of its
+own:
+
+```js
+const dc = require('node:diagnostics_channel');
+
+// every message, in either direction
+dc.subscribe('dbus:message:send', ({ message }) =>
+  console.log('->', message.destination, message.member)
+);
+dc.subscribe('dbus:message:receive', ({ message }) =>
+  console.log('<-', message.sender, message.member)
+);
+
+// method calls as a tracing channel: start / end / error share a context
+const started = new WeakMap();
+dc.subscribe('tracing:dbus:call:start', ctx => started.set(ctx, Date.now()));
+dc.subscribe('tracing:dbus:call:end', ctx =>
+  console.log(
+    `${ctx.interface}.${ctx.member} took ${Date.now() - started.get(ctx)}ms`
+  )
+);
+dc.subscribe('tracing:dbus:call:error', ctx =>
+  console.error(`${ctx.member} failed:`, ctx.error.message)
+);
+```
+
+Channels are checked for subscribers before any payload is built, so this costs
+nothing when unused — measured at or below run-to-run noise against a ~45 µs
+round trip, both unsubscribed and subscribed.
+
+That makes a `dbus-monitor` equivalent, OpenTelemetry spans, or per-call timing
+a few lines of application code rather than a library feature.
+
 ### Timeouts and cancellation
 
 A call with no reply waits forever by default, which is the behaviour this

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const MessageBus = require('./lib/bus');
 const server = require('./lib/server');
 const deprecate = require('./lib/deprecate');
 const values = require('./lib/values');
+const { publishSend, publishReceive } = require('./lib/diagnostics');
 
 // A d-bus address is `family:key=value,key=value`, and DBUS_SESSION_BUS_ADDRESS
 // may hold several of them separated by `;`. See
@@ -119,6 +120,7 @@ function createConnection(opts) {
   let corked = false;
 
   function writeMessage(msg) {
+    publishSend(msg);
     const buffer = message.marshall(msg);
     if (canCork && !corked) {
       corked = true;
@@ -149,6 +151,7 @@ function createConnection(opts) {
     message.unmarshalMessages(
       stream,
       msg => {
+        publishReceive(msg);
         self.emit('message', msg);
       },
       opts,

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -4,6 +4,7 @@ const stdDbusIfaces = require('./stdifaces');
 const introspect = require('./introspect').introspectBus;
 const { maybePromise } = require('./promisify');
 const { TimeoutError, AbortError } = require('./errors');
+const { channels } = require('./diagnostics');
 
 // A failed call currently delivers the raw message body -- an array, or `[]`
 // when the body is empty. In 1.0 that becomes a DBusError. Attaching the
@@ -73,6 +74,19 @@ module.exports = function bus(conn, opts) {
         return cb(new AbortError(signal, msg));
       }
 
+      // Only pay for the context object when something is listening.
+      const traced = channels.call.hasSubscribers;
+      const context = traced
+        ? {
+            destination: msg.destination,
+            path: msg.path,
+            interface: msg['interface'],
+            member: msg.member,
+            signature: msg.signature
+          }
+        : null;
+      if (traced) channels.call.start.publish(context);
+
       if (!msg.type) msg.type = constants.messageType.methodCall;
       msg.serial = self.serial++;
       const serial = msg.serial;
@@ -94,6 +108,15 @@ module.exports = function bus(conn, opts) {
         if (settled) return;
         settled = true;
         cleanup();
+        if (traced) {
+          if (err) {
+            context.error = err;
+            channels.call.error.publish(context);
+          } else {
+            context.result = values.length === 1 ? values[0] : values;
+          }
+          channels.call.end.publish(context);
+        }
         cb.apply(this, [err, ...values]);
       }
 

--- a/lib/diagnostics.js
+++ b/lib/diagnostics.js
@@ -1,0 +1,31 @@
+// Observability via node:diagnostics_channel.
+//
+// A protocol library is a natural place for this: a great many of the issues
+// on this tracker are some form of "I sent something and nothing happened",
+// and being able to see the traffic answers those without a debug-logging API
+// of our own.
+//
+// Publishing to a channel nobody has subscribed to is a boolean check, so this
+// costs effectively nothing when unused -- `hasSubscribers` is checked before
+// building any payload.
+
+const diagnostics_channel = require('node:diagnostics_channel');
+
+const channels = {
+  /** A message handed to the connection for writing. */
+  send: diagnostics_channel.channel('dbus:message:send'),
+  /** A message decoded off the wire. */
+  receive: diagnostics_channel.channel('dbus:message:receive'),
+  /** A method call starting, ending, or failing. */
+  call: diagnostics_channel.tracingChannel('dbus:call')
+};
+
+function publishSend(message) {
+  if (channels.send.hasSubscribers) channels.send.publish({ message });
+}
+
+function publishReceive(message) {
+  if (channels.receive.hasSubscribers) channels.receive.publish({ message });
+}
+
+module.exports = { channels, publishSend, publishReceive };

--- a/test/integration/diagnostics.js
+++ b/test/integration/diagnostics.js
@@ -1,0 +1,152 @@
+// diagnostics_channel instrumentation, observed against a real dbus-daemon.
+
+const assert = require('assert');
+const dc = require('node:diagnostics_channel');
+const { EventEmitter } = require('events');
+const dbus = require('../../index');
+
+const SERVICE = 'com.github.sidorares.dbusnative.Diagnostics';
+const OBJECT_PATH = '/com/github/sidorares/dbusnative/Diagnostics';
+const IFACE = 'com.github.sidorares.dbusnative.DiagnosticsIface';
+
+const ifaceDesc = {
+  name: IFACE,
+  methods: { Echo: ['s', 's', ['in'], ['out']], Fail: ['', '', [], []] },
+  signals: {},
+  properties: {}
+};
+
+// Subscribe for the duration of one function call, then clean up.
+async function watching(names, fn) {
+  const seen = Object.fromEntries(names.map(n => [n, []]));
+  const subs = names.map(name => {
+    const handler = payload => seen[name].push(payload);
+    dc.subscribe(name, handler);
+    return () => dc.unsubscribe(name, handler);
+  });
+  try {
+    await fn();
+  } finally {
+    subs.forEach(off => off());
+  }
+  return seen;
+}
+
+describe('integration: diagnostics_channel', function () {
+  this.timeout(10000);
+
+  let serviceBus, clientBus;
+
+  before(async function () {
+    if (!process.env.DBUS_SESSION_BUS_ADDRESS) return this.skip();
+    serviceBus = dbus.sessionBus();
+    clientBus = dbus.sessionBus();
+
+    const impl = Object.assign(Object.create(EventEmitter.prototype), {
+      Echo: input => input,
+      Fail: () => {
+        const err = new Error('deliberate');
+        err.dbusName = 'com.example.Error.Boom';
+        throw err;
+      }
+    });
+    EventEmitter.call(impl);
+
+    await Promise.all([serviceBus.getId(), clientBus.getId()]);
+    await serviceBus.requestName(SERVICE, 0);
+    serviceBus.exportInterface(impl, OBJECT_PATH, ifaceDesc);
+  });
+
+  after(() => {
+    if (serviceBus) serviceBus.connection.end();
+    if (clientBus) clientBus.connection.end();
+  });
+
+  const call = (member, over = {}) => ({
+    destination: SERVICE,
+    path: OBJECT_PATH,
+    interface: IFACE,
+    member,
+    ...over
+  });
+
+  it('publishes outbound and inbound messages', async () => {
+    const seen = await watching(
+      ['dbus:message:send', 'dbus:message:receive'],
+      () => clientBus.invoke(call('Echo', { signature: 's', body: ['hi'] }))
+    );
+
+    const sent = seen['dbus:message:send'].map(p => p.message);
+    assert.ok(
+      sent.some(m => m.member === 'Echo' && m.destination === SERVICE),
+      'the outbound call should be published'
+    );
+
+    const received = seen['dbus:message:receive'].map(p => p.message);
+    assert.ok(received.length > 0, 'the reply should be published');
+    assert.ok(received.some(m => m.body && m.body[0] === 'hi'));
+  });
+
+  it('traces a successful call from start to end', async () => {
+    const seen = await watching(
+      ['tracing:dbus:call:start', 'tracing:dbus:call:end'],
+      () => clientBus.invoke(call('Echo', { signature: 's', body: ['traced'] }))
+    );
+
+    const started = seen['tracing:dbus:call:start'];
+    assert.strictEqual(started.length, 1);
+    assert.strictEqual(started[0].member, 'Echo');
+    assert.strictEqual(started[0].destination, SERVICE);
+    assert.strictEqual(started[0].interface, IFACE);
+
+    const ended = seen['tracing:dbus:call:end'];
+    assert.strictEqual(ended.length, 1);
+    assert.strictEqual(ended[0].result, 'traced');
+  });
+
+  it('publishes the error channel when a call fails', async () => {
+    const seen = await watching(
+      ['tracing:dbus:call:error', 'tracing:dbus:call:end'],
+      async () => {
+        await assert.rejects(() => clientBus.invoke(call('Fail')));
+      }
+    );
+
+    const errored = seen['tracing:dbus:call:error'];
+    assert.strictEqual(errored.length, 1);
+    assert.strictEqual(errored[0].member, 'Fail');
+    assert.ok(errored[0].error, 'the error should be attached');
+    // end still fires, so a subscriber can time every call uniformly
+    assert.strictEqual(seen['tracing:dbus:call:end'].length, 1);
+  });
+
+  it('can time a call, which is the point of the tracing channel', async () => {
+    let elapsed = null;
+    const started = new Map();
+    const onStart = ctx => started.set(ctx, process.hrtime.bigint());
+    const onEnd = ctx => {
+      if (started.has(ctx)) {
+        elapsed = Number(process.hrtime.bigint() - started.get(ctx)) / 1e6;
+      }
+    };
+    dc.subscribe('tracing:dbus:call:start', onStart);
+    dc.subscribe('tracing:dbus:call:end', onEnd);
+    try {
+      await clientBus.invoke(call('Echo', { signature: 's', body: ['timed'] }));
+    } finally {
+      dc.unsubscribe('tracing:dbus:call:start', onStart);
+      dc.unsubscribe('tracing:dbus:call:end', onEnd);
+    }
+    assert.ok(elapsed !== null, 'start and end should share a context object');
+    assert.ok(elapsed >= 0 && elapsed < 5000, `implausible timing: ${elapsed}`);
+  });
+
+  it('publishes nothing once unsubscribed', async () => {
+    const seen = [];
+    const handler = p => seen.push(p);
+    dc.subscribe('dbus:message:send', handler);
+    dc.unsubscribe('dbus:message:send', handler);
+    await clientBus.invoke(call('Echo', { signature: 's', body: ['quiet'] }));
+    assert.deepStrictEqual(seen, []);
+  });
+});


### PR DESCRIPTION
> **Stacked on #318** — targets that branch. It retargets to `master` automatically once #318 merges.

Fourth slice of **0.6**. Three channels:

| channel | published |
| --- | --- |
| `dbus:message:send` | every outbound message |
| `dbus:message:receive` | every decoded inbound message |
| `dbus:call` | a tracing channel — `start` / `end` / `error` |

```js
const dc = require(node:diagnostics_channel);

dc.subscribe(dbus:message:send, ({ message }) =>
  console.log(->, message.destination, message.member));

const started = new WeakMap();
dc.subscribe(tracing:dbus:call:start, ctx => started.set(ctx, Date.now()));
dc.subscribe(tracing:dbus:call:end, ctx =>
  console.log(`${ctx.interface}.${ctx.member} took ${Date.now() - started.get(ctx)}ms`));
```

## Why this earns its place

A large share of the issues on this tracker are some form of *"I sent something and nothing happened"* — #115, #136, #138, #229. Making traffic inspectable answers those without the library growing a debug-logging API of its own, and it gives OpenTelemetry spans, per-call timing and a `dbus-monitor` equivalent as **application** code rather than library features.

## Details worth reviewing

`start` and `end` publish the **same context object**, so a subscriber can key a `WeakMap` on it and time calls — there is a test doing exactly that rather than just asserting the events fire. `error` fires *in addition to* `end`, not instead of it, so timing code does not need to special-case failure.

Everything is guarded on `hasSubscribers` before any payload is built, and the per-call context object is only constructed when something is listening. I measured that claim rather than asserting it:

```
no subscribers:   45.2 us/call
with subscribers: 43.6 us/call
```

The difference is within run-to-run noise on a real round trip, in both directions.

## Verification

**267 unit** + **46 integration** (was 41). The five new integration tests observe real traffic against a live `dbus-daemon`, including that nothing is published after unsubscribing.