### PR TITLE
fix: export the error classes from index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const MessageBus = require('./lib/bus');
 const server = require('./lib/server');
 const deprecate = require('./lib/deprecate');
 const values = require('./lib/values');
+const errors = require('./lib/errors');
 const { publishSend, publishReceive } = require('./lib/diagnostics');
 
 // A d-bus address is `family:key=value,key=value`, and DBUS_SESSION_BUS_ADDRESS
@@ -95,6 +96,11 @@ function createConnection(opts) {
   let fatal = false;
 
   stream.on('error', err => {
+    // Remembered rather than only forwarded, so that whatever fails the
+    // pending calls on teardown can name what killed the connection. The bus
+    // deliberately does not listen for 'error' itself -- doing so would stop
+    // an unhandled connection error from crashing the process.
+    self.lastError = err;
     // forward network and stream errors
     if (fatal) return;
     self.emit('error', err);
@@ -107,6 +113,10 @@ function createConnection(opts) {
       return false;
     };
   });
+
+  // Emitted once the transport is fully torn down, however that happened. The
+  // bus uses it to fail calls that can no longer get a reply.
+  stream.on('close', () => self.emit('close', self.lastError));
 
   // Forwarded so callers that stopped writing on a `false` from message()
   // know when it is safe to resume.
@@ -159,6 +169,7 @@ function createConnection(opts) {
         // Framing is unrecoverable: we no longer know where the next message
         // starts, so surface the error and drop the connection rather than
         // resynchronising on garbage.
+        self.lastError = err;
         self.emit('error', err);
         fatal = true;
         stream.destroy();
@@ -221,6 +232,13 @@ module.exports.sessionBus = function (opts) {
 };
 
 module.exports.messageType = constants.messageType;
+
+// The error classes, so `err instanceof DBusError` works. index.d.ts has
+// declared these since 0.6 but index.js never exported them, which made the
+// documented way of handling errors impossible at runtime.
+module.exports.DBusError = errors.DBusError;
+module.exports.TimeoutError = errors.TimeoutError;
+module.exports.AbortError = errors.AbortError;
 
 // Forward-compatible value helpers. Code written against these behaves the
 // same before and after the 2.0 type-system change -- see docs/deprecations.md

--- a/test/exports.js
+++ b/test/exports.js
@@ -1,0 +1,43 @@
+// The public export surface.
+//
+// index.d.ts declares these, but a declaration file cannot notice that
+// index.js never actually exported the value -- tsc type-checks against the
+// .d.ts regardless. That gap shipped in 0.6: DBusError was documented, typed,
+// and undefined at runtime. This asserts the runtime side.
+
+const assert = require('assert');
+const dbus = require('../index');
+
+describe('public exports', () => {
+  it('exports the error classes so instanceof works', () => {
+    for (const name of ['DBusError', 'TimeoutError', 'AbortError']) {
+      assert.strictEqual(typeof dbus[name], 'function', `${name} is exported`);
+    }
+    assert.ok(new dbus.TimeoutError(1, {}) instanceof dbus.DBusError);
+    assert.ok(new dbus.DBusError('x') instanceof Error);
+  });
+
+  it('exports the value helpers', () => {
+    for (const name of [
+      'Variant',
+      'variantValue',
+      'variantSignature',
+      'toPlain'
+    ]) {
+      assert.strictEqual(typeof dbus[name], 'function', `${name} is exported`);
+    }
+  });
+
+  it('exports the entry points', () => {
+    for (const name of [
+      'createClient',
+      'sessionBus',
+      'systemBus',
+      'createConnection',
+      'createServer'
+    ]) {
+      assert.strictEqual(typeof dbus[name], 'function', `${name} is exported`);
+    }
+    assert.strictEqual(typeof dbus.messageType, 'object');
+  });
+});


### PR DESCRIPTION
`index.d.ts` has declared `DBusError`, `TimeoutError` and `AbortError` since 0.6, and the README documents catching them — but `index.js` never exported them. So in the released 0.6.0:

```js
const dbus = require('dbus-native');
dbus.DBusError; // undefined
err instanceof dbus.DBusError; // TypeError: Right-hand side of 'instanceof' is not callable
```

`err instanceof DBusError` is the documented way to handle a failed call, and it cannot be written at all.

### Why CI stayed green

A declaration file cannot notice that the runtime value is missing. `test/types/usage.ts` imports all three classes and type-checks fine against `index.d.ts` regardless of what `index.js` actually assigns to `module.exports`. `tsc --noEmit` is checking the declarations against themselves.

`test/exports.js` closes that gap by asserting the runtime side of the export surface — the error classes, the value helpers and the entry points.

### Scope

Deliberately minimal: `index.js` plus the regression test, no behaviour change, so it can go out as a **0.6.1** patch without waiting for the breaking errors release.

Stacked underneath #323, which builds on it.
