### PR TITLE
feat: add `dbus-native lint` for the value shapes that change in 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,22 @@ const props = toPlain(getAllResult); // { Greeting: 'hello', Count: 7 }
 `toPlain()` only converts arrays this library parsed as dicts, so an `a(ss)`
 (array of two-string structs) is left as an array rather than being guessed at.
 
+To find the call sites in your own code that still read the old shapes:
+
+```shell
+npx dbus-native lint src/
+```
+
+```
+src/net.js:42  DBUS_DEP0002  variant index chain `[1][1][0]`
+    -> variantValue(), or a plain property read after 2.0
+```
+
+It reports rather than rewrites — an index chain says nothing about what the
+value is, so there is no codemod for this that would not sometimes be wrong.
+Exits non-zero when there are findings so it can gate CI; `--exit-zero` and
+`--rule` adjust that.
+
 For writing, `Variant` is accepted anywhere a `[signature, value]` pair is:
 
 ```js

--- a/RELEASE_PLAN.md
+++ b/RELEASE_PLAN.md
@@ -259,12 +259,18 @@ deserves its own guide page.
    ```sh
    npx dbus-native lint src/
    src/net.js:42  DBUS_DEP0002  variant index chain `[1][1][0]`
-                                 -> variantValue(), or `.Udi` after 2.0
+       -> variantValue(), or a plain property read after 2.0
    ```
 
    Being honest about this is important: **there is no complete codemod for
    2.0.** Anyone promising one has not thought about it. The tooling narrows
    the problem to a reviewed list of call sites.
+
+   Shipped ahead of 2.0, so the list can be worked through on a released
+   version. The dict rules are marked `(possible)` in the report rather than
+   asserted: `for (const [k, v] of xs)` is also ordinary JavaScript, and a
+   linter that cries wolf gets switched off. `Object.entries()` and the other
+   standard pair producers are excluded outright.
 
 3. **`dbus-native/compat`** for code that cannot be migrated yet:
 
@@ -349,7 +355,9 @@ Ordered by how much they unblock:
    contains the fix.
 4. **`npx dbus-native lint`** for the patterns codemods cannot safely rewrite.
    ast-grep rules are enough; this does not need to be a real ESLint plugin
-   initially.
+   initially. **Done** — built on jscodeshift rather than ast-grep, reusing the
+   plumbing the codemod already needed, so there is one dependency story for
+   both rather than two.
 5. **A migration guide per major** — `docs/migrating-to-1.md` and so on — with
    a before/after table for every changed behaviour, not prose.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -477,6 +477,20 @@ Related: [#3](https://github.com/sidorares/dbus-native/issues/3),
 "how do I deal with `a{sv}`". A documented, ergonomic dict/variant story would
 close roughly a dozen issues at once.
 
+**Our own call sites**, from `npx dbus-native lint lib index.js` — this is the
+internal half of the 2.0 change, and it is small:
+
+| site                    | reads               | what it is                             |
+| ----------------------- | ------------------- | -------------------------------------- |
+| `lib/message.js:120`    | `field[1][1][0]`    | header fields                          |
+| `lib/message.js:183`    | `field[1][1][0]`    | header fields                          |
+| `lib/stdifaces.js:148`  | `msg.body[2][1][0]` | the value argument of `Properties.Set` |
+| `lib/introspect.js:194` | `val[1][0]`         | the reply from `Properties.Get`        |
+
+Plus four `ReturnLongjs` branches in `index.js` and `lib/dbus-buffer.js`, which
+§3.2 removes. The linter finds no false positives on this codebase, which is
+the evidence that its rules are worth pointing at consumers.
+
 ### 4.2 Marshall JS objects as `a{sv}`
 
 There is a `// TODO: serialise JS objects as a{sv}` in `lib/marshall.js` and a

--- a/bin/dbus-native.js
+++ b/bin/dbus-native.js
@@ -6,6 +6,7 @@
 
 const fs = require('fs');
 const { parseArgs } = require('util');
