### PR TITLE
feat: ship TypeScript definitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run format:check
+      - run: npm run test:types
 
   test:
     name: test (node ${{ matrix.node }}, ${{ matrix.os }})

--- a/README.md
+++ b/README.md
@@ -151,6 +151,35 @@ conn.on('message', function (msg) {
 });
 ```
 
+### TypeScript
+
+Types ship with the package — no `@types/` install, and nothing to keep in
+sync separately. They are checked in CI against a usage fixture, so they
+cannot drift from the implementation without the build failing.
+
+```ts
+import dbus = require('dbus-native');
+import { MessageBus, DBusInterface, TimeoutError } from 'dbus-native';
+
+const bus: MessageBus = dbus.sessionBus({ timeout: 25000 });
+const names: string[] = await bus.listNames();
+
+// describe a remote interface for a checked surface
+interface Player extends DBusInterface {
+  PlayPause(): Promise<void>;
+}
+const player = await bus
+  .getService('org.mpris.MediaPlayer2.vlc')
+  .getInterface<Player>(
+    '/org/mpris/MediaPlayer2',
+    'org.mpris.MediaPlayer2.Player'
+  );
+await player.PlayPause();
+```
+
+Note that a call with no callback is typed as `DBusPromise<T>`, not
+`Promise<T>` — see the note under [Promises](#promises) for why.
+
 ### Promises
 
 Every callback-taking method returns a promise when you omit the callback. The

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,419 @@
+// Type definitions for dbus-native
+//
+// Hand-written and checked in CI against test/types/usage.ts, so they cannot
+// drift from the implementation without the build failing.
+//
+// Note the value shapes here describe the *current* API. The 2.0 type-system
+// change is documented in docs/deprecations.md and RELEASE_PLAN.md; the
+// forward-compatible helpers (variantValue, toPlain, Variant) are typed to
+// accept both shapes so code written against them keeps type-checking.
+
+/// <reference types="node" />
+
+import { EventEmitter } from 'events';
+import { Duplex } from 'stream';
+
+/**
+ * What a call returns when no callback is given.
+ *
+ * Deliberately not a `Promise`. Calling without a callback has always meant
+ * fire-and-forget, so the underlying promise is only constructed once someone
+ * observes the result -- ignoring it must not turn a dropped failure into an
+ * unhandled rejection. `await`, `Promise.all`, `.catch` and `.finally` all
+ * work; `instanceof Promise` does not.
+ */
+export interface DBusPromise<T> extends PromiseLike<T> {
+  then<R1 = T, R2 = never>(
+    onfulfilled?: ((value: T) => R1 | PromiseLike<R1>) | null,
+    onrejected?: ((reason: DBusError) => R2 | PromiseLike<R2>) | null
+  ): Promise<R1 | R2>;
+  catch<R = never>(
+    onrejected?: ((reason: DBusError) => R | PromiseLike<R>) | null
+  ): Promise<T | R>;
+  finally(onfinally?: (() => void) | null): Promise<T>;
+}
+
+// ---------------------------------------------------------------------------
+// Values
+// ---------------------------------------------------------------------------
+
+/** A node of a parsed d-bus signature. */
+export interface SignatureNode {
+  type: string;
+  child: SignatureNode[];
+}
+
+/**
+ * A variant as it is unmarshalled today: the parsed signature, then a
+ * one-element array holding the value. Changes in 2.0 -- read it with
+ * `variantValue()` rather than by index.
+ */
+export type ClassicVariant = [SignatureNode[], unknown[]];
+
+/** Any value that came off the wire. */
+export type DBusValue = unknown;
+
+/**
+ * An explicitly typed value. Accepted by the marshaller anywhere a
+ * `[signature, value]` pair is, and the forward-compatible way to write a
+ * variant.
+ */
+export class Variant<T = unknown> {
+  constructor(signature: string, value: T);
+  signature: string;
+  value: T;
+}
+
+/**
+ * Read the value out of a variant, in either the current or the 2.0 shape.
+ * Returns the argument unchanged if it is already a plain value.
+ */
+export function variantValue<T = unknown>(value: unknown): T;
+
+/** The signature of a variant, or undefined once the value has been flattened. */
+export function variantSignature(value: unknown): string | undefined;
+
+/**
+ * Recursively convert to plain JavaScript: dicts become objects, variants are
+ * unwrapped. A no-op on values that are already plain.
+ */
+export function toPlain<T = unknown>(value: unknown): T;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/** A method call that returned an error reply. */
+export class DBusError extends Error {
+  name: string;
+  /** e.g. 'org.freedesktop.DBus.Error.ServiceUnknown' */
+  dbusName?: string;
+  /** the raw reply body */
+  body?: unknown;
+  /** the full reply message */
+  reply?: Message;
+}
+
+/** A call given a timeout that did not get a reply in time. */
+export class TimeoutError extends DBusError {
+  code: 'ETIMEDOUT';
+  timeout: number;
+}
+
+/** A call cancelled through an AbortSignal. `cause` is the signal's reason. */
+export class AbortError extends DBusError {
+  code: 'ABORT_ERR';
+}
+
+// ---------------------------------------------------------------------------
+// Messages
+// ---------------------------------------------------------------------------
+
+export interface MessageType {
+  invalid: 0;
+  methodCall: 1;
+  methodReturn: 2;
+  error: 3;
+  signal: 4;
+}
+
+export const messageType: MessageType;
+
+export interface Message {
+  type?: number;
+  flags?: number;
+  serial?: number;
+  path?: string;
+  interface?: string;
+  member?: string;
+  errorName?: string;
+  replySerial?: number;
+  destination?: string;
+  sender?: string;
+  signature?: string;
+  body?: unknown[];
+}
+
+// ---------------------------------------------------------------------------
+// Connections
+// ---------------------------------------------------------------------------
+
+export interface ConnectionOptions {
+  /** an already-connected duplex stream to use instead of dialling */
+  stream?: Duplex;
+  /** unix socket path */
+  socket?: string;
+  /** TCP port */
+  port?: number;
+  /** TCP host */
+  host?: string;
+  /** encoded bus address; defaults to $DBUS_SESSION_BUS_ADDRESS */
+  busAddress?: string;
+  /** attempted in order; default ['EXTERNAL', 'DBUS_COOKIE_SHA1', 'ANONYMOUS'] */
+  authMethods?: string[];
+  /** act as the server side of the handshake */
+  server?: boolean;
+  /** skip the initial Hello, for peer-to-peer connections */
+  direct?: boolean;
+  /**
+   * How `ay` fields are returned. `true` (default) copies into a Buffer,
+   * `'view'` shares memory with the message, `false` gives an array of numbers.
+   */
+  ayBuffer?: boolean | 'view';
+  /** @deprecated DBUS_DEP0001 -- 64-bit values become BigInt in 2.0 */
+  ReturnLongjs?: boolean;
+  /** reject a message declaring more than this many bytes; default 128 MiB */
+  maxMessageSize?: number;
+  /** default timeout in ms for every call on this client; default: no timeout */
+  timeout?: number;
+}
+
+export interface DBusConnection extends EventEmitter {
+  stream: Duplex;
+  guid?: string;
+  state?: string;
+  /**
+   * Write a message. Returns false when the socket's buffer is full, following
+   * the `stream.write()` convention; wait for 'drain' before continuing.
+   */
+  message(msg: Message): boolean;
+  end(): this;
+
+  on(event: 'connect', listener: () => void): this;
+  on(event: 'message', listener: (msg: Message) => void): this;
+  on(event: 'drain', listener: () => void): this;
+  on(event: 'end', listener: () => void): this;
+  /** transport or protocol failure; the connection is destroyed after a protocol error */
+  on(event: 'error', listener: (err: Error) => void): this;
+  /** an exception thrown by one of your own message/signal listeners */
+  on(event: 'handlerError', listener: (err: Error) => void): this;
+  on(event: string, listener: (...args: any[]) => void): this;
+}
+
+export function createConnection(opts?: ConnectionOptions): DBusConnection;
+
+export interface DBusServer {
+  listen(...args: any[]): unknown;
+}
+
+export function createServer(
+  handler?: (conn: DBusConnection) => void
+): DBusServer;
+
+// ---------------------------------------------------------------------------
+// Calls
+// ---------------------------------------------------------------------------
+
+export interface CallOptions {
+  /** cancel the call; rejects with AbortError */
+  signal?: AbortSignal;
+  /** ms to wait for a reply; 0 disables. Defaults to the client's timeout */
+  timeout?: number;
+}
+
+/**
+ * Called with the reply. `err` is the raw body array until 1.0, carrying
+ * non-enumerable `message` and `dbusName` -- see docs/deprecations.md.
+ */
+export type InvokeCallback = (err: any, ...values: any[]) => void;
+
+// ---------------------------------------------------------------------------
+// Interfaces and services
+// ---------------------------------------------------------------------------
+
+/**
+ * A method as declared in an interface descriptor:
+ * [inputSignature, outputSignature, inputNames, outputNames]
+ */
+export type MethodDescriptor = [string, string, string[], string[]];
+
+/** A signal: [signature, ...argumentNames] */
+export type SignalDescriptor = string[];
+
+export interface InterfaceDescriptor {
+  name: string;
+  methods?: Record<string, MethodDescriptor>;
+  signals?: Record<string, SignalDescriptor>;
+  properties?: Record<string, string>;
+}
+
+/**
+ * A proxy for a remote interface. Members discovered by introspection are
+ * added dynamically, so they are typed loosely here; pass a shape to
+ * `getInterface<T>()` for a checked surface.
+ */
+export interface DBusInterface {
+  $name: string;
+  $parent: DBusObject;
+  $methods: Record<string, string>;
+  $properties: Record<string, { type: string; access?: string }>;
+
+  $callMethod(name: string, args: unknown[]): DBusPromise<any>;
+  $readProp(name: string): DBusPromise<any>;
+  $readProp(name: string, callback: InvokeCallback): void;
+  $writeProp(name: string, value: unknown): DBusPromise<void>;
+  $writeProp(name: string, value: unknown, callback: InvokeCallback): void;
+
+  addListener(signal: string, listener: (...args: any[]) => void): void;
+  on(signal: string, listener: (...args: any[]) => void): void;
+  removeListener(signal: string, listener: (...args: any[]) => void): void;
+  off(signal: string, listener: (...args: any[]) => void): void;
+
+  [member: string]: any;
+}
+
+export interface DBusObject {
+  name: string;
+  service: DBusService;
+  proxy: Record<string, DBusInterface>;
+  nodes?: string[];
+  as(interfaceName: string): DBusInterface;
+}
+
+export interface DBusService {
+  name: string;
+  bus: MessageBus;
+
+  getObject(path: string): DBusPromise<DBusObject>;
+  getObject(path: string, callback: (err: any, obj: DBusObject) => void): void;
+
+  getInterface<T = DBusInterface>(
+    path: string,
+    interfaceName: string
+  ): DBusPromise<T & DBusInterface>;
+  getInterface<T = DBusInterface>(
+    path: string,
+    interfaceName: string,
+    callback: (err: any, iface: T & DBusInterface) => void
+  ): void;
+}
+
+// ---------------------------------------------------------------------------
+// The bus
+// ---------------------------------------------------------------------------
+
+export interface MessageBus {
+  connection: DBusConnection;
+  serial: number;
+  cookies: Record<number, InvokeCallback>;
+  signals: EventEmitter;
+  exportedObjects: Record<string, Record<string, [InterfaceDescriptor, any]>>;
+  name?: string;
+
+  invoke<T = any>(msg: Message, options?: CallOptions): DBusPromise<T>;
+  invoke(msg: Message, callback: InvokeCallback): void;
+  invoke(msg: Message, options: CallOptions, callback: InvokeCallback): void;
+
+  invokeDbus<T = any>(msg: Message, options?: CallOptions): DBusPromise<T>;
+  invokeDbus(msg: Message, callback: InvokeCallback): void;
+  invokeDbus(
+    msg: Message,
+    options: CallOptions,
+    callback: InvokeCallback
+  ): void;
+
+  /** Build the key used for `bus.signals` events. */
+  mangle(path: string, iface: string, member: string): string;
+  mangle(msg: Message): string;
+
+  sendSignal(
+    path: string,
+    iface: string,
+    name: string,
+    signature?: string,
+    args?: unknown[]
+  ): void;
+  sendError(msg: Message, errorName: string, errorText: string): void;
+  sendReply(msg: Message, signature: string, body: unknown[]): void;
+
+  setMethodCallHandler(
+    objectPath: string,
+    iface: string,
+    member: string,
+    handler: [(...args: any[]) => any, string]
+  ): void;
+  exportInterface(obj: unknown, path: string, iface: InterfaceDescriptor): void;
+
+  getService(name: string): DBusService;
+
+  getObject(service: string, path: string): DBusPromise<DBusObject>;
+  getObject(
+    service: string,
+    path: string,
+    callback: (err: any, obj: DBusObject) => void
+  ): void;
+
+  getInterface<T = DBusInterface>(
+    service: string,
+    path: string,
+    interfaceName: string
+  ): DBusPromise<T & DBusInterface>;
+  getInterface<T = DBusInterface>(
+    service: string,
+    path: string,
+    interfaceName: string,
+    callback: (err: any, iface: T & DBusInterface) => void
+  ): void;
+
+  addMatch(match: string): DBusPromise<void>;
+  addMatch(match: string, callback: InvokeCallback): void;
+  removeMatch(match: string): DBusPromise<void>;
+  removeMatch(match: string, callback: InvokeCallback): void;
+
+  getId(): DBusPromise<string>;
+  getId(callback: (err: any, id: string) => void): void;
+
+  requestName(name: string, flags: number): DBusPromise<number>;
+  requestName(
+    name: string,
+    flags: number,
+    callback: (err: any, result: number) => void
+  ): void;
+
+  releaseName(name: string): DBusPromise<number>;
+  releaseName(name: string, callback: (err: any, result: number) => void): void;
+
+  listNames(): DBusPromise<string[]>;
+  listNames(callback: (err: any, names: string[]) => void): void;
+
+  listActivatableNames(): DBusPromise<string[]>;
+  listActivatableNames(callback: (err: any, names: string[]) => void): void;
+
+  updateActivationEnvironment(env: Record<string, string>): DBusPromise<void>;
+  updateActivationEnvironment(
+    env: Record<string, string>,
+    callback: InvokeCallback
+  ): void;
+
+  startServiceByName(name: string, flags: number): DBusPromise<number>;
+  startServiceByName(
+    name: string,
+    flags: number,
+    callback: (err: any, result: number) => void
+  ): void;
+
+  getConnectionUnixUser(name: string): DBusPromise<number>;
+  getConnectionUnixUser(
+    name: string,
+    callback: (err: any, uid: number) => void
+  ): void;
+
+  getConnectionUnixProcessId(name: string): DBusPromise<number>;
+  getConnectionUnixProcessId(
+    name: string,
+    callback: (err: any, pid: number) => void
+  ): void;
+
+  getNameOwner(name: string): DBusPromise<string>;
+  getNameOwner(name: string, callback: (err: any, owner: string) => void): void;
+
+  nameHasOwner(name: string): DBusPromise<boolean>;
+  nameHasOwner(
+    name: string,
+    callback: (err: any, hasOwner: boolean) => void
+  ): void;
+}
+
+export function createClient(opts?: ConnectionOptions): MessageBus;
+export function sessionBus(opts?: ConnectionOptions): MessageBus;
+export function systemBus(): MessageBus;

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,11 +18,13 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@types/node": "^26.1.2",
         "eslint": "^10.8.0",
         "eslint-config-prettier": "^10.1.8",
         "globals": "^17.8.0",
         "mocha": "^11.7.6",
-        "prettier": "^3.9.6"
+        "prettier": "^3.9.6",
+        "typescript": "^7.0.2"
       },
       "engines": {
         "node": ">=20.8.0"
@@ -271,6 +273,356 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.17.0",
@@ -1688,6 +2040,48 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "bin/dbus2js.js",
     "lib/*",
     "index.js",
+    "index.d.ts",
     "package.json"
   ],
   "directories": {
@@ -48,22 +49,25 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/node": "^26.1.2",
     "eslint": "^10.8.0",
     "eslint-config-prettier": "^10.1.8",
     "globals": "^17.8.0",
     "mocha": "^11.7.6",
-    "prettier": "^3.9.6"
+    "prettier": "^3.9.6",
+    "typescript": "^7.0.2"
   },
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "test": "npm run lint && npm run format:check && npm run test:raw",
+    "test": "npm run lint && npm run format:check && npm run test:types && npm run test:raw",
     "test:raw": "mocha",
     "test:integration": "node scripts/with-dbus.js -- npm run test:integration:raw",
     "test:integration:raw": "mocha --no-config --timeout 10000 test/integration/*.js",
-    "dbus:session": "node scripts/dbus-session.js"
+    "dbus:session": "node scripts/dbus-session.js",
+    "test:types": "tsc --noEmit"
   },
   "overrides": {
     "brace-expansion": "^5.0.8",
@@ -77,5 +81,6 @@
   },
   "engines": {
     "node": ">=20.8.0"
-  }
+  },
+  "types": "index.d.ts"
 }

--- a/test/types/usage.ts
+++ b/test/types/usage.ts
@@ -1,0 +1,166 @@
+// Compile-time exercise of index.d.ts. Not executed -- `npm run test:types`
+// type-checks it, so the definitions cannot drift from the API without CI
+// noticing.
+//
+// Every construct here mirrors something documented in the README.
+
+import dbus = require('../..');
+import {
+  MessageBus,
+  DBusInterface,
+  DBusError,
+  TimeoutError,
+  Variant,
+  variantValue,
+  toPlain,
+  Message
+} from '../..';
+
+async function calls() {
+  const bus: MessageBus = dbus.sessionBus({ timeout: 25000 });
+  const system: MessageBus = dbus.systemBus();
+  const client: MessageBus = dbus.createClient({ busAddress: 'unix:path=/x' });
+
+  const msg: Message = {
+    destination: 'org.freedesktop.DBus',
+    path: '/org/freedesktop/DBus',
+    interface: 'org.freedesktop.DBus',
+    member: 'GetId'
+  };
+
+  // promise form, with and without a type argument
+  const id: string = await bus.invoke<string>(msg);
+  const anything = await bus.invoke(msg);
+
+  // options
+  await bus.invoke(msg, { timeout: 5000 });
+  await bus.invoke(msg, { signal: AbortSignal.timeout(5000) });
+
+  // callback form, and options plus callback
+  bus.invoke(msg, (err, value) => void (err ?? value));
+  bus.invoke(msg, { timeout: 100 }, (err, value) => void (err ?? value));
+
+  // meta methods, both forms
+  const names: string[] = await bus.listNames();
+  const hasOwner: boolean = await bus.nameHasOwner('org.freedesktop.DBus');
+  const busId: string = await bus.getId();
+  bus.getId((err, value: string) => void (err ?? value));
+  await bus.requestName('com.example.Thing', 0);
+  await bus.addMatch("type='signal'");
+  await bus.removeMatch("type='signal'");
+
+  void [id, anything, names, hasOwner, busId, system, client];
+}
+
+async function proxies() {
+  const bus = dbus.sessionBus();
+
+  const iface = await bus
+    .getService('org.freedesktop.Notifications')
+    .getInterface(
+      '/org/freedesktop/Notifications',
+      'org.freedesktop.Notifications'
+    );
+
+  const notificationId = await iface.Notify(
+    'app',
+    0,
+    '',
+    'summary',
+    'body',
+    [],
+    {},
+    5000
+  );
+
+  // a caller can describe the remote interface for a checked surface
+  interface Player extends DBusInterface {
+    PlayPause(): Promise<void>;
+    Metadata(): Promise<unknown>;
+  }
+  const player = await bus
+    .getService('org.mpris.MediaPlayer2.vlc')
+    .getInterface<Player>(
+      '/org/mpris/MediaPlayer2',
+      'org.mpris.MediaPlayer2.Player'
+    );
+  await player.PlayPause();
+
+  const obj = await bus.getObject(
+    'org.freedesktop.DBus',
+    '/org/freedesktop/DBus'
+  );
+  const asIface: DBusInterface = obj.as('org.freedesktop.DBus');
+
+  await iface.$writeProp('Greeting', 'hi');
+  const prop = await iface.$readProp('Greeting');
+
+  void [notificationId, asIface, prop];
+}
+
+async function errors() {
+  const bus = dbus.sessionBus();
+  try {
+    await bus.invoke({ member: 'Nope' });
+  } catch (err) {
+    if (err instanceof TimeoutError) {
+      const ms: number = err.timeout;
+      void ms;
+    }
+    if (err instanceof DBusError) {
+      const name: string | undefined = err.dbusName;
+      void name;
+    }
+  }
+}
+
+function values() {
+  // reading works on either shape
+  const greeting = variantValue<string>(['s', 'hello']);
+  const props = toPlain<Record<string, unknown>>([['k', ['s', 'v']]]);
+
+  // writing
+  const v = new Variant('s', 'hello');
+  const signature: string = v.signature;
+  const value: string = v.value;
+
+  void [greeting, props, signature, value];
+}
+
+function service() {
+  const bus = dbus.sessionBus();
+  const impl = {
+    Echo(input: string) {
+      return input;
+    }
+  };
+  bus.exportInterface(impl, '/com/example/Thing', {
+    name: 'com.example.Thing',
+    methods: { Echo: ['s', 's', ['input'], ['output']] },
+    signals: { Pinged: ['s', 'payload'] },
+    properties: { Greeting: 's' }
+  });
+
+  bus.sendSignal('/com/example/Thing', 'com.example.Thing', 'Pinged', 's', [
+    'hi'
+  ]);
+
+  const key: string = bus.mangle(
+    '/com/example/Thing',
+    'com.example.Thing',
+    'Pinged'
+  );
+  bus.signals.on(key, (body: unknown[]) => void body);
+}
+
+function connections() {
+  const conn = dbus.createConnection({ busAddress: 'unix:path=/x' });
+  const writable: boolean = conn.message({ member: 'Hello', serial: 1 });
+  conn.on('drain', () => {});
+  conn.on('handlerError', (err: Error) => void err);
+  conn.on('message', (m: Message) => void m.member);
+  conn.end();
+  void writable;
+}
+
+void [calls, proxies, errors, values, service, connections];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "node16",
+    "moduleResolution": "node16",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["index.d.ts", "test/types/**/*.ts"]
+}


### PR DESCRIPTION
Fifth slice of **0.6**. Closes #276, open since 2020 and probably the single biggest reason people reach for `dbus-next` instead.

```ts
import dbus = require(dbus-native);
import { MessageBus, DBusInterface, TimeoutError } from dbus-native;

