### PR TITLE
feat: emit PropertiesChanged, and honour declared property access

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -547,6 +547,27 @@ and it is the most credible path to reconciling the two projects.
 - `GetAll` on an interface with no properties still misbehaves
   ([#102](https://github.com/sidorares/dbus-native/issues/102)).
 
+**Done, except that the third item was wrong.**
+
+`PropertiesChanged` is now emitted whenever `Properties.Set` writes, and
+`bus.emitPropertiesChanged()` lets a service announce changes it makes itself
+— an ordinary assignment to the implementation object cannot be observed
+without redefining its accessors, which is not a reasonable thing for
+exporting an object to do to it.
+
+Properties may now be declared as `{ type, access }` as well as a bare
+signature, the XML advertises what was declared, `Set` refuses a read-only
+property with `PropertyReadOnly`, `Get` refuses a write-only one with
+`AccessDenied`, and `GetAll` omits what cannot be read. The bare-signature
+form still means `readwrite`, so nothing existing changes.
+
+On the third item: [#102](https://github.com/sidorares/dbus-native/issues/102)
+is **closed**, and it was never about an interface with no properties — it
+reports `GetAll` failing on a property whose _value_ is an empty array (`as`
+= `[]`). Both cases were checked against the current marshaller and both work.
+Whatever broke in 2015 was fixed somewhere along the way; the roadmap entry
+had simply gone stale.
+
 ### 4.5 Finish the server/broker
 
 `lib/server.js` plus `lib/server-handshake.js` are a stub: the handshake replies

--- a/docs/api.md
+++ b/docs/api.md
@@ -276,7 +276,11 @@ const ifaceDesc = {
     Pinged: ['s', 'payload']
   },
   properties: {
-    Greeting: 's'
+    // a signature alone means readwrite
+    Greeting: 's',
+    // or declare the access explicitly
+    Locked: { type: 'b', access: 'read' },
+    Secret: { type: 's', access: 'write' }
   }
 };
 
@@ -300,6 +304,44 @@ with no body.
 `exportInterface` monkey-patches `impl.emit` so a local emit also sends the
 signal. `org.freedesktop.DBus.Introspectable`, `.Properties` and `.Peer` are
 answered for you.
+
+### Property access
+
+`access` defaults to `readwrite`, which is what a bare signature has always
+meant. It is advertised in the introspection XML and enforced:
+
+|                     | `read`             | `write`        | `readwrite` |
+| ------------------- | ------------------ | -------------- | ----------- |
+| `Properties.Get`    | ✓                  | `AccessDenied` | ✓           |
+| `Properties.Set`    | `PropertyReadOnly` | ✓              | ✓           |
+| `Properties.GetAll` | included           | omitted        | included    |
+
+### PropertiesChanged
+
+`Properties.Set` emits `org.freedesktop.DBus.Properties.PropertiesChanged` for
+you. A write-only property is reported as _invalidated_ rather than broadcast,
+since there is no value subscribers are allowed to see.
+
+When the service changes a property itself, say so — an ordinary assignment to
+the implementation object cannot be observed:
+
+```js
+impl.Greeting = 'hello again';
+bus.emitPropertiesChanged(path, iface.name, { Greeting: impl.Greeting });
+```
+
+`emitPropertiesChanged(path, interfaceName, changed, invalidated?)` takes
+signatures from the interface descriptor, so values are marshalled as declared
+rather than guessed from their JS type. It throws if the interface is not
+exported at that path, or if a named property is not declared on it.
+
+The `invalidated` list names properties whose value changed but is not being
+sent — write-only ones, or anything expensive to compute. Listing them tells a
+subscriber to re-read rather than keep a stale value:
+
+```js
+bus.emitPropertiesChanged(path, iface.name, {}, ['Expensive']);
+```
 
 Lower-level pieces, if you are not using `exportInterface`:
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -267,11 +267,22 @@ export type MethodDescriptor = [string, string, string[], string[]];
 /** A signal: [signature, ...argumentNames] */
 export type SignalDescriptor = string[];
 
+/** How a property may be used. Defaults to 'readwrite'. */
+export type PropertyAccess = 'read' | 'write' | 'readwrite';
+
+/**
+ * A property: a signature, or a signature plus its access.
+ *
+ * The bare-string form means `readwrite`, which is what it always meant.
+ */
+export type PropertyDescriptor =
+  string | { type: string; access?: PropertyAccess };
+
 export interface InterfaceDescriptor {
   name: string;
   methods?: Record<string, MethodDescriptor>;
   signals?: Record<string, SignalDescriptor>;
-  properties?: Record<string, string>;
+  properties?: Record<string, PropertyDescriptor>;
 }
 
 /**
@@ -371,6 +382,26 @@ export interface MessageBus {
     handler: [(...args: any[]) => any, string]
   ): void;
   exportInterface(obj: unknown, path: string, iface: InterfaceDescriptor): void;
+
+  /**
+   * Emit org.freedesktop.DBus.Properties.PropertiesChanged for an exported
+   * interface.
+   *
+   * `Properties.Set` does this for you. Call it when the service changes a
+   * property itself — an ordinary assignment cannot be observed.
+   *
+   * `invalidated` names properties whose value changed but is not being sent,
+   * telling subscribers to re-read rather than keep a stale value.
+   *
+   * @throws if the interface is not exported at `path`, or a named property is
+   * not declared on it
+   */
+  emitPropertiesChanged(
+    path: string,
+    interfaceName: string,
+    changed: Record<string, unknown>,
+    invalidated?: string[]
+  ): void;
 
   getService(name: string): DBusService;
 

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -11,6 +11,10 @@ const {
   fromReply
 } = require('./errors');
 const { channels } = require('./diagnostics');
+const {
+  declaration: propertyDeclaration,
+  changedSignal: propertiesChangedSignal
+} = require('./properties');
 
 module.exports = function bus(conn, opts) {
   if (!(this instanceof bus)) {
@@ -183,6 +187,59 @@ module.exports = function bus(conn, opts) {
       signalMsg.body = args;
     }
     self.connection.message(signalMsg);
+  };
+
+  /**
+   * Announce that exported properties changed.
+   *
+   * `Properties.Set` calls this for you. Call it yourself when the service
+   * changes a property on its own -- assigning to `impl.Greeting` is an
+   * ordinary property write and there is no way to observe it without
+   * redefining the accessor, which would be a surprising thing for exporting
+   * an object to do to it.
+   *
+   *   bus.emitPropertiesChanged('/com/example/Obj', 'com.example.Iface', {
+   *     Greeting: 'hello again'
+   *   });
+   *
+   * `invalidated` names properties whose value changed but is not being
+   * broadcast -- write-only ones, or anything expensive to compute. Listing
+   * them is what tells a subscriber to re-read rather than keep a stale value.
+   *
+   * Signatures come from the interface descriptor, so the values are marshalled
+   * as the interface declares them rather than guessed from the JS type.
+   */
+  this.emitPropertiesChanged = function (
+    path,
+    interfaceName,
+    changed,
+    invalidated
+  ) {
+    const entry = self.exportedObjects[path];
+    const iface = entry && entry[interfaceName] && entry[interfaceName][0];
+    if (!iface) {
+      throw new Error(
+        `No interface "${interfaceName}" exported at object path "${path}"`
+      );
+    }
+    const changedEntries = Object.keys(changed || {}).map(name => {
+      const decl = propertyDeclaration(iface, name);
+      if (!decl) {
+        throw new Error(
+          `No such property "${name}" on interface "${interfaceName}"`
+        );
+      }
+      return [name, [decl.type, changed[name]]];
+    });
+    self.connection.message(
+      propertiesChangedSignal(
+        self.serial++,
+        path,
+        interfaceName,
+        changedEntries,
+        invalidated || []
+      )
+    );
   };
 
   // Warning: errorName must respect the same rules as interface names (must contain a dot)

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -1,0 +1,78 @@
+// Property declarations and the PropertiesChanged signal.
+//
+// An interface descriptor declares properties as `{ Greeting: 's' }` -- a
+// signature per name. That form says nothing about access, so `interfaceToXML`
+// used to advertise everything as `readwrite` whatever the service intended,
+// and `Properties.Set` would write a property meant to be read-only.
+//
+// The declaration is therefore widened rather than replaced: a value may still
+// be a signature string, or it may be `{ type, access }`. The string form is
+// what almost every existing service uses and keeps meaning exactly what it
+// did, so nothing needs rewriting.
+
+const constants = require('./constants');
+
+const ACCESS = new Set(['read', 'write', 'readwrite']);
+
+/**
+ * Normalise one property declaration.
+ *
+ * @returns {{type: string, access: string}|undefined} undefined if undeclared
+ */
+function declaration(iface, name) {
+  const props = iface && iface.properties;
+  // `Object.hasOwn` rather than a truthiness check: a property legitimately
+  // declared as the empty signature would otherwise look undeclared.
+  if (!props || !Object.hasOwn(props, name)) return undefined;
+  const decl = props[name];
+  if (typeof decl === 'string') return { type: decl, access: 'readwrite' };
+  if (decl && typeof decl === 'object' && typeof decl.type === 'string') {
+    const access = decl.access === undefined ? 'readwrite' : decl.access;
+    if (!ACCESS.has(access)) {
+      throw new Error(
+        `Property "${name}" declares access "${access}"; expected one of ${[...ACCESS].join(', ')}`
+      );
+    }
+    return { type: decl.type, access };
+  }
+  throw new Error(
+    `Property "${name}" must be declared as a signature string or { type, access }`
+  );
+}
+
+/** Every declared property name, in declaration order. */
+function names(iface) {
+  const props = iface && iface.properties;
+  return props ? Object.keys(props) : [];
+}
+
+const isReadable = access => access === 'read' || access === 'readwrite';
+const isWritable = access => access === 'write' || access === 'readwrite';
+
+/**
+ * Build an org.freedesktop.DBus.Properties.PropertiesChanged signal.
+ *
+ * `changed` carries the new values; `invalidated` names properties whose value
+ * has changed but is not being broadcast -- which is what the spec wants for
+ * anything write-only or expensive to compute, rather than omitting it and
+ * leaving subscribers with a stale value.
+ */
+function changedSignal(serial, path, interfaceName, changed, invalidated) {
+  return {
+    type: constants.messageType.signal,
+    serial,
+    path,
+    interface: 'org.freedesktop.DBus.Properties',
+    member: 'PropertiesChanged',
+    signature: 'sa{sv}as',
+    body: [interfaceName, changed, invalidated]
+  };
+}
+
+module.exports = {
+  declaration,
+  names,
+  isReadable,
+  isWritable,
+  changedSignal
+};

--- a/lib/stdifaces.js
+++ b/lib/stdifaces.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 
 const constants = require('./constants');
 const parseSignature = require('./signature');
+const properties = require('./properties');
 
 // org.freedesktop.DBus.Peer.GetMachineId must return the same 32-char hex id
 // for the lifetime of the machine. Prefer the real one written by dbus/systemd,
@@ -126,10 +127,20 @@ module.exports = function (msg, bus) {
       replySerial: msg.serial,
       destination: msg.sender
     };
+    const ifaceDesc = propertiesObj[interfaceName][0];
+
     if (msg.member === 'Get' || msg.member === 'Set') {
       const propertyName = msg.body[1];
-      const propType = propertiesObj[interfaceName][0].properties[propertyName];
-      if (propType === undefined) {
+      let decl;
+      try {
+        decl = properties.declaration(ifaceDesc, propertyName);
+      } catch (e) {
+        // A malformed declaration is the service's bug, not the caller's, but
+        // the caller is the one waiting for a reply.
+        bus.sendError(msg, 'org.freedesktop.DBus.Error.Failed', e.message);
+        return 1;
+      }
+      if (decl === undefined) {
         bus.sendError(
           msg,
           'org.freedesktop.DBus.Error.UnknownProperty',
@@ -138,21 +149,59 @@ module.exports = function (msg, bus) {
         return 1;
       }
       if (msg.member === 'Get') {
+        if (!properties.isReadable(decl.access)) {
+          bus.sendError(
+            msg,
+            'org.freedesktop.DBus.Error.AccessDenied',
+            `Property "${propertyName}" on interface "${interfaceName}" is write-only`
+          );
+          return 1;
+        }
         const propValue = impl[propertyName];
         propertiesReply.signature = 'v';
-        propertiesReply.body = [[propType, propValue]];
+        propertiesReply.body = [[decl.type, propValue]];
       } else {
+        if (!properties.isWritable(decl.access)) {
+          bus.sendError(
+            msg,
+            'org.freedesktop.DBus.Error.PropertyReadOnly',
+            `Property "${propertyName}" on interface "${interfaceName}" is read-only`
+          );
+          return 1;
+        }
         // Set takes (interface_name, property_name, value) where the value is a
         // variant. An unmarshalled variant is [signatureTree, [value]], so the
         // value we want to assign lives at body[2][1][0].
-        impl[propertyName] = msg.body[2][1][0];
+        const value = msg.body[2][1][0];
+        impl[propertyName] = value;
+        // Tell subscribers. A write-only property has no value to broadcast,
+        // so it is reported as invalidated instead -- which is what the spec
+        // wants, rather than leaving subscribers with a stale value.
+        if (properties.isReadable(decl.access)) {
+          bus.emitPropertiesChanged(msg.path, interfaceName, {
+            [propertyName]: value
+          });
+        } else {
+          bus.emitPropertiesChanged(msg.path, interfaceName, {}, [
+            propertyName
+          ]);
+        }
       }
     } else if (msg.member === 'GetAll') {
       propertiesReply.signature = 'a{sv}';
       const props = [];
-      for (const p in propertiesObj[interfaceName][0].properties) {
-        const propertySignature = propertiesObj[interfaceName][0].properties[p];
-        props.push([p, [propertySignature, impl[p]]]);
+      for (const p of properties.names(ifaceDesc)) {
+        let decl;
+        try {
+          decl = properties.declaration(ifaceDesc, p);
+        } catch (e) {
+          bus.sendError(msg, 'org.freedesktop.DBus.Error.Failed', e.message);
+          return 1;
+        }
+        // GetAll returns what can be read; a write-only property has no value
+        // to report and the spec says to leave it out rather than guess.
+        if (!properties.isReadable(decl.access)) continue;
+        props.push([p, [decl.type, impl[p]]]);
       }
       propertiesReply.body = [props];
     }
@@ -212,15 +261,13 @@ function interfaceToXML(iface) {
       result.push('    </signal>');
     }
   }
-  if (iface.properties) {
-    for (const propertyName in iface.properties) {
-      // TODO: decide how to encode access
-      result.push(
-        `    <property name="${propertyName}" type="${
-          iface.properties[propertyName]
-        }" access="readwrite"/>`
-      );
-    }
+  for (const propertyName of properties.names(iface)) {
+    const decl = properties.declaration(iface, propertyName);
+    result.push(
+      `    <property name="${propertyName}" type="${decl.type}" access="${
+        decl.access
+      }"/>`
+    );
   }
   result.push('  </interface>');
   return result.join('\n');

--- a/test/integration/properties.js
+++ b/test/integration/properties.js
@@ -1,0 +1,207 @@
+// Properties end to end: access control, introspection XML, and the
+// PropertiesChanged signal actually arriving at a subscriber.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const dbus = require('../../index');
+
+const NO_BUS =
+  !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
+
+const SERVICE = 'com.github.sidorares.dbusnative.Props';
+const OBJECT_PATH = '/com/github/sidorares/dbusnative/Props';
+const IFACE = 'com.github.sidorares.dbusnative.PropsIface';
+const PROPS = 'org.freedesktop.DBus.Properties';
+
+const ifaceDesc = {
+  name: IFACE,
+  methods: {},
+  signals: {},
+  properties: {
+    // the classic form: a bare signature, still meaning readwrite
+    Greeting: 's',
+    Locked: { type: 'b', access: 'read' },
+    Secret: { type: 's', access: 'write' }
+  }
+};
+
+describe('integration: properties', { timeout: 10000, skip: NO_BUS }, () => {
+  let serviceBus, clientBus, impl;
+
+  const whenReady = bus =>
+    new Promise((resolve, reject) =>
+      bus.getId(err => (err ? reject(err) : resolve()))
+    );
+
+  const call = (member, signature, body) =>
+    clientBus.invoke({
+      destination: SERVICE,
+      path: OBJECT_PATH,
+      interface: PROPS,
+      member,
+      signature,
+      body
+    });
+
+  before(async () => {
+    serviceBus = dbus.sessionBus();
+    clientBus = dbus.sessionBus();
+    impl = Object.assign(Object.create(EventEmitter.prototype), {
+      Greeting: 'hello',
+      Locked: true,
+      Secret: 'shh'
+    });
+    EventEmitter.call(impl);
+
+    await Promise.all([whenReady(serviceBus), whenReady(clientBus)]);
+    await new Promise((resolve, reject) =>
+      serviceBus.requestName(SERVICE, 0, err => {
+        if (err) return reject(err);
+        serviceBus.exportInterface(impl, OBJECT_PATH, ifaceDesc);
+        resolve();
+      })
+    );
+    await clientBus.addMatch(
+      `type='signal',path='${OBJECT_PATH}',interface='${PROPS}'`
+    );
+  });
+
+  after(() => {
+    for (const bus of [serviceBus, clientBus]) if (bus) bus.connection.end();
+  });
+
+  // Resolves with the next PropertiesChanged, flattened to plain values.
+  const nextChange = () =>
+    new Promise(resolve => {
+      const key = clientBus.mangle(OBJECT_PATH, PROPS, 'PropertiesChanged');
+      clientBus.signals.once(key, body =>
+        resolve({
+          interfaceName: body[0],
+          changed: Object.fromEntries(body[1].map(([k, v]) => [k, v[1][0]])),
+          invalidated: body[2]
+        })
+      );
+    });
+
+  describe('introspection', () => {
+    it('advertises the declared access, not readwrite for everything', async () => {
+      const xml = await clientBus.invoke({
+        destination: SERVICE,
+        path: OBJECT_PATH,
+        interface: 'org.freedesktop.DBus.Introspectable',
+        member: 'Introspect'
+      });
+      assert.match(
+        xml,
+        /<property name="Greeting" type="s" access="readwrite"\/>/
+      );
+      assert.match(xml, /<property name="Locked" type="b" access="read"\/>/);
+      assert.match(xml, /<property name="Secret" type="s" access="write"\/>/);
+    });
+  });
+
+  describe('access control', () => {
+    it('rejects writing a read-only property', async () => {
+      await assert.rejects(
+        () => call('Set', 'ssv', [IFACE, 'Locked', ['b', false]]),
+        err => {
+          assert.strictEqual(
+            err.dbusName,
+            'org.freedesktop.DBus.Error.PropertyReadOnly'
+          );
+          return true;
+        }
+      );
+      assert.strictEqual(impl.Locked, true, 'value must be unchanged');
+    });
+
+    it('rejects reading a write-only property', async () => {
+      await assert.rejects(() => call('Get', 'ss', [IFACE, 'Secret']), {
+        dbusName: 'org.freedesktop.DBus.Error.AccessDenied'
+      });
+    });
+
+    it('omits write-only properties from GetAll', async () => {
+      const all = await call('GetAll', 's', [IFACE]);
+      const names = all.map(([k]) => k);
+      assert.deepStrictEqual(names, ['Greeting', 'Locked']);
+    });
+
+    it('still reads and writes a readwrite property', async () => {
+      await call('Set', 'ssv', [IFACE, 'Greeting', ['s', 'written']]);
+      assert.strictEqual(impl.Greeting, 'written');
+      const value = await call('Get', 'ss', [IFACE, 'Greeting']);
+      assert.strictEqual(value[1][0], 'written');
+    });
+
+    it('still reads a read-only property', async () => {
+      const value = await call('Get', 'ss', [IFACE, 'Locked']);
+      assert.strictEqual(value[1][0], true);
+    });
+
+    it('still rejects an undeclared property', async () => {
+      await assert.rejects(() => call('Get', 'ss', [IFACE, 'Nope']), {
+        dbusName: 'org.freedesktop.DBus.Error.UnknownProperty'
+      });
+    });
+  });
+
+  describe('PropertiesChanged', () => {
+    it('is emitted when Set writes a property', async () => {
+      const change = nextChange();
+      await call('Set', 'ssv', [IFACE, 'Greeting', ['s', 'via set']]);
+      assert.deepStrictEqual(await change, {
+        interfaceName: IFACE,
+        changed: { Greeting: 'via set' },
+        invalidated: []
+      });
+    });
+
+    it('invalidates rather than broadcasts a write-only property', async () => {
+      // There is no value to send, so subscribers are told to re-read.
+      const change = nextChange();
+      await call('Set', 'ssv', [IFACE, 'Secret', ['s', 'new secret']]);
+      const got = await change;
+      assert.deepStrictEqual(got.changed, {});
+      assert.deepStrictEqual(got.invalidated, ['Secret']);
+      assert.strictEqual(impl.Secret, 'new secret');
+    });
+
+    it('can be emitted by the service itself', async () => {
+      // Assigning to impl.Greeting is an ordinary property write and cannot be
+      // observed, so a service announces its own changes explicitly.
+      const change = nextChange();
+      impl.Greeting = 'changed locally';
+      serviceBus.emitPropertiesChanged(OBJECT_PATH, IFACE, {
+        Greeting: impl.Greeting
+      });
+      assert.deepStrictEqual(await change, {
+        interfaceName: IFACE,
+        changed: { Greeting: 'changed locally' },
+        invalidated: []
+      });
+    });
+
+    it('carries invalidated names given by the service', async () => {
+      const change = nextChange();
+      serviceBus.emitPropertiesChanged(OBJECT_PATH, IFACE, {}, ['Locked']);
+      const got = await change;
+      assert.deepStrictEqual(got.invalidated, ['Locked']);
+    });
+
+    it('refuses to announce a property the interface does not declare', () => {
+      assert.throws(
+        () => serviceBus.emitPropertiesChanged(OBJECT_PATH, IFACE, { Nope: 1 }),
+        /No such property "Nope"/
+      );
+    });
+
+    it('refuses to announce on an interface that is not exported', () => {
+      assert.throws(
+        () => serviceBus.emitPropertiesChanged(OBJECT_PATH, 'not.here', {}),
+        /No interface "not.here" exported/
+      );
+    });
+  });
+});

--- a/test/properties.js
+++ b/test/properties.js
@@ -1,0 +1,126 @@
+// Property declarations: the widened form, and what it means.
+//
+// The string form (`{ Greeting: 's' }`) is what essentially every existing
+// service uses, so most of what matters here is that it keeps meaning exactly
+// what it did.
+
+const { describe, it } = require('node:test');
+const assert = require('assert');
+const properties = require('../lib/properties');
+const constants = require('../lib/constants');
+
+const iface = props => ({ name: 'a.b.C', properties: props });
+
+describe('property declarations', () => {
+  it('reads the string form as readwrite', () => {
+    assert.deepStrictEqual(properties.declaration(iface({ P: 's' }), 'P'), {
+      type: 's',
+      access: 'readwrite'
+    });
+  });
+
+  it('reads the object form', () => {
+    assert.deepStrictEqual(
+      properties.declaration(iface({ P: { type: 'b', access: 'read' } }), 'P'),
+      { type: 'b', access: 'read' }
+    );
+  });
+
+  it('defaults the object form to readwrite', () => {
+    assert.deepStrictEqual(
+      properties.declaration(iface({ P: { type: 'u' } }), 'P'),
+      { type: 'u', access: 'readwrite' }
+    );
+  });
+
+  it('is undefined for a property that was not declared', () => {
+    assert.strictEqual(
+      properties.declaration(iface({ P: 's' }), 'Q'),
+      undefined
+    );
+  });
+
+  it('is undefined when the interface declares no properties', () => {
+    assert.strictEqual(
+      properties.declaration({ name: 'a.b.C' }, 'P'),
+      undefined
+    );
+  });
+
+  // `if (!props[name])` would call this undeclared.
+  it('handles a property declared with the empty signature', () => {
+    assert.deepStrictEqual(properties.declaration(iface({ P: '' }), 'P'), {
+      type: '',
+      access: 'readwrite'
+    });
+  });
+
+  it('does not treat inherited object keys as properties', () => {
+    assert.strictEqual(
+      properties.declaration(iface({ P: 's' }), 'toString'),
+      undefined
+    );
+  });
+
+  it('rejects an unknown access value', () => {
+    assert.throws(
+      () =>
+        properties.declaration(iface({ P: { type: 's', access: 'rw' } }), 'P'),
+      /expected one of read, write, readwrite/
+    );
+  });
+
+  it('rejects a declaration that is neither form', () => {
+    assert.throws(
+      () => properties.declaration(iface({ P: 42 }), 'P'),
+      /signature string or \{ type, access \}/
+    );
+  });
+
+  it('lists names in declaration order', () => {
+    assert.deepStrictEqual(
+      properties.names(iface({ B: 's', A: 's', C: { type: 'u' } })),
+      ['B', 'A', 'C']
+    );
+    assert.deepStrictEqual(properties.names({ name: 'a.b.C' }), []);
+  });
+});
+
+describe('property access', () => {
+  it('classifies readability', () => {
+    assert.ok(properties.isReadable('read'));
+    assert.ok(properties.isReadable('readwrite'));
+    assert.ok(!properties.isReadable('write'));
+  });
+
+  it('classifies writability', () => {
+    assert.ok(properties.isWritable('write'));
+    assert.ok(properties.isWritable('readwrite'));
+    assert.ok(!properties.isWritable('read'));
+  });
+});
+
+describe('PropertiesChanged signal', () => {
+  it('has the shape the spec requires', () => {
+    const sig = properties.changedSignal(
+      7,
+      '/a/b',
+      'a.b.C',
+      [['P', ['s', 'v']]],
+      ['Q']
+    );
+    assert.strictEqual(sig.type, constants.messageType.signal);
+    assert.strictEqual(sig.interface, 'org.freedesktop.DBus.Properties');
+    assert.strictEqual(sig.member, 'PropertiesChanged');
+    assert.strictEqual(sig.signature, 'sa{sv}as');
+    assert.strictEqual(sig.path, '/a/b');
+    assert.deepStrictEqual(sig.body, ['a.b.C', [['P', ['s', 'v']]], ['Q']]);
+  });
+
+  it('marshalls', () => {
+    // The signature and body have to agree or this throws.
+    const marshall = require('../lib/marshall');
+    const sig = properties.changedSignal(1, '/a', 'a.b.C', [], []);
+    assert.ok(marshall(sig.signature, sig.body).length > 0);
+  });
+});

--- a/test/types/usage.ts
+++ b/test/types/usage.ts
@@ -163,8 +163,19 @@ function service() {
     name: 'com.example.Thing',
     methods: { Echo: ['s', 's', ['input'], ['output']] },
     signals: { Pinged: ['s', 'payload'] },
-    properties: { Greeting: 's' }
+    properties: {
+      // both declaration forms
+      Greeting: 's',
+      Locked: { type: 'b', access: 'read' }
+    }
   });
+
+  bus.emitPropertiesChanged('/com/example/Thing', 'com.example.Thing', {
+    Greeting: 'hi'
+  });
+  bus.emitPropertiesChanged('/com/example/Thing', 'com.example.Thing', {}, [
+    'Locked'
+  ]);
 
   bus.sendSignal('/com/example/Thing', 'com.example.Thing', 'Pinged', 's', [
     'hi'


### PR DESCRIPTION
[ROADMAP §4.4](https://github.com/sidorares/dbus-native/blob/master/ROADMAP.md). Two of its three items — the third turned out to be stale, see below.

Additive: a bare signature still means `readwrite`, so no existing descriptor changes meaning.

## PropertiesChanged

`org.freedesktop.DBus.Properties.PropertiesChanged` was never emitted, so a subscriber to a service exported with this library could not tell when anything changed — which is the entire point of the signal.

**`Properties.Set` now emits it.** A write-only property that gets written is reported as *invalidated* rather than broadcast, since there is no value subscribers are allowed to see.

**A service announces its own changes explicitly:**

```js
impl.Greeting = 'hello again';
bus.emitPropertiesChanged(path, iface.name, { Greeting: impl.Greeting });
```

That half is deliberately not automatic. Assigning to `impl.Greeting` is an ordinary property write, and the only way to observe it would be to redefine the accessors on the object the caller handed us — surprising for `exportInterface` to do, and it would break an implementation that already uses getters. Signatures come from the interface descriptor either way, so values are marshalled as declared rather than guessed from their JS type.

## Access control

There was a `// TODO: decide how to encode access` in `interfaceToXML`, which advertised everything as `readwrite` regardless of intent — and `Set` would happily write a property meant to be read-only.

```js
properties: {
  Greeting: 's',                          // readwrite, as it always was
  Locked:   { type: 'b', access: 'read' },
  Secret:   { type: 's', access: 'write' }
}
```

| | `read` | `write` | `readwrite` |
| --- | --- | --- | --- |
| `Get` | ✓ | `AccessDenied` | ✓ |
| `Set` | `PropertyReadOnly` | ✓ | ✓ |
| `GetAll` | included | omitted | included |

The XML now advertises what was declared:

```xml
<property name="Greeting" type="s" access="readwrite"/>
<property name="Locked" type="b" access="read"/>
<property name="Secret" type="s" access="write"/>
```

## The third item was wrong

> `GetAll` on an interface with no properties still misbehaves ([#102](https://github.com/sidorares/dbus-native/issues/102)).

**#102 is closed**, and it was never about that. It reports `GetAll` failing on a property whose *value* is an empty array (`as` = `[]`) — a different thing. I checked both against the current marshaller and both work: an empty `as` property round-trips, and an interface declaring no properties at all marshals to an empty `a{sv}`.

Whatever broke in 2015 was fixed somewhere along the way. The roadmap now says so, rather than sending the next person after a bug that is not there.

## Verification

- 369 unit + 80 integration tests green (14 new unit, 13 new integration).
- Integration covers the signal actually **arriving at a subscriber** over a real daemon, not just being constructed — including the invalidated-vs-changed split for write-only properties, and that a rejected write leaves the value untouched.
- Unit tests cover the declaration parser's edge cases: a property declared with the empty signature (`if (!props[name])` would call that undeclared), inherited keys like `toString`, and both malformed forms.
- `test/types/usage.ts` exercises both declaration forms and `emitPropertiesChanged`, so the `.d.ts` cannot drift.