+const path = require('path');
 const { spawnSync } = require('child_process');
 const dbus = require('../index');
 const { parseIntrospection } = require('../lib/codegen/introspection');
@@ -17,6 +18,7 @@ Commands:
   types        generate TypeScript declarations for a service
   introspect   print a service's raw introspection XML
   codemod      rewrite your source for a breaking change
+  lint         report reads of value shapes that change in 2.0
 
 Options for both:
   --service <name>   bus name, e.g. org.freedesktop.NetworkManager
@@ -37,8 +39,15 @@ Options for 'codemod':
   --dry              report what would change without writing
   Available: errors-to-error-objects  (0.7: errors became Error objects)
 
+Options for 'lint':
+  dbus-native lint <path...>
+  --rule <codes>     only these, comma separated (DBUS_DEP0001..0003)
+  --exit-zero        report findings but still exit 0
+  Exits non-zero when there are findings, so it can gate CI.
+
 Examples:
   dbus-native codemod errors-to-error-objects src/
+  dbus-native lint --rule DBUS_DEP0002 src/
 
   dbus-native types --system \\
     --service org.freedesktop.NetworkManager \\
@@ -68,6 +77,8 @@ function parse(argv) {
         module: { type: 'string', default: 'dbus-native' },
         all: { type: 'boolean', default: false },
         dry: { type: 'boolean', default: false },
+        rule: { type: 'string' },
+        'exit-zero': { type: 'boolean', default: false },
         help: { type: 'boolean', default: false }
       },
       allowPositionals: true
