### PR TITLE
feat: opt-in BigInt for the 64-bit types

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,15 @@ options:
     you hold the byte array — a 4 byte `ay` taken from a 4 MB message keeps all
     4 MB alive. Only use it if you consume the value and drop it promptly.
   - `false` returns a plain array of numbers.
-- ReturnLongjs - boolean (default:false): if true 64 bit dbus fields (x/t) are read out as Long.js objects, otherwise they are converted to numbers (which should be good up to 53 bits)
+- returnBigInt - boolean (default:false): if true 64 bit dbus fields (x/t) are read
+  out as native `bigint`, which covers the whole range exactly. This is what they
+  become by default in 2.0, so opting in now means nothing changes then. Wins over
+  `ReturnLongjs` if both are set.
+- ReturnLongjs - boolean (default:false): **deprecated** (`DBUS_DEP0001`). If true
+  64 bit dbus fields (x/t) are read out as Long.js objects, otherwise they are
+  converted to numbers (which should be good up to 53 bits). The capital R is a
+  historical accident — it is the only PascalCase option in the API, and fixing
+  it would break the callers who set it.
 - ( TODO: add/document option to use address from X11 session )
 
 connection has only one method, `message(msg)`
@@ -447,16 +455,43 @@ rest rather than guessing. See
 [`dbus-native/compat`](docs/migrating-to-0.7.md#the-escape-hatch) if you need the
 old shape while you migrate.
 
-### Note on INT64 'x' and UINT64 't'
+### 64-bit values: INT64 'x' and UINT64 't'
 
-Long.js is used for 64 Bit support. https://github.com/dcodeIO/long.js
-The following javascript types can be marshalled into 64 bit dbus fields:
+By default these are unmarshalled into a `number`, which **loses precision
+above 2⁵³** — `9223372036854775807` comes back as `9223372036854776000`. Ask
+for `bigint` and you get the whole range, exactly:
 
-- typeof 'number' up to 53bits
-- typeof 'string' (consisting of decimal digits with no separators or '0x' prefixed hexadecimal) up to full 64bit range
-- Long.js objects (or object with compatible properties)
+```js
+const bus = dbus.sessionBus({ returnBigInt: true });
+const size = await disk.Size(); // 2000398934016n
+```
 
-By default 64 bit dbus fields are unmarshalled into a 'number' (with precision loss beyond 53 bits). Use {ReturnLongjs:true} option to return the actual Long.js object and preserve the entire 64 bits.
+This is what 64-bit values become **by default in 2.0**, so opting in now means
+nothing changes then. It is per connection, so services and clients can be
+migrated one at a time — though note a service reads its _arguments_ through
+the same parser, so it needs the option too if it handles large 64-bit inputs.
+
+`bigint` is not a drop-in for `number`, and the failure mode is a `TypeError`
+in production rather than a subtly wrong value. Plan for it:
+
+```js
+size + 1; // TypeError: Cannot mix BigInt and other types
+JSON.stringify({ size }); // TypeError: Do not know how to serialize a BigInt
+size > 100; // fine, comparisons work
+Number(size); // fine, if you accept the precision loss you already had
+```
+
+These can be **written** to a 64-bit field, whatever the read option:
+
+- `bigint`, over the full range
+- `number`, up to 53 bits
+- `string`, decimal or `0x`-prefixed hex, over the full range
+- Long.js objects, or anything with compatible `low`/`high`/`unsigned`
+
+`{ ReturnLongjs: true }` still returns [Long.js](https://github.com/dcodeIO/long.js)
+objects and is **deprecated** (`DBUS_DEP0001`); `returnBigInt` wins if both are
+set. Dropping Long.js also removes the ARMv6 crash that made downstream forks
+vendor their own copy.
 
 Development
 -----------

--- a/RELEASE_PLAN.md
+++ b/RELEASE_PLAN.md
@@ -21,7 +21,7 @@ Two tracks, one package, no new npm name.
 
 The second track is the departure from "add alongside forever". The reason is
 the flag-sprawl failure mode: `ayBuffer: true|false|'view'`, `ReturnLongjs`,
-plus a hypothetical `ReturnBigInt` and `variants: 'plain'|'tree'` gives a
+plus a hypothetical `returnBigInt` and `variants: 'plain'|'tree'` gives a
 combinatorial test matrix and documentation that has to explain the wrong way
 first. A deliberate break, well supported, is cheaper for everyone than
 permanent duality.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -423,6 +423,30 @@ Plan: read `x`/`t` with `readBigInt64LE`/`readBigUInt64LE`; accept
 return type behind an option (`ReturnBigInt`) for one minor release alongside
 the existing `ReturnLongjs`, then flip the default in 0.7 and drop `long`.
 
+**Half done.** The option, the BigInt read path and `bigint` on marshall are
+all in — see [docs/deprecations.md](./docs/deprecations.md#dbus_dep0001).
+
+It shipped as **`returnBigInt`**, not `ReturnBigInt` as proposed above. Every
+other option in the API is lowercase-first camelCase; `ReturnLongjs` is the
+sole outlier and only keeps its capital R because callers already set it.
+Copying it would have doubled a historical accident rather than leaving it
+behind.
+What remains is flipping the default and dropping `long`, which is a break and
+belongs in 2.0 with the rest of the type-system change. The gap is deliberate:
+`bigint` is not a drop-in for `number` and the failure mode is a `TypeError` in
+production, so it earns a release of opt-in first.
+
+Two things the implementation turned up:
+
+- **A service needs the option too.** It reads its own arguments through the
+  same parser, so a service without it receives a large `x` as a lossy
+  `number` — and then fails the 53-bit check when it tries to send that back.
+  Loud, at least, rather than silently truncating.
+- **`JSON.stringify` throws on a BigInt**, so three of the marshaller's error
+  messages used to replace the error they were describing with
+  `TypeError: Do not know how to serialize a BigInt`. Fixed alongside; worth
+  remembering wherever else a diagnostic renders user values.
+
 ### 3.3 TypeScript declarations
 
 **Issue:** [#276](https://github.com/sidorares/dbus-native/issues/276)

--- a/docs/api.md
+++ b/docs/api.md
@@ -58,6 +58,7 @@ all three take the same options.
 | `timeout`        | `number`                  | none                                            | default timeout in ms for every call on this client            |
 | `ayBuffer`       | `true \| false \| 'view'` | `true`                                          | how `ay` comes back — see [Values](#values-and-types)          |
 | `maxMessageSize` | `number`                  | 128 MiB                                         | reject a message declaring more than this                      |
+| `returnBigInt`   | `boolean`                 | `false`                                         | read `x`/`t` as native `bigint`, exactly — the 2.0 default     |
 | `ReturnLongjs`   | `boolean`                 | `false`                                         | **deprecated** (`DBUS_DEP0001`) — 64-bit as Long.js            |
 
 Address forms understood by `busAddress`: `unix:path=…`, `unix:abstract=…`,
@@ -373,22 +374,22 @@ re-thrown asynchronously, matching Node's default for a throwing listener.
 
 ### Type mapping
 
-| D-Bus          | code    | JavaScript                                                 |
-| -------------- | ------- | ---------------------------------------------------------- |
-| byte           | `y`     | `number`                                                   |
-| boolean        | `b`     | `boolean`                                                  |
-| int16 / uint16 | `n` `q` | `number`                                                   |
-| int32 / uint32 | `i` `u` | `number`                                                   |
-| int64 / uint64 | `x` `t` | `number`, lossy above 2⁵³ — or Long.js with `ReturnLongjs` |
-| double         | `d`     | `number`                                                   |
-| string         | `s`     | `string`                                                   |
-| object path    | `o`     | `string`                                                   |
-| signature      | `g`     | `string`                                                   |
-| array          | `a`     | `Array`                                                    |
-| byte array     | `ay`    | `Buffer` — see `ayBuffer`                                  |
-| struct         | `()`    | `Array`                                                    |
-| dict           | `a{}`   | `Array` of `[key, value]` pairs                            |
-| variant        | `v`     | `[parsedSignature, [value]]`                               |
+| D-Bus          | code    | JavaScript                                                                               |
+| -------------- | ------- | ---------------------------------------------------------------------------------------- |
+| byte           | `y`     | `number`                                                                                 |
+| boolean        | `b`     | `boolean`                                                                                |
+| int16 / uint16 | `n` `q` | `number`                                                                                 |
+| int32 / uint32 | `i` `u` | `number`                                                                                 |
+| int64 / uint64 | `x` `t` | `number`, lossy above 2⁵³ — `bigint` with `returnBigInt`, or Long.js with `ReturnLongjs` |
+| double         | `d`     | `number`                                                                                 |
+| string         | `s`     | `string`                                                                                 |
+| object path    | `o`     | `string`                                                                                 |
+| signature      | `g`     | `string`                                                                                 |
+| array          | `a`     | `Array`                                                                                  |
+| byte array     | `ay`    | `Buffer` — see `ayBuffer`                                                                |
+| struct         | `()`    | `Array`                                                                                  |
+| dict           | `a{}`   | `Array` of `[key, value]` pairs                                                          |
+| variant        | `v`     | `[parsedSignature, [value]]`                                                             |
 
 `h` (UNIX_FD) is not supported.
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -47,18 +47,30 @@ individual codes.
 In **2.0** they become native `BigInt`, which represents the full 64-bit range
 with no dependency and no option.
 
+**You can have that now**, on a released version, with `returnBigInt: true` —
+the same values 2.0 returns by default, so a call site migrated today needs no
+change then:
+
 ```js
 // deprecated
 const bus = dbus.sessionBus({ ReturnLongjs: true });
-const size = value.toNumber();
+const size = value.toNumber(); // lossy above 2^53
 
-// 2.0
-const size = await disk.props.Size; // 2000398934016n
+// available now, and the default in 2.0
+const bus = dbus.sessionBus({ returnBigInt: true });
+const size = await disk.Size(); // 2000398934016n
 ```
 
+`returnBigInt` wins if both options are set, and writing a `bigint` is accepted
+whatever the read option — so a service and its clients can move separately.
+Note a service reads its _arguments_ through the same parser, so it needs the
+option too if it handles large 64-bit inputs.
+
 `BigInt` is not a drop-in for `number`: `size + 1` and `JSON.stringify({ size })`
-both throw. Plan for that rather than discovering it in production — there will
-be a dedicated migration guide.
+both throw. That is the whole reason this is opt-in for a release before it
+becomes the default — the failure mode is a `TypeError` in production rather
+than a subtly wrong value, so it is better found deliberately than on upgrade
+day.
 
 ---
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -178,7 +178,21 @@ export interface ConnectionOptions {
    * `'view'` shares memory with the message, `false` gives an array of numbers.
    */
   ayBuffer?: boolean | 'view';
-  /** @deprecated DBUS_DEP0001 -- 64-bit values become BigInt in 2.0 */
+  /**
+   * Read 64-bit values (`x`, `t`) as native `bigint`, exactly, instead of a
+   * `number` that loses precision above 2^53. This is what they become by
+   * default in 2.0 — opting in now means no change then.
+   *
+   * Wins over `ReturnLongjs` if both are set. Writing a `bigint` is accepted
+   * regardless of this option.
+   */
+  returnBigInt?: boolean;
+  /**
+   * @deprecated DBUS_DEP0001 -- 64-bit values become BigInt in 2.0; use
+   * `returnBigInt`. Note the capital R: this one option predates the rest and
+   * is the only PascalCase name in the API. It cannot be corrected without
+   * breaking the callers who set it.
+   */
   ReturnLongjs?: boolean;
   /** reject a message declaring more than this many bytes; default 128 MiB */
   maxMessageSize?: number;

--- a/lib/dbus-buffer.js
+++ b/lib/dbus-buffer.js
@@ -3,7 +3,11 @@ const constants = require('./constants');
 const parseSignature = require('./signature');
 const { VARIANT, DICT, tag } = require('./values');
 
-const DEFAULT_OPTIONS = { ayBuffer: true, ReturnLongjs: false };
+const DEFAULT_OPTIONS = {
+  ayBuffer: true,
+  ReturnLongjs: false,
+  returnBigInt: false
+};
 
 // Buffer + position + global start position ( used in alignment )
 //
@@ -197,6 +201,22 @@ DBusBuffer.prototype.readLong = function readLong(unsigned) {
     : Long.fromBits(second, first, unsigned);
 };
 
+// The same 64 bits as readLong, as a native BigInt.
+//
+// Read straight from the buffer rather than composing two 32-bit words: Node
+// has accessors for exactly this, and going through readInt32 twice would mean
+// reassembling a value the platform can already produce exactly.
+DBusBuffer.prototype.readBigInt = function readBigInt(unsigned) {
+  this.align(3);
+  const buf = this.buffer;
+  const at = this.pos;
+  this.pos += 8;
+  if (unsigned) {
+    return this.le ? buf.readBigUInt64LE(at) : buf.readBigUInt64BE(at);
+  }
+  return this.le ? buf.readBigInt64LE(at) : buf.readBigInt64BE(at);
+};
+
 DBusBuffer.prototype.readSimpleType = function readSimpleType(t) {
   let data, len;
   switch (t) {
@@ -224,13 +244,19 @@ DBusBuffer.prototype.readSimpleType = function readSimpleType(t) {
     // TODO: validate object path here
     //if (t === 'o' && !isValidObjectPath(str))
     //  throw new Error('string is not a valid object path'));
+    // 64-bit. `returnBigInt` is the forward-compatible option and wins over
+    // `ReturnLongjs` when both are set: BigInt is what these become in 2.0,
+    // and silently preferring the deprecated one would be the wrong default
+    // for someone who has asked for both while migrating.
     case 'x':
       //signed
+      if (this.options.returnBigInt) return this.readBigInt(false);
       data = this.readLong(false);
       if (this.options.ReturnLongjs) return data;
       return data.toNumber(); // convert to number (good up to 53 bits)
     case 't':
       //unsigned
+      if (this.options.returnBigInt) return this.readBigInt(true);
       data = this.readLong(true);
       if (this.options.ReturnLongjs) return data;
       return data.toNumber(); // convert to number (good up to 53 bits)

--- a/lib/marshall.js
+++ b/lib/marshall.js
@@ -11,11 +11,28 @@ const ALIGN_8 = new Set(['x', 't', 'd', '{', '(', 'r']);
 
 const STRING_TYPES = new Set(['g', 'o', 's']);
 
+// JSON.stringify throws on a BigInt, so building a diagnostic out of a body
+// that contains one used to replace the real error -- "does not match message
+// signature" became "Do not know how to serialize a BigInt", which says
+// nothing about the actual problem. 64-bit values are exactly the case these
+// messages need to describe, so they render them here instead.
+function describe(value) {
+  try {
+    return JSON.stringify(value, (_key, v) =>
+      typeof v === 'bigint' ? `${v}n` : v
+    );
+  } catch {
+    // Circular, or anything else JSON dislikes: the diagnostic must not become
+    // the failure.
+    return String(value);
+  }
+}
+
 module.exports = function marshall(signature, data, offset = 0) {
   const tree = parseSignature(signature);
   if (!Array.isArray(data) || data.length !== tree.length) {
     throw new Error(
-      `message body does not match message signature. Body:${JSON.stringify(
+      `message body does not match message signature. Body:${describe(
         data
       )}, signature:${signature}`
     );
@@ -90,7 +107,7 @@ function writeArray(writer, ele, data) {
   } else {
     if (!Array.isArray(data) && typeof data?.length !== 'number') {
       throw new Error(
-        `Expected an array for signature 'a${child.type}', got ${JSON.stringify(data)}`
+        `Expected an array for signature 'a${child.type}', got ${describe(data)}`
       );
     }
     for (let i = 0; i < data.length; ++i) write(writer, child, data[i]);
@@ -110,7 +127,7 @@ function writeSimple(writer, type, data) {
   if (Buffer.isBuffer(data)) data = data.toString(); // encoding?
   if (STRING_TYPES.has(type) && typeof data !== 'string') {
     throw new Error(
-      `Expected string or buffer argument, got ${JSON.stringify(
+      `Expected string or buffer argument, got ${describe(
         data
       )} of type '${type}'`
     );

--- a/lib/marshallers.js
+++ b/lib/marshallers.js
@@ -64,9 +64,27 @@ const checkBoolean = function (data) {
 
 // This is essentially a tweaked version of 'fromValue' from Long.js with error checking.
 // This can take number or string of decimal characters or 'Long' instance (or Long-style object with props low,high,unsigned).
+// Range constants for `bigint`, which has no bounds of its own -- unlike every
+// other input here it will happily hold a number far too large for the field.
+const MAX_INT64 = 9223372036854775807n;
+const MIN_INT64 = -9223372036854775808n;
+const MAX_UINT64 = 18446744073709551615n;
+
 const makeLong = function (val, signed) {
   if (val instanceof Long) return val;
   if (val instanceof Number) val = val.valueOf();
+  // Accepted on write whatever the read option is, so code can be migrated to
+  // BigInt one call at a time rather than in a flag day. Range-checked here
+  // because Long.fromString would wrap silently.
+  if (typeof val === 'bigint') {
+    if (signed) {
+      if (val > MAX_INT64 || val < MIN_INT64)
+        throw new Error(`Data: ${val} was out of range (64-bit signed)`);
+    } else if (val > MAX_UINT64 || val < 0n) {
+      throw new Error(`Data: ${val} was out of range (64-bit unsigned)`);
+    }
+    return Long.fromString(val.toString(), !signed);
+  }
   if (typeof val === 'number') {
     try {
       // Long.js won't alert you to precision loss in passing more than 53 bit ints through a double number, so we check here

--- a/test/bigint.js
+++ b/test/bigint.js
@@ -1,0 +1,188 @@
+// Opt-in BigInt for the 64-bit types.
+//
+// `x` and `t` cover the full signed/unsigned 64-bit range, which a JS `number`
+// cannot: everything above 2^53 comes back approximated. These tests use the
+// exact boundary values, because that is where the current behaviour is wrong
+// and where an off-by-one in the conversion would hide.
+
+const { describe, it } = require('node:test');
+const assert = require('assert');
+const marshall = require('../lib/marshall');
+const unmarshall = require('../lib/unmarshall');
+const DBusBuffer = require('../lib/dbus-buffer');
+const constants = require('../lib/constants');
+
+const INT64_MAX = 9223372036854775807n;
+const INT64_MIN = -9223372036854775808n;
+const UINT64_MAX = 18446744073709551615n;
+
+// unmarshall(buffer, signature, startPos, options) -- note the startPos.
+const read = (buf, sig, options) => unmarshall(buf, sig, 0, options);
+const roundTrip = (sig, value, options) =>
+  read(marshall(sig, [value]), sig, options)[0];
+
+describe('BigInt: reading with returnBigInt', () => {
+  const big = { returnBigInt: true };
+
+  it('round-trips the signed 64-bit extremes exactly', () => {
+    assert.strictEqual(roundTrip('x', INT64_MAX, big), INT64_MAX);
+    assert.strictEqual(roundTrip('x', INT64_MIN, big), INT64_MIN);
+  });
+
+  it('round-trips the unsigned 64-bit extremes exactly', () => {
+    assert.strictEqual(roundTrip('t', UINT64_MAX, big), UINT64_MAX);
+    assert.strictEqual(roundTrip('t', 0n, big), 0n);
+  });
+
+  it('round-trips small and negative values', () => {
+    for (const v of [1n, -1n, 42n, -42n, 4294967296n]) {
+      assert.strictEqual(roundTrip('x', v, big), v, `${v}`);
+    }
+  });
+
+  it('returns a bigint, not a number or a Long', () => {
+    assert.strictEqual(typeof roundTrip('t', 7n, big), 'bigint');
+  });
+
+  // The reason the option exists.
+  it('is exact where a number is not', () => {
+    const asNumber = roundTrip('x', INT64_MAX);
+    assert.strictEqual(typeof asNumber, 'number');
+    assert.notStrictEqual(BigInt(asNumber), INT64_MAX);
+    assert.strictEqual(roundTrip('x', INT64_MAX, big), INT64_MAX);
+  });
+
+  it('reads big-endian messages too', () => {
+    const value = 0x1122334455667788n;
+    for (const [endianness, write] of [
+      [constants.endianness.le, 'writeBigInt64LE'],
+      [constants.endianness.be, 'writeBigInt64BE']
+    ]) {
+      const buf = Buffer.alloc(8);
+      buf[write](value);
+      const parser = new DBusBuffer(buf, 0, { returnBigInt: true }, endianness);
+      assert.strictEqual(parser.readSimpleType('x'), value, write);
+    }
+  });
+
+  it('reads an unsigned value above the signed maximum', () => {
+    // The bit pattern is negative when read as signed; the unsigned accessor
+    // is what makes `t` come back right.
+    assert.strictEqual(roundTrip('t', UINT64_MAX, big), UINT64_MAX);
+    assert.strictEqual(roundTrip('x', -1n, big), -1n);
+  });
+
+  it('handles 64-bit values inside a container', () => {
+    const buf = marshall('a(xt)', [[[INT64_MIN, UINT64_MAX]]]);
+    assert.deepStrictEqual(read(buf, 'a(xt)', big)[0], [
+      [INT64_MIN, UINT64_MAX]
+    ]);
+  });
+});
+
+describe('BigInt: the default is unchanged', () => {
+  it('still returns a number when the option is absent', () => {
+    assert.strictEqual(typeof roundTrip('x', 42n), 'number');
+    assert.strictEqual(roundTrip('x', 42n), 42);
+  });
+
+  it('still returns a Long with ReturnLongjs', () => {
+    const v = roundTrip('x', 42n, { ReturnLongjs: true });
+    assert.strictEqual(typeof v, 'object');
+    assert.strictEqual(v.toString(), '42');
+  });
+
+  it('prefers BigInt when both options are set', () => {
+    // returnBigInt is the shape these become in 2.0. Someone who sets both is
+    // migrating, and should get the destination rather than the deprecation.
+    assert.strictEqual(
+      roundTrip('x', 42n, { returnBigInt: true, ReturnLongjs: true }),
+      42n
+    );
+  });
+});
+
+describe('BigInt: writing', () => {
+  // Accepting bigint on write is not gated on the read option, so a call site
+  // can be migrated on its own rather than in a flag day.
+  it('accepts a bigint without returnBigInt', () => {
+    assert.strictEqual(roundTrip('x', 123n), 123);
+  });
+
+  it('accepts the 64-bit extremes', () => {
+    for (const [sig, v] of [
+      ['x', INT64_MAX],
+      ['x', INT64_MIN],
+      ['t', UINT64_MAX]
+    ]) {
+      assert.strictEqual(
+        roundTrip(sig, v, { returnBigInt: true }),
+        v,
+        `${sig} ${v}`
+      );
+    }
+  });
+
+  it('rejects a bigint past the signed range', () => {
+    assert.throws(() => marshall('x', [INT64_MAX + 1n]), /out of range/);
+    assert.throws(() => marshall('x', [INT64_MIN - 1n]), /out of range/);
+  });
+
+  it('rejects a bigint past the unsigned range', () => {
+    assert.throws(() => marshall('t', [UINT64_MAX + 1n]), /out of range/);
+    assert.throws(() => marshall('t', [-1n]), /out of range/);
+  });
+
+  it('still accepts numbers, strings and hex strings', () => {
+    const big = { returnBigInt: true };
+    assert.strictEqual(roundTrip('x', 42, big), 42n);
+    assert.strictEqual(roundTrip('t', '18446744073709551615', big), UINT64_MAX);
+    assert.strictEqual(roundTrip('x', '-0x8000000000000000', big), INT64_MIN);
+  });
+
+  it('marshalls a bigint and a string to identical bytes', () => {
+    assert.deepStrictEqual(
+      marshall('t', [UINT64_MAX]),
+      marshall('t', ['18446744073709551615'])
+    );
+  });
+});
+
+describe('BigInt: diagnostics survive a bigint body', () => {
+  // These messages are built with JSON.stringify, which throws on a BigInt.
+  // Without care the diagnostic replaces the error it was describing: a body
+  // that did not match its signature reported "Do not know how to serialize a
+  // BigInt" instead, which says nothing about the actual problem.
+  it('reports a signature mismatch, not a serialisation failure', () => {
+    assert.throws(
+      () => marshall('xt', [[1n, 2n]]),
+      err => {
+        assert.match(err.message, /does not match message signature/);
+        assert.doesNotMatch(err.message, /serialize a BigInt/);
+        return true;
+      }
+    );
+  });
+
+  it('reports a wrong type for a string field', () => {
+    assert.throws(
+      () => marshall('s', [42n]),
+      err => {
+        assert.match(err.message, /Expected string or buffer/);
+        assert.match(err.message, /42n/, 'renders the value it rejected');
+        return true;
+      }
+    );
+  });
+
+  it('reports a non-array where an array was expected', () => {
+    assert.throws(
+      () => marshall('as', [1n]),
+      err => {
+        assert.match(err.message, /Expected an array/);
+        assert.doesNotMatch(err.message, /serialize a BigInt/);
+        return true;
+      }
+    );
+  });
+});

--- a/test/integration/bigint.js
+++ b/test/integration/bigint.js
@@ -1,0 +1,129 @@
+// Opt-in BigInt over a real dbus-daemon.
+//
+// The unit tests marshall and unmarshall in one process; this proves the
+// option survives the connection -- it is set on the client and has to reach
+// the parser through the message layer, which is a different path.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const dbus = require('../../index');
+
+const NO_BUS =
+  !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
+
+const SERVICE = 'com.github.sidorares.dbusnative.BigInt';
+const OBJECT_PATH = '/com/github/sidorares/dbusnative/BigInt';
+const IFACE = 'com.github.sidorares.dbusnative.BigIntIface';
+
+const INT64_MAX = 9223372036854775807n;
+const INT64_MIN = -9223372036854775808n;
+const UINT64_MAX = 18446744073709551615n;
+
+const ifaceDesc = {
+  name: IFACE,
+  methods: {
+    // echo a signed and an unsigned 64-bit value straight back
+    EchoX: ['x', 'x', ['in'], ['out']],
+    EchoT: ['t', 't', ['in'], ['out']],
+    // A struct, not two return values: exportInterface sends whatever the
+    // implementation returns as a single body element.
+    BigOnes: ['', '(xt)', [], ['pair']]
+  },
+  signals: {},
+  properties: {}
+};
+
+describe('integration: BigInt', { timeout: 10000, skip: NO_BUS }, () => {
+  let serviceBus, bigClient, plainClient;
+
+  const whenReady = bus =>
+    new Promise((resolve, reject) =>
+      bus.getId(err => (err ? reject(err) : resolve()))
+    );
+
+  const call = (bus, member, signature, body) =>
+    bus.invoke({
+      destination: SERVICE,
+      path: OBJECT_PATH,
+      interface: IFACE,
+      member,
+      ...(signature ? { signature, body } : {})
+    });
+
+  before(async () => {
+    // The service reads its *arguments* through the same parser, so it needs
+    // the option too. Without it an `x` argument arrives as a lossy number,
+    // and echoing that back fails the 53-bit check on marshall -- loudly,
+    // which is better than the silent truncation it would otherwise be.
+    serviceBus = dbus.sessionBus({ returnBigInt: true });
+    // The option is per connection, so the same daemon and the same service
+    // can be read either way -- which is what makes migration incremental.
+    bigClient = dbus.sessionBus({ returnBigInt: true });
+    plainClient = dbus.sessionBus();
+
+    const impl = Object.assign(Object.create(EventEmitter.prototype), {
+      EchoX: v => v,
+      EchoT: v => v,
+      BigOnes: () => [INT64_MIN, UINT64_MAX]
+    });
+    EventEmitter.call(impl);
+
+    await Promise.all([
+      whenReady(serviceBus),
+      whenReady(bigClient),
+      whenReady(plainClient)
+    ]);
+    await new Promise((resolve, reject) =>
+      serviceBus.requestName(SERVICE, 0, err => {
+        if (err) return reject(err);
+        serviceBus.exportInterface(impl, OBJECT_PATH, ifaceDesc);
+        resolve();
+      })
+    );
+  });
+
+  after(() => {
+    for (const bus of [serviceBus, bigClient, plainClient])
+      if (bus) bus.connection.end();
+  });
+
+  it('carries the signed 64-bit maximum over the wire intact', async () => {
+    assert.strictEqual(
+      await call(bigClient, 'EchoX', 'x', [INT64_MAX]),
+      INT64_MAX
+    );
+  });
+
+  it('carries the signed 64-bit minimum over the wire intact', async () => {
+    assert.strictEqual(
+      await call(bigClient, 'EchoX', 'x', [INT64_MIN]),
+      INT64_MIN
+    );
+  });
+
+  it('carries the unsigned 64-bit maximum over the wire intact', async () => {
+    assert.strictEqual(
+      await call(bigClient, 'EchoT', 't', [UINT64_MAX]),
+      UINT64_MAX
+    );
+  });
+
+  it('reads several 64-bit values from one struct', async () => {
+    const [signed, unsigned] = await call(bigClient, 'BigOnes');
+    assert.strictEqual(signed, INT64_MIN);
+    assert.strictEqual(unsigned, UINT64_MAX);
+  });
+
+  // Same daemon, same service, same message -- only the client option differs.
+  it('leaves a client without the option on numbers', async () => {
+    const value = await call(plainClient, 'EchoX', 'x', [INT64_MAX]);
+    assert.strictEqual(typeof value, 'number');
+    assert.notStrictEqual(BigInt(value), INT64_MAX, 'this is the lossy path');
+  });
+
+  it('accepts a bigint argument from a client that does not read them', async () => {
+    // Writing is never gated on the read option.
+    assert.strictEqual(await call(plainClient, 'EchoX', 'x', [42n]), 42);
+  });
+});


### PR DESCRIPTION
`x` and `t` cover the full signed and unsigned 64-bit range, which a JS `number` cannot:

```js
await disk.Size(); //  9223372036854776000   ← wrong
```

```js
const bus = dbus.sessionBus({ returnBigInt: true });
await disk.Size(); //  9223372036854775807n  ← exact
```

Additive — the default is unchanged.

### Why opt-in rather than just doing it

Both documents ask for exactly this shape. ROADMAP §3.2:

> Gate the return type behind an option (`ReturnBigInt`) for one minor release alongside the existing `ReturnLongjs`, then flip the default […]

and RELEASE_PLAN's risk list:

> the one place a temporary flag genuinely earns its keep, because the failure mode is a `TypeError` in production rather than a subtly wrong value.

`bigint` is not a drop-in for `number` — `size + 1` and `JSON.stringify({ size })` both throw. Better found deliberately than on upgrade day. This is the same forward-compatible bargain as the 0.6 value accessors: **a call site migrated today needs no change in 2.0.**

### Shape

| | |
| --- | --- |
| reading | `{ returnBigInt: true }` → exact `bigint` for `x`/`t` |
| writing | `bigint` accepted **whatever the read option is** |
| still accepted | `number` (≤53 bits), decimal/hex `string`, Long-shaped objects |
| precedence | `returnBigInt` wins over the deprecated `ReturnLongjs` |
| scope | per connection, so a service and its clients migrate separately |

Range-checked at the exact 64-bit boundaries — `Long.fromString` would otherwise wrap silently.

**On the name.** Every option in this API is lowercase-first camelCase — `stream`, `socket`, `busAddress`, `authMethods`, `ayBuffer`, `maxMessageSize`, `timeout` — with exactly one exception, `ReturnLongjs`, which predates the rest and is now stuck with its capital R because callers set it. `returnBigInt` follows the convention rather than the outlier; copying `ReturnLongjs` would have doubled a historical accident into the API instead of leaving it behind. The `.d.ts` and README note this where the two sit together.

`returnBigInt` winning over `ReturnLongjs` is deliberate: someone who has set both is mid-migration and should get the destination, not the deprecation.

### Two things the implementation turned up

**A service needs the option too.** It reads its own *arguments* through the same parser. Without it, a large `x` argument arrives as a lossy `number` and then fails the 53-bit check on the way back out. Loud rather than silent, at least — but surprising, so it is called out in the README, in `DBUS_DEP0001`, and in the integration test that first hit it.

**`JSON.stringify` throws on a BigInt**, and three of the marshaller's error messages are built with it. A body that did not match its signature reported:

```
TypeError: Do not know how to serialize a BigInt
```

— the diagnostic replacing the error it was describing, saying nothing about the real problem. This would have shipped *with* the feature that makes BigInt bodies common. Fixed with a BigInt-aware renderer that also survives circular values, since a diagnostic must not become the failure.

### Verification

- 355 unit + 67 integration tests green on Node 20 and 26. 20 new unit tests, 6 new integration tests.
- Round-trips asserted at the **exact** boundaries — `INT64_MAX`, `INT64_MIN`, `UINT64_MAX` — where an off-by-one in the conversion would hide, plus big-endian, containers, and the `-1n` bit pattern that distinguishes signed from unsigned reads.
- One test asserts the lossy path is *still* lossy without the option, so the default cannot drift silently.
- Integration coverage proves the option survives a real connection, which the unit tests cannot: it is set on the client and has to reach the parser through the message layer.

### What is not here

Flipping the default and dropping `long` — those are breaking and belong in 2.0 with the rest of the type-system change. Dropping long.js is also what removes the ARMv6 crash that made the Homebridge fork vendor their own copy, which is worth mentioning in that conversation.

Progresses #248 and supersedes #252.
