### PR TITLE
fix: do not write to a connection closed during the handshake

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -475,9 +475,19 @@ grow unboundedly today.
 **Both halves are now done.** The per-call and per-client `timeout` option, with
 `AbortSignal` support, shipped in 0.6. Connection death fails every pending call
 with a `ConnectionClosedError` as of 0.7, which absorbs #213 — see
-[docs/migrating-to-0.7.md](./docs/migrating-to-0.7.md). What remains under this
-heading is #20 and #137: `connection.end()` still throws
-`ERR_STREAM_WRITE_AFTER_END` rather than flushing cleanly, and a _default_
+[docs/migrating-to-0.7.md](./docs/migrating-to-0.7.md).
+
+The `ERR_STREAM_WRITE_AFTER_END` half of [#20](https://github.com/sidorares/dbus-native/issues/20)
+is also fixed: closing a connection during the SASL handshake made the next
+handshake write land on an ended socket, which surfaced as an unhandled
+`'error'` and killed the process. It was a race, so it appeared intermittently
+— it took down one CI job in seven before being tracked down. The handshake now
+abandons quietly when the caller has closed the stream.
+
+**Not** the whole of #20: that issue reports `ECONNRESET` on the _read_ side
+after an early `end()`, which is a different path and still open.
+
+What remains under this heading is the read half of #20, and #137: a _default_
 timeout is deliberately held back to 3.0 because it makes previously-hanging
 calls start failing.
 

--- a/bin/dbus2js.js
+++ b/bin/dbus2js.js
@@ -111,13 +111,27 @@ if (!argv.xml && (!argv.service || !argv.path)) {
   process.exit(1);
 }
 
-const bus = argv.bus === 'system' ? dbus.systemBus() : dbus.sessionBus();
+// Connected lazily. Reading introspection XML from a file needs no daemon at
+// all, and opening one anyway meant `--xml` raced its own teardown: the
+// connection was closed as soon as the output was written, sometimes while the
+// SASL handshake was still in flight. See issue #20.
+let busInstance = null;
+function getBus() {
+  if (!busInstance)
+    busInstance = argv.bus === 'system' ? dbus.systemBus() : dbus.sessionBus();
+  return busInstance;
+}
+
+// Only closes a connection that was actually opened.
+function closeBus() {
+  if (busInstance) busInstance.connection.end();
+}
 
 function getXML(callback) {
   if (argv.xml) {
     fs.readFile(argv.xml, 'ascii', callback);
   } else {
-    bus.invoke(
+    getBus().invoke(
       {
         destination: argv.service,
         path: argv.path,
@@ -138,7 +152,7 @@ if (argv.dump) {
   getXML((err, xml) => {
     if (err) die(err);
     console.log(xml);
-    bus.connection.end();
+    closeBus();
   });
 } else if (!argv.server) {
   getXML((err, xml) => {
@@ -223,10 +237,10 @@ if (argv.dump) {
         output.push('}');
       }
       console.log(output.join('\n'));
-      bus.connection.end();
+      closeBus();
     });
   });
 } else {
   // --server generates nothing today; do not leave the connection open.
-  bus.connection.end();
+  closeBus();
 }

--- a/lib/handshake.js
+++ b/lib/handshake.js
@@ -60,9 +60,32 @@ function hexlify(input) {
   return Buffer.from(input.toString(), 'ascii').toString('hex');
 }
 
+// The handshake is a conversation, so between any two of its writes the
+// caller may have closed the connection -- a short-lived tool that calls
+// `connection.end()` as soon as it has what it wants does exactly that. The
+// write then fails with ERR_STREAM_WRITE_AFTER_END, which surfaces as an
+// unhandled 'error' on the connection and takes the process down. That is
+// issue #20, and it is a race, so it shows up intermittently.
+//
+// Writing to a stream the caller has closed is not an error worth reporting:
+// they asked for the connection to go away, and it has. Abandon the handshake
+// quietly instead.
+function writable(stream) {
+  return (
+    !stream.writableEnded && !stream.destroyed && stream.writable !== false
+  );
+}
+
+// Returns false when the stream went away, so callers can stop.
+function send(stream, data) {
+  if (!writable(stream)) return false;
+  stream.write(data);
+  return true;
+}
+
 module.exports = function auth(stream, opts, cb) {
   const authMethods = opts.authMethods || constants.defaultAuthMethods;
-  stream.write('\0');
+  if (!send(stream, '\0')) return;
   // slice() so we don't accidentally mutate the caller's array
   tryAuth(stream, authMethods.slice(), cb);
 };
@@ -80,7 +103,7 @@ function tryAuth(stream, methods, cb) {
     readLine(stream, line => {
       const ok = line.toString('ascii').match(/^([A-Za-z]+) (.*)/);
       if (ok && ok[1] === 'OK') {
-        stream.write('BEGIN\r\n');
+        if (!send(stream, 'BEGIN\r\n')) return;
         return cb(null, ok[2]); // ok[2] = guid. Do we need it?
       }
       // The server rejected this mechanism (typically `REJECTED <methods>`);
@@ -100,11 +123,11 @@ function tryAuth(stream, methods, cb) {
 
   switch (authMethod) {
     case 'EXTERNAL':
-      stream.write(`AUTH ${authMethod} ${id}\r\n`);
+      if (!send(stream, `AUTH ${authMethod} ${id}\r\n`)) return;
       beginOrNextAuth();
       break;
     case 'DBUS_COOKIE_SHA1':
-      stream.write(`AUTH ${authMethod} ${id}\r\n`);
+      if (!send(stream, `AUTH ${authMethod} ${id}\r\n`)) return;
       readLine(stream, line => {
         const data = Buffer.from(line.toString().split(' ')[1].trim(), 'hex')
           .toString()
@@ -120,13 +143,13 @@ function tryAuth(stream, methods, cb) {
             [serverChallenge, clientChallenge, cookie].join(':')
           );
           const reply = hexlify(clientChallenge + response);
-          stream.write(`DATA ${reply}\r\n`);
+          if (!send(stream, `DATA ${reply}\r\n`)) return;
           beginOrNextAuth();
         });
       });
       break;
     case 'ANONYMOUS':
-      stream.write('AUTH ANONYMOUS \r\n');
+      if (!send(stream, 'AUTH ANONYMOUS \r\n')) return;
       beginOrNextAuth();
       break;
     default:

--- a/test/handshake-teardown.js
+++ b/test/handshake-teardown.js
@@ -1,0 +1,116 @@
+// Closing a connection while the SASL handshake is still in flight.
+//
+// Issue #20. A short-lived tool that calls `connection.end()` as soon as it
+// has what it wants can close the socket between two handshake writes. The
+// next write then fails with ERR_STREAM_WRITE_AFTER_END, which surfaces as an
+// unhandled 'error' on the connection and takes the process down.
+//
+// It is a race, so in the wild it is intermittent -- it failed one CI job in
+// seven on the run that surfaced it. These tests close at each point the
+// handshake can be interrupted, deterministically.
+
+const { describe, it } = require('node:test');
+const assert = require('assert');
+const { Duplex } = require('stream');
+const dbus = require('../index');
+
+// A socket stand-in that behaves like a real one on write-after-end: throws
+// asynchronously via an 'error' event rather than returning false.
+class FakeSocket extends Duplex {
+  constructor() {
+    super();
+    this.written = [];
+  }
+  _write(chunk, enc, cb) {
+    this.written.push(chunk.toString());
+    cb();
+  }
+  _read() {}
+  text() {
+    return this.written.join('');
+  }
+}
+
+// Collects anything that would have crashed the process.
+function watch(conn) {
+  const errors = [];
+  conn.on('error', err => errors.push(err));
+  return errors;
+}
+
+const settle = () => new Promise(resolve => setImmediate(resolve));
+
+describe('closing during the handshake', () => {
+  it('does not write after end when closed before the greeting reply', async () => {
+    const socket = new FakeSocket();
+    const conn = dbus.createConnection({ stream: socket, direct: true });
+    const errors = watch(conn);
+
+    conn.end(); // user closes immediately
+    await settle();
+    // The server answers anyway; the handshake must not write BEGIN now.
+    socket.push('OK 0123456789abcdef\r\n');
+    await settle();
+
+    assert.deepStrictEqual(
+      errors.map(e => e.code),
+      [],
+      `expected no error, got ${errors.map(e => e.message)}`
+    );
+    assert.ok(
+      !socket.text().includes('BEGIN'),
+      'BEGIN was written to a closed stream'
+    );
+  });
+
+  it('does not write after end when closed mid-authentication', async () => {
+    const socket = new FakeSocket();
+    const conn = dbus.createConnection({ stream: socket, direct: true });
+    const errors = watch(conn);
+
+    await settle();
+    // AUTH EXTERNAL has gone out; close before the server replies.
+    assert.ok(socket.text().includes('AUTH'), 'expected AUTH to be sent first');
+    conn.end();
+    await settle();
+    socket.push('REJECTED EXTERNAL DBUS_COOKIE_SHA1 ANONYMOUS\r\n');
+    await settle();
+
+    assert.deepStrictEqual(
+      errors.map(e => e.code),
+      [],
+      `expected no error, got ${errors.map(e => e.message)}`
+    );
+  });
+
+  it('does not crash when the socket is destroyed outright', async () => {
+    const socket = new FakeSocket();
+    const conn = dbus.createConnection({ stream: socket, direct: true });
+    const errors = watch(conn);
+
+    await settle();
+    socket.destroy();
+    await settle();
+    socket.push('OK 0123456789abcdef\r\n');
+    await settle();
+
+    assert.ok(
+      !errors.some(e => e.code === 'ERR_STREAM_WRITE_AFTER_END'),
+      'write-after-end escaped'
+    );
+  });
+
+  // The fix must not break the ordinary path.
+  it('still completes a handshake that is not interrupted', async () => {
+    const socket = new FakeSocket();
+    const conn = dbus.createConnection({ stream: socket, direct: true });
+    const connected = new Promise(resolve => conn.once('connect', resolve));
+
+    await settle();
+    socket.push('OK 0123456789abcdef\r\n');
+    await connected;
+
+    assert.strictEqual(conn.guid, '0123456789abcdef');
+    assert.ok(socket.text().includes('BEGIN'), 'BEGIN should still be sent');
+  });
+});


### PR DESCRIPTION
Found while investigating [the failing job](https://github.com/sidorares/dbus-native/actions/runs/30417211323) on #327 — `test (node 24, ubuntu-latest)` failed while the other six passed.

It is not flaky infrastructure. It is a real race, and it can take down a user's process.

```
Error [ERR_STREAM_WRITE_AFTER_END]: write after end
    at lib/handshake.js:83
    at Socket.readable (lib/readline.js:28)
Emitted 'error' event at:
    at Socket.<anonymous> (index.js:106)
```

### What happens

The SASL handshake is a conversation. Between any two of its writes the caller may have closed the connection — a short-lived tool that calls `connection.end()` as soon as it has what it wants does exactly that. The server's next line still arrives, `readLine` fires, and the handshake writes `BEGIN\r\n` to an ended socket. The failure surfaces as an **unhandled `'error'` on the connection**, so the process dies.

Whether `end()` lands before or after that write is a matter of microseconds, which is why it showed up in one job of seven rather than reproducibly.

### The fix

Every handshake write now checks the caller still wants the connection, and abandons quietly if not. Writing to a stream someone deliberately closed is not an error worth reporting — they asked for it to go away, and it has.

### Making a race into a test

`test/handshake-teardown.js` closes at each point the handshake can be interrupted — before the greeting reply, mid-authentication, and on an outright `destroy()` — plus one case asserting an uninterrupted handshake still completes.

**Two of the four fail without this change**, verified by reverting the fix and re-running:

```
✖ does not write after end when closed before the greeting reply
✖ does not write after end when closed mid-authentication
✔ does not crash when the socket is destroyed outright
✔ still completes a handshake that is not interrupted
```

### The trigger, fixed too

`dbus2js` opened a bus at module load — even for `--xml`, which reads introspection from a file and needs no daemon at all — then closed it as soon as it had written its output. That is the exact shape that loses this race. The connection is now created on first use.

Side effect worth having: `dbus2js --xml` now works with **no `DBUS_SESSION_BUS_ADDRESS` at all**, where it previously died with `unknown bus address`. Generating from a saved file should never have required a bus.

```console
$ env -u DBUS_SESSION_BUS_ADDRESS node bin/dbus2js.js --xml empty.xml
Error: unknown bus address        # before
$ env -u DBUS_SESSION_BUS_ADDRESS node bin/dbus2js.js --xml empty.xml
                                  # after: exit 0
```

`dbus-native types --xml` was already correct — it returns before connecting.

### Scope

Related to [#20](https://github.com/sidorares/dbus-native/issues/20), which reports this family of "closed too early" problems. **It does not close it:** that issue's symptom is `ECONNRESET` on the *read* side, which is a different path and remains open. ROADMAP §3.4 records the split.

### Verification

359 unit + 67 integration tests green on Node 20 and 26.