@@ -110,13 +121,29 @@ async function getXml(argv) {
 const CODEMODS = ['errors-to-error-objects'];
 
 /**
- * Run a shipped codemod over the user's source.
+ * How to invoke jscodeshift.
  *
- * jscodeshift is a devDependency here, not a runtime one -- a d-bus library
- * has no business putting a whole AST toolchain into every install for a
- * one-off migration. So we look for it in the consuming project first and fall
- * back to `npx`, which fetches it on demand and throws it away afterwards.
+ * It is a devDependency here, not a runtime one -- a d-bus library has no
+ * business putting a whole AST toolchain into every install for a one-off
+ * migration. So we look for it in the consuming project first and fall back to
+ * `npx`, which fetches it on demand and throws it away afterwards.
  */
+function jscodeshiftCommand(args) {
+  try {
+    return {
+      command: process.execPath,
+      commandArgs: [require.resolve('jscodeshift/bin/jscodeshift.js'), ...args]
+    };
+  } catch {
+    console.error('jscodeshift not installed locally; running it through npx');
+    return {
+      command: process.platform === 'win32' ? 'npx.cmd' : 'npx',
+      commandArgs: ['--yes', 'jscodeshift', ...args]
+    };
+  }
+}
+
+/** Run a shipped codemod over the user's source. */
 function runCodemod(name, paths, argv) {
   if (!CODEMODS.includes(name)) {
     fail(
@@ -125,27 +152,86 @@ function runCodemod(name, paths, argv) {
   }
   if (paths.length === 0) fail(`Nothing to transform.\n\n${USAGE}`);
 
-  const transform = require.resolve(`../lib/codemods/${name}`);
-  const args = ['-t', transform, '--parser', 'babel'];
+  const args = [
+    '-t',
+    require.resolve(`../lib/codemods/${name}`),
+    '--parser',
+    'babel'
+  ];
   if (argv.dry) args.push('--dry', '--print');
   args.push(...paths);
 
-  let command, commandArgs;
-  try {
-    // jscodeshift's own bin, if the project already has it.
-    command = process.execPath;
-    commandArgs = [require.resolve('jscodeshift/bin/jscodeshift.js'), ...args];
-  } catch {
-    command = process.platform === 'win32' ? 'npx.cmd' : 'npx';
-    commandArgs = ['--yes', 'jscodeshift', ...args];
-    console.error('jscodeshift not installed locally; running it through npx');
-  }
-
+  const { command, commandArgs } = jscodeshiftCommand(args);
   const { status, error } = spawnSync(command, commandArgs, {
     stdio: 'inherit'
   });
   if (error) fail(`could not run jscodeshift: ${error.message}`);
   process.exit(status === null ? 1 : status);
+}
+
+/**
+ * Report reads of the value shapes that change in 2.0.
+ *
+ * Separate from `codemod` because these are the patterns a codemod *cannot*
+ * safely rewrite: reading a variant is an index chain, and nothing in the
+ * source says what the value is. Being honest about that matters -- the
+ * tooling narrows the problem to a reviewed list of call sites, and there is
+ * no complete codemod for 2.0.
+ */
+function runLint(paths, argv) {
+  if (paths.length === 0) fail(`Nothing to lint.\n\n${USAGE}`);
+
+  const lint = require('../lib/lint/deprecated-value-shapes');
+  const args = ['-t', require.resolve('../lib/lint/deprecated-value-shapes')];
+  args.push('--parser', 'babel', '--dry', '--run-in-band');
+  if (argv.rule) args.push('--rule', argv.rule);
+  args.push(...paths);
+
+  const { command, commandArgs } = jscodeshiftCommand(args);
+  const result = spawnSync(command, commandArgs, {
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024
+  });
+  if (result.error) fail(`could not run jscodeshift: ${result.error.message}`);
+
+  const findings = [];
+  for (const line of (result.stdout || '').split('\n')) {
+    const at = line.indexOf(lint.MARKER);
+    if (at === -1) continue;
+    try {
+      findings.push(JSON.parse(line.slice(at + lint.MARKER.length)));
+    } catch {
+      // A partially flushed line is not worth failing the run over.
+    }
+  }
+
+  if (findings.length === 0) {
+    console.log('No deprecated value reads found.');
+    return process.exit(0);
+  }
+
+  findings.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line || 0);
+  for (const f of findings) {
+    // Relative, so the report stays readable from a deep checkout, and a fixed
+    // indent rather than one aligned to the path -- an absolute path pushes an
+    // aligned hint off the side of the terminal.
+    const where = `${path.relative(process.cwd(), f.file) || f.file}:${f.line}`;
+    const maybe = f.confidence === 'possible' ? ' (possible)' : '';
+    console.log(`${where}  ${f.code}  ${f.detail}${maybe}`);
+    console.log(`    -> ${f.hint}`);
+  }
+
+  const byCode = {};
+  for (const f of findings) byCode[f.code] = (byCode[f.code] || 0) + 1;
+  const summary = Object.keys(byCode)
+    .sort()
+    .map(c => `${byCode[c]} ${c}`)
+    .join(', ');
+  console.log(
+    `\n${findings.length} finding${findings.length === 1 ? '' : 's'} (${summary}). See docs/deprecations.md.`
+  );
+  // Non-zero so it can gate CI; --no-fail for a report-only run.
+  process.exit(argv['exit-zero'] ? 0 : 1);
 }
 
 function write(argv, content) {
@@ -168,6 +254,10 @@ async function main() {
 
   if (command === 'codemod') {
     return runCodemod(positionals[1], positionals.slice(2), argv);
+  }
+
+  if (command === 'lint') {
+    return runLint(positionals.slice(1), argv);
   }
 
   if (!['types', 'introspect'].includes(command)) {

--- a/docs/api.md
+++ b/docs/api.md
@@ -523,13 +523,21 @@ npx dbus-native types --system \
 
 npx dbus-native introspect --service org.example --path /org/example
 npx dbus-native codemod errors-to-error-objects --dry src/
+npx dbus-native lint src/
 ```
 
-| command      |                                           |
-| ------------ | ----------------------------------------- |
-| `types`      | TypeScript declarations for a service     |
-| `introspect` | a service's raw introspection XML         |
-| `codemod`    | rewrite your source for a breaking change |
+| command      |                                                     |
+| ------------ | --------------------------------------------------- |
+| `types`      | TypeScript declarations for a service               |
+| `introspect` | a service's raw introspection XML                   |
+| `codemod`    | rewrite your source for a breaking change           |
+| `lint`       | report reads of the value shapes that change in 2.0 |
+
+`lint` exits non-zero when there are findings, so it can gate CI. `--exit-zero`
+reports without failing; `--rule DBUS_DEP0002` selects individual codes. It
+never rewrites — reading a variant is an index chain and nothing in the source
+says what the value is, so it narrows the problem to a reviewed list rather
+than guessing. Findings marked `(possible)` are heuristic.
 
 `dbus2js` still exists and is **deprecated** (`DBUS_DEP0005`).
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -17,9 +17,24 @@ Codes marked **documentation** describe a shape change rather than an API call.
 They are deliberately _not_ runtime warnings — the warning would have to fire
 inside the parser when the value is read, so the stack trace would point at
 this library rather than at the line in your code that unpacks the value. It
-would tell you that you are affected without telling you where. A lint rule
-that flags the access patterns is planned for that; until then the migration is
-to route reads through the helpers below.
+would tell you that you are affected without telling you where.
+
+Finding those call sites is the linter's job:
+
+```sh
+npx dbus-native lint src/
+```
+
+```
+src/net.js:42  DBUS_DEP0002  variant index chain `[1][1][0]`
+    -> variantValue(), or a plain property read after 2.0
+```
+
+It reports and never rewrites, because reading a variant is an index chain and
+nothing in the source says what the value is — see
+[DBUS_DEP0002](#dbus_dep0002). It exits non-zero when there are findings, so it
+can gate CI; `--exit-zero` reports without failing, and `--rule` selects
+individual codes.
 
 ---
 

--- a/lib/lint/deprecated-value-shapes.js
+++ b/lib/lint/deprecated-value-shapes.js
@@ -1,0 +1,194 @@
+// jscodeshift transform: find reads of the value shapes that change in 2.0.
+//
+// This is a *linter*, not a codemod -- it never modifies a file. Reading a
+// variant is `result[1][1][0]`, an index chain a codemod cannot safely rewrite
+// because it has no idea what the value is. So we flag rather than transform,
+// and narrow the problem to a reviewed list of call sites.
+//
+// Findings go to stdout as one JSON line each, prefixed with a marker, because
+// jscodeshift owns the rest of the output and runs transforms in worker
+// processes. bin/dbus-native.js picks them back out and formats the report.
+//
+// See docs/deprecations.md and RELEASE_PLAN.md.
+
+const MARKER = '##DBUS_LINT##';
+
+// `Object.entries(x)` and friends produce the same `[key, value]` pairs a
+// d-bus dict does. Iterating one of those is ordinary JavaScript, not a
+// deprecated read, so the pair rule steps around them.
+const PAIR_SOURCES = new Set([
+  'entries',
+  'keys',
+  'values',
+  'items',
+  'getOwnPropertyEntries'
+]);
+
+const RULES = {
+  DBUS_DEP0001: 'ReturnLongjs',
+  DBUS_DEP0002: 'variant index chain',
+  DBUS_DEP0003: 'dict read as an array of pairs'
+};
+
+function report(fileInfo, node, code, detail, hint, confidence) {
+  process.stdout.write(
+    `${MARKER}${JSON.stringify({
+      file: fileInfo.path,
+      line: node.loc ? node.loc.start.line : 0,
+      column: node.loc ? node.loc.start.column + 1 : 0,
+      code,
+      rule: RULES[code],
+      detail,
+      hint,
+      confidence
+    })}\n`
+  );
+}
+
+// Render an index chain back to something recognisable, e.g. `[1][1][0]`.
+function indexChain(node) {
+  const parts = [];
+  let cur = node;
+  while (
+    cur &&
+    cur.type === 'MemberExpression' &&
+    cur.computed &&
+    cur.property &&
+    cur.property.type === 'Literal' &&
+    typeof cur.property.value === 'number'
+  ) {
+    parts.unshift(`[${cur.property.value}]`);
+    cur = cur.object;
+  }
+  return parts.join('');
+}
+
+const isIndex = (node, value) =>
+  node &&
+  node.type === 'MemberExpression' &&
+  node.computed &&
+  node.property &&
+  node.property.type === 'Literal' &&
+  node.property.value === value;
+
+module.exports = function transform(fileInfo, api, options) {
+  const j = api.jscodeshift;
+  const root = j(fileInfo.source);
+  const only = options && options.rule ? String(options.rule).split(',') : null;
+  const wanted = code => !only || only.includes(code);
+
+  // --- DBUS_DEP0002: `x[1][0]`, the variant unwrap -------------------------
+  //
+  // A variant unmarshals as [signatureTree, [value]], so the value is at
+  // [1][0]. Any `[0]` applied directly to a `[1]` is that shape.
+  if (wanted('DBUS_DEP0002')) {
+    root.find(j.MemberExpression, { computed: true }).forEach(path => {
+      const node = path.node;
+      if (!isIndex(node, 0) || !isIndex(node.object, 1)) return;
+      // Report the outermost chain only, so `a[1][1][0]` is one finding.
+      if (isIndex(path.parent.node, 0) && path.parent.node.object === node)
+        return;
+      report(
+        fileInfo,
+        node,
+        'DBUS_DEP0002',
+        `variant index chain \`${indexChain(node)}\``,
+        'variantValue(), or a plain property read after 2.0',
+        'high'
+      );
+    });
+  }
+
+  // --- DBUS_DEP0003: iterating a dict as [key, value] pairs ----------------
+  //
+  // Lower confidence by nature: `for (const [k, v] of Object.entries(o))` is
+  // the same syntax and is not affected. We exclude the standard producers of
+  // pairs and say so in the report, because a linter that cries wolf gets
+  // switched off.
+  if (wanted('DBUS_DEP0003')) {
+    const fromStandardPairSource = right => {
+      if (!right) return false;
+      if (right.type === 'CallExpression') {
+        const callee = right.callee;
+        if (
+          callee &&
+          callee.type === 'MemberExpression' &&
+          !callee.computed &&
+          callee.property.type === 'Identifier' &&
+          PAIR_SOURCES.has(callee.property.name)
+        )
+          return true;
+      }
+      return false;
+    };
+
+    root.find(j.ForOfStatement).forEach(path => {
+      const left = path.node.left;
+      const decl =
+        left.type === 'VariableDeclaration' ? left.declarations[0].id : left;
+      if (!decl || decl.type !== 'ArrayPattern') return;
+      if (decl.elements.length !== 2) return;
+      if (fromStandardPairSource(path.node.right)) return;
+      report(
+        fileInfo,
+        path.node,
+        'DBUS_DEP0003',
+        'iterating `[key, value]` pairs',
+        'toPlain(), or read it as an object after 2.0',
+        'possible'
+      );
+    });
+
+    // `dict.find(([key]) => key === 'Udi')` -- the other common pair idiom.
+    root
+      .find(j.CallExpression, {
+        callee: { type: 'MemberExpression', property: { name: 'find' } }
+      })
+      .forEach(path => {
+        const [fn] = path.node.arguments;
+        if (
+          !fn ||
+          (fn.type !== 'ArrowFunctionExpression' &&
+            fn.type !== 'FunctionExpression')
+        )
+          return;
+        const [param] = fn.params;
+        if (!param || param.type !== 'ArrayPattern') return;
+        report(
+          fileInfo,
+          path.node,
+          'DBUS_DEP0003',
+          'searching `[key, value]` pairs',
+          'toPlain(), then read the property directly',
+          'possible'
+        );
+      });
+  }
+
+  // --- DBUS_DEP0001: the ReturnLongjs option -------------------------------
+  if (wanted('DBUS_DEP0001')) {
+    root.find(j.Identifier, { name: 'ReturnLongjs' }).forEach(path => {
+      // Only where it is used as an option, not in a string or a comment.
+      const parent = path.parent.node;
+      const isKey = parent.type === 'Property' && parent.key === path.node;
+      const isProp =
+        parent.type === 'MemberExpression' && parent.property === path.node;
+      if (!isKey && !isProp) return;
+      report(
+        fileInfo,
+        path.node,
+        'DBUS_DEP0001',
+        '`ReturnLongjs` option',
+        '64-bit values become native BigInt in 2.0; plan for the TypeError',
+        'high'
+      );
+    });
+  }
+
+  // A linter never rewrites.
+  return null;
+};
+
+module.exports.parser = 'babel';
+module.exports.MARKER = MARKER;
+module.exports.RULES = RULES;