const bus: MessageBus = dbus.sessionBus({ timeout: 25000 });
const names: string[] = await bus.listNames();

interface Player extends DBusInterface {
  PlayPause(): Promise<void>;
}
const player = await bus
  .getService(org.mpris.MediaPlayer2.vlc)
  .getInterface<Player>(/org/mpris/MediaPlayer2, org.mpris.MediaPlayer2.Player);
await player.PlayPause();
```

Types ship **in the package**, not on DefinitelyTyped, so they cannot drift from a release. `index.d.ts` is in `files`, so it is actually published.

Written against the 0.6 API, so the promise surface, `CallOptions`, `DBusError`/`TimeoutError`/`AbortError`, the value helpers, and the `drain`/`handlerError` events are typed from the start rather than retrofitted.

## Two decisions worth reviewing

**A call with no callback is `DBusPromise<T>`, not `Promise<T>`.** It genuinely is a thenable — see #317 — and typing it as a `Promise` would be a lie that breaks the moment someone checks `instanceof`. The interface still gives full `then`/`catch`/`finally` and `await`, and the doc comment explains why.

**`getInterface` is generic.** Members come from introspection at runtime, so they cannot be known statically; a caller can describe the remote interface and get a checked surface instead of `any`. That is the honest ceiling until codegen (§8 of BIG_FUTURE_PLANS).

## Types nothing checks are types that rot

So this also adds `test/types/usage.ts`, a compile-only fixture exercising every documented construct, and `npm run test:types` (`tsc --noEmit`) wired into both `npm test` and the CI lint job.

And I checked the definitions actually constrain, rather than being `any` in a trenchcoat — a deliberately wrong fixture produces five distinct errors:

```
error TS2322: Type string[] is not assignable to type number.
error TS2769: ... timoeut does not exist in type InvokeCallback.
error TS2345: Argument of type number is not assignable to parameter of type string.
error TS2554: Expected 2 arguments, but got 0.
error TS2322: Type "nope" is not assignable to type "view" | boolean | undefined.
```

No runtime code changes: **267 unit + 46 integration**, unchanged.