--- a/test/lint.js
+++ b/test/lint.js
@@ -1,0 +1,195 @@
+// Fixtures for the deprecated-value-shapes linter.
+//
+// The rules that matter most here are the negative ones. A linter that flags
+// `for (const [k, v] of Object.entries(o))` -- ordinary JavaScript that 2.0
+// does not touch -- gets switched off, and then it protects nobody.
+
+const { describe, it } = require('node:test');
+const assert = require('assert');
+const jscodeshift = require('jscodeshift');
+const lint = require('../lib/lint/deprecated-value-shapes');
+
+// The transform reports on stdout so its findings survive jscodeshift's worker
+// processes; capture them rather than letting them into the test output.
+function run(source, options = {}) {
+  const findings = [];
+  const original = process.stdout.write;
+  process.stdout.write = chunk => {
+    const line = String(chunk);
+    if (line.startsWith(lint.MARKER)) {
+      findings.push(JSON.parse(line.slice(lint.MARKER.length)));
+      return true;
+    }
+    return original.call(process.stdout, chunk);
+  };
+  let result;
+  try {
+    const j = jscodeshift.withParser('babel');
+    result = lint(
+      { path: 'input.js', source },
+      { jscodeshift: j, j, stats: () => {} },
+      options
+    );
+  } finally {
+    process.stdout.write = original;
+  }
+  return { findings, result };
+}
+
+const codes = findings => findings.map(f => f.code).sort();
+
+describe('lint: DBUS_DEP0002, variant index chains', () => {
+  it('flags the variant unwrap', () => {
+    const { findings } = run('const v = entry[1][0];', {
+      rule: 'DBUS_DEP0002'
+    });
+    assert.strictEqual(findings.length, 1);
+    assert.strictEqual(findings[0].code, 'DBUS_DEP0002');
+    assert.match(findings[0].detail, /\[1\]\[0\]/);
+    assert.strictEqual(findings[0].confidence, 'high');
+  });
+
+  it('reports a longer chain once, with the whole chain', () => {
+    // `dict.find(...)[1][1][0]` is one mistake, not two.
+    const { findings } = run(
+      "const udi = dict.find(([k]) => k === 'Udi')[1][1][0];",
+      { rule: 'DBUS_DEP0002' }
+    );
+    assert.strictEqual(findings.length, 1);
+    assert.match(findings[0].detail, /\[1\]\[1\]\[0\]/);
+  });
+
+  it('reports the line it is on', () => {
+    const { findings } = run('\n\nconst v = entry[1][0];', {
+      rule: 'DBUS_DEP0002'
+    });
+    assert.strictEqual(findings[0].line, 3);
+  });
+
+  it('leaves an unrelated index alone', () => {
+    // `[0][1]` is not the variant shape, and neither is a plain `[0]`.
+    const { findings } = run(
+      'const a = xs[0]; const b = xs[0][1]; const c = xs[2][0];',
+      { rule: 'DBUS_DEP0002' }
+    );
+    assert.deepStrictEqual(findings, []);
+  });
+
+  it('leaves a non-numeric index alone', () => {
+    const { findings } = run('const v = entry[k][0];', {
+      rule: 'DBUS_DEP0002'
+    });
+    assert.deepStrictEqual(findings, []);
+  });
+});
+
+describe('lint: DBUS_DEP0003, dicts read as pairs', () => {
+  it('flags iterating pairs', () => {
+    const { findings } = run('for (const [k, v] of props) use(k, v);', {
+      rule: 'DBUS_DEP0003'
+    });
+    assert.strictEqual(findings.length, 1);
+    assert.strictEqual(findings[0].confidence, 'possible');
+  });
+
+  it('flags searching pairs', () => {
+    const { findings } = run("dict.find(([key]) => key === 'Udi');", {
+      rule: 'DBUS_DEP0003'
+    });
+    assert.strictEqual(findings.length, 1);
+    assert.match(findings[0].detail, /searching/);
+  });
+
+  // The whole point of the exclusion list.
+  it('does not flag Object.entries', () => {
+    const { findings } = run(
+      'for (const [k, v] of Object.entries(obj)) use(k, v);',
+      { rule: 'DBUS_DEP0003' }
+    );
+    assert.deepStrictEqual(findings, []);
+  });
+
+  it('does not flag a Map or an iterator helper', () => {
+    for (const src of [
+      'for (const [k, v] of map.entries()) use(k, v);',
+      'for (const [k, v] of thing.values()) use(k, v);'
+    ]) {
+      const { findings } = run(src, { rule: 'DBUS_DEP0003' });
+      assert.deepStrictEqual(findings, [], src);
+    }
+  });
+
+  it('does not flag destructuring of a different arity', () => {
+    const { findings } = run('for (const [a, b, c] of rows) use(a, b, c);', {
+      rule: 'DBUS_DEP0003'
+    });
+    assert.deepStrictEqual(findings, []);
+  });
+
+  it('does not flag find() with an ordinary parameter', () => {
+    const { findings } = run('xs.find(x => x.id === 3);', {
+      rule: 'DBUS_DEP0003'
+    });
+    assert.deepStrictEqual(findings, []);
+  });
+});
+
+describe('lint: DBUS_DEP0001, ReturnLongjs', () => {
+  it('flags the option', () => {
+    const { findings } = run(
+      'const bus = dbus.sessionBus({ ReturnLongjs: true });'
+    );
+    assert.ok(findings.some(f => f.code === 'DBUS_DEP0001'));
+  });
+
+  it('does not flag the name in a string', () => {
+    const { findings } = run("const s = 'ReturnLongjs';", {
+      rule: 'DBUS_DEP0001'
+    });
+    assert.deepStrictEqual(findings, []);
+  });
+});
+
+describe('lint: behaviour', () => {
+  it('never modifies the source', () => {
+    // It is a linter. Returning anything but null would make jscodeshift
+    // rewrite the file.
+    const { result } = run('const v = entry[1][0];');
+    assert.strictEqual(result, null);
+  });
+
+  it('reports the forward-compatible helper as the fix', () => {
+    const { findings } = run('const v = entry[1][0];');
+    assert.match(findings[0].hint, /variantValue/);
+  });
+
+  it('says nothing about code already using the helpers', () => {
+    const { findings } = run(
+      `const { variantValue, toPlain } = require('dbus-native');
+       const udi = variantValue(entry);
+       const props = toPlain(dict);`
+    );
+    assert.deepStrictEqual(findings, []);
+  });
+
+  it('runs every rule when none is selected', () => {
+    const { findings } = run(
+      `const bus = dbus.sessionBus({ ReturnLongjs: true });
+       const v = entry[1][0];
+       for (const [k, x] of props) use(k, x);`
+    );
+    assert.deepStrictEqual(codes(findings), [
+      'DBUS_DEP0001',
+      'DBUS_DEP0002',
+      'DBUS_DEP0003'
+    ]);
+  });
+
+  it('honours a comma-separated rule filter', () => {
+    const src = `const bus = dbus.sessionBus({ ReturnLongjs: true });
+       const v = entry[1][0];
+       for (const [k, x] of props) use(k, x);`;
+    const { findings } = run(src, { rule: 'DBUS_DEP0001,DBUS_DEP0002' });
+    assert.deepStrictEqual(codes(findings), ['DBUS_DEP0001', 'DBUS_DEP0002']);
+  });
+});


### PR DESCRIPTION
The last item on [RELEASE_PLAN's machinery list](https://github.com/sidorares/dbus-native/blob/master/RELEASE_PLAN.md#machinery-to-build-first), and the mitigation for the risk that list exists to manage:

> **The 0.6 accessors go unused.** They only pay off if people adopt them […] If 0.6 lands quietly, 2.0 hurts.

Nothing so far told anyone *where* their affected call sites were.

```sh
npx dbus-native lint src/
```

```
src/net.js:42  DBUS_DEP0002  variant index chain `[1][1][0]`
    -> variantValue(), or a plain property read after 2.0
src/net.js:58  DBUS_DEP0003  iterating `[key, value]` pairs (possible)
    -> toPlain(), or read it as an object after 2.0

2 findings (1 DBUS_DEP0002, 1 DBUS_DEP0003). See docs/deprecations.md.
```

Additive — nothing existing changes behaviour.

### It reports, it does not rewrite

Reading a variant is `result[1][1][0]`: an index chain that says nothing about what the value is. There is no codemod for that which would not sometimes be wrong in a way the author never notices — so this narrows the problem to a reviewed list instead of guessing. That is the plan's position too ("there is no complete codemod for 2.0. Anyone promising one has not thought about it").

Exits non-zero when there are findings so it can gate CI; `--exit-zero` reports without failing and `--rule DBUS_DEP0002` selects individual codes.

### Confidence is part of the output

| rule | what | confidence |
| --- | --- | --- |
| `DBUS_DEP0002` | variant index chains — `x[1][0]` | high |
| `DBUS_DEP0001` | the `ReturnLongjs` option | high |
| `DBUS_DEP0003` | dicts read as `[key, value]` pairs | **`(possible)`** |

`DBUS_DEP0003` is inherently heuristic — `for (const [k, v] of xs)` is also ordinary JavaScript. It excludes `Object.entries()` and the other standard pair producers outright, and everything it does report is labelled `(possible)`. **A linter that cries wolf gets switched off, and then it protects nobody**, so most of the test suite is the negative cases.

### On jscodeshift instead of ast-grep

The plan suggested ast-grep. Using jscodeshift instead means the codemod and the linter share one dependency story rather than two — including the same devDependency-plus-`npx` arrangement, since neither belongs in a d-bus library's runtime tree.

### Dogfooded

Run against this repo, it finds the four internal variant reads and the four `ReturnLongjs` branches, with **no false positives**:

| site | reads | what it is |
| --- | --- | --- |
| `lib/message.js:120`, `:183` | `field[1][1][0]` | header fields |
| `lib/stdifaces.js:148` | `msg.body[2][1][0]` | the value argument of `Properties.Set` |
| `lib/introspect.js:194` | `val[1][0]` | the reply from `Properties.Get` |

`stdifaces.js:148` even carries a comment spelling out the `[signatureTree, [value]]` shape, which is about as good a confirmation as a rule can get. Those sites are now tabulated in ROADMAP §4.1 as the internal half of the 2.0 change — it turns out to be small.

The repo's own CI does not run the linter: this library *is* the parser, so it reads the classic shapes on purpose and always would.

### Verification

- 335 unit + 61 integration tests green on Node 20 and 26 (18 new lint tests, most of them negative cases).
- CLI exercised end to end: report formatting, `--rule`, `--exit-zero`, a clean tree, and long absolute paths.
- `--no-fail` was the first spelling; it is `--exit-zero` because `parseArgs` only gained `allowNegative` in Node 20.16, above this package's 20.8 floor.
