### PR TITLE
feat: introspect signals, and fix proxy signal subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,50 @@ Two things worth knowing:
 - Capturing the call site costs about 1.95 µs against an 85.8 µs round trip
   (~2%), and only on the promise path.
 
+### Signals
+
+A proxy interface is an event emitter, and installs the match rule for you:
+
+```js
+iface.on('ActionInvoked', (id, action) => console.log(id, action));
+iface.once('NotificationClosed', id => console.log('closed', id));
+iface.off('ActionInvoked', handler); // drops the match rule with the last listener
+```
+
+Introspection records what the interface declares, so you can see what there is
+to subscribe to — same `[signature, ...argumentNames]` shape a service is
+exported with:
+
+```js
+iface.$signals; // { ActionInvoked: ['us', 'id', 'action_key'], ... }
+```
+
+Installing a match rule is a round trip, and `on` returns the interface for
+chaining rather than something you can wait on. When you are about to trigger
+the thing that emits the signal — or want to catch `AddMatch` being refused —
+use `$subscribe`:
+
+```js
+await iface.$subscribe('ActionInvoked', handler); // resolved => the daemon is routing it
+await iface.$unsubscribe('ActionInvoked', handler);
+```
+
+**PropertiesChanged** is a signal on `org.freedesktop.DBus.Properties`, not on
+the interface owning the property, so subscribe to the standard interface:
+
+```js
+const props = await bus
+  .getService(name)
+  .getInterface(path, 'org.freedesktop.DBus.Properties');
+
+await props.$subscribe('PropertiesChanged', (ifaceName, changed) => {
+  for (const [prop, value] of changed) console.log(prop, variantValue(value));
+});
+```
+
+For the service side of this, see
+[docs/api.md](./docs/api.md#propertieschanged).
+
 ### Observability
 
 Traffic and call timing are published on

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -571,6 +571,8 @@ property with `PropertyReadOnly`, `Get` refuses a write-only one with
 `AccessDenied`, and `GetAll` omits what cannot be read. The bare-signature
 form still means `readwrite`, so nothing existing changes.
 
+Receiving a `PropertiesChanged` — the client half — is §4.6.
+
 On the third item: [#102](https://github.com/sidorares/dbus-native/issues/102)
 is **closed**, and it was never about an interface with no properties — it
 reports `GetAll` failing on a property whose _value_ is an empty array (`as`
@@ -590,6 +592,48 @@ Note the `test/integration/` suite added in this pass already gives us real
 coverage against `dbus-daemon`, so this is now an ergonomics win rather than a
 blocker.
 
+### 4.6 Signals on the client side
+
+**Issues:** [#117](https://github.com/sidorares/dbus-native/issues/117),
+[#75](https://github.com/sidorares/dbus-native/issues/75),
+[#236](https://github.com/sidorares/dbus-native/issues/236)
+
+The other half of §4.4. A service emits `PropertiesChanged` as of 0.9; this is
+what it takes to receive one.
+
+**Done.** `lib/introspect.js` parses `<signal>` elements, so `iface.$signals`
+lists what an interface declares in the same `[signature, ...argumentNames]`
+shape a service is exported with. That closes the `// TODO: introspect signals`
+left in the file, and makes the runtime agree with `dbus-native types`, which
+had been emitting typed `on()` overloads for signals the runtime never recorded.
+
+Three things the implementation turned up:
+
+- **`off()` could silently fail to unsubscribe.** The listener bookkeeping was
+  two flat arrays shared by the whole interface, so it could not tell two
+  signals apart. Removing the last listener of one signal emptied them for
+  _every_ signal on that interface; the next `off()` then built a wrapper it had
+  never registered, removed nothing, and left the listener firing with no way to
+  stop it. Now keyed per signal name, with a count so a listener added twice
+  needs removing twice, as `EventEmitter` does. Reproduced against a real
+  daemon before the fix, and pinned by a test that fails on the old code.
+- **The subscription was installed one round trip too late.** The listener was
+  registered in the `AddMatch` _reply_ handler, but the daemon starts routing
+  when it processes the rule — necessarily before the reply gets back — so a
+  signal arriving in that window was dropped. Registering first and rolling back
+  on failure closes it.
+- **A failed `AddMatch` had nowhere to go.** It was a `throw` from inside a
+  reply handler, which the read loop turns into a connection `handlerError`.
+  That is still what `on()` does, since anything else would be a break, but
+  `$subscribe`/`$unsubscribe` now return promises: they reject with the
+  `DBusError`, and resolving means the rule is actually in place. `once()`,
+  `removeAllListeners()` and `listenerCount()` came along with them.
+
+Not addressed: the match rule still omits `sender`, so two services exporting
+the same object path deliver each other's signals. Fixing it properly means
+putting the sender in `bus.mangle`'s dispatch key, which is public API and
+belongs with the lifecycle work rather than here.
+
 ---
 
 ## 5. Lower priority / opportunistic
@@ -602,8 +646,7 @@ blocker.
   — `StartServiceByName` exists but the new API never consults it.
 - **`dbus-send` equivalent** ([#56](https://github.com/sidorares/dbus-native/issues/56))
   — a small CLI on top of the library; good first issue.
-- **Introspect signals** — `lib/introspect.js` has `// TODO: introspect signals`,
-  so proxies expose methods and properties but signals must be wired by hand.
+- **Introspect signals** — **done**, see §4.6.
 - **Double serial increment** — `exportInterface`'s patched `emit()` does
   `self.serial++` a second time after sending, burning a serial number per
   signal. Harmless but wrong; related to

--- a/docs/api.md
+++ b/docs/api.md
@@ -257,7 +257,32 @@ Assignment cannot be awaited, so a failed write has nowhere to report. Use
 
 ```js
 iface.on('ActionInvoked', (...args) => {});
+iface.once('ActionInvoked', handler); // fires at most once, then unsubscribes
 iface.off('ActionInvoked', handler); // removes the match rule when the last listener goes
+iface.removeAllListeners('ActionInvoked'); // or with no argument, every signal
+iface.listenerCount('ActionInvoked');
+```
+
+`on`/`once`/`off` return the interface, so they chain.
+
+Installing the match rule is a round trip to the daemon, and `on` cannot report
+when it finishes or that it failed. `$subscribe`/`$unsubscribe` do both:
+
+```js
+// resolved => the daemon is routing the signal to us
+await iface.$subscribe('ActionInvoked', handler);
+await iface.$unsubscribe('ActionInvoked', handler);
+```
+
+Prefer them when you are about to trigger whatever emits the signal, or when
+`AddMatch` failing is something you want to catch — from `on` it surfaces as a
+connection `handlerError` instead.
+
+**`$signals`** lists what the interface declared, in the same
+`[signature, ...argumentNames]` shape a service is exported with:
+
+```js
+iface.$signals; // { ActionInvoked: ['su', 'id', 'action'] }
 ```
 
 ---
@@ -334,6 +359,29 @@ bus.emitPropertiesChanged(path, iface.name, { Greeting: impl.Greeting });
 signatures from the interface descriptor, so values are marshalled as declared
 rather than guessed from their JS type. It throws if the interface is not
 exported at that path, or if a named property is not declared on it.
+
+**Receiving one** is a subscription on `org.freedesktop.DBus.Properties`, not on
+the interface that owns the property — the signal names that interface in its
+first argument:
+
+```js
+const props = await bus
+  .getService(name)
+  .getInterface(path, 'org.freedesktop.DBus.Properties');
+
+await props.$subscribe(
+  'PropertiesChanged',
+  (interfaceName, changed, invalidated) => {
+    for (const [prop, value] of changed) {
+      console.log(prop, variantValue(value));
+    }
+  }
+);
+```
+
+`changed` is an `a{sv}`, so until 2.0 it is an array of pairs whose values are
+variants — see [Values and types](#values-and-types) and use `variantValue()` so
+the code survives the change.
 
 The `invalidated` list names properties whose value changed but is not being
 sent — write-only ones, or anything expensive to compute. Listing them tells a

--- a/index.d.ts
+++ b/index.d.ts
@@ -294,6 +294,8 @@ export interface DBusInterface {
   $name: string;
   $parent: DBusObject;
   $methods: Record<string, string>;
+  /** Signals declared by the interface, as discovered by introspection. */
+  $signals: Record<string, SignalDescriptor>;
   $properties: Record<string, { type: string; access?: string }>;
 
   $callMethod(name: string, args: unknown[]): DBusPromise<any>;
@@ -302,10 +304,30 @@ export interface DBusInterface {
   $writeProp(name: string, value: unknown): DBusPromise<void>;
   $writeProp(name: string, value: unknown, callback: InvokeCallback): void;
 
-  addListener(signal: string, listener: (...args: any[]) => void): void;
-  on(signal: string, listener: (...args: any[]) => void): void;
-  removeListener(signal: string, listener: (...args: any[]) => void): void;
-  off(signal: string, listener: (...args: any[]) => void): void;
+  /**
+   * Subscribe, resolving once the match rule is in place.
+   *
+   * `on()` returns `this` and so cannot report that, nor report AddMatch
+   * failing. Await this when you need the subscription live before triggering
+   * whatever emits the signal.
+   */
+  $subscribe(
+    signal: string,
+    listener: (...args: any[]) => void
+  ): DBusPromise<void>;
+  /** Unsubscribe, resolving once the match rule has been dropped. */
+  $unsubscribe(
+    signal: string,
+    listener: (...args: any[]) => void
+  ): DBusPromise<void>;
+
+  addListener(signal: string, listener: (...args: any[]) => void): this;
+  on(signal: string, listener: (...args: any[]) => void): this;
+  once(signal: string, listener: (...args: any[]) => void): this;
+  removeListener(signal: string, listener: (...args: any[]) => void): this;
+  off(signal: string, listener: (...args: any[]) => void): this;
+  removeAllListeners(signal?: string): this;
+  listenerCount(signal: string): number;
 
   [member: string]: any;
 }

--- a/lib/codegen/emit-types.js
+++ b/lib/codegen/emit-types.js
@@ -58,10 +58,16 @@ function emitSignal(signal, options) {
     const [type] = signatureToTs(arg.type, options);
     return `${paramName(arg.name, i)}: ${type || 'unknown'}`;
   });
-  return `${docComment(
+  const listener = `listener: (${params.join(', ')}) => void`;
+  const doc = docComment(
     [`signal \`${signal.args.map(a => a.type).join('')}\``],
     '  '
-  )}  on(event: '${signal.name}', listener: (${params.join(', ')}) => void): void;\n`;
+  );
+  // `this` rather than void: the runtime returns the interface for chaining.
+  return (
+    `${doc}  on(event: '${signal.name}', ${listener}): this;\n` +
+    `${doc}  once(event: '${signal.name}', ${listener}): this;\n`
+  );
 }
 
 function emitProperty(property, options) {

--- a/lib/introspect.js
+++ b/lib/introspect.js
@@ -68,7 +68,20 @@ module.exports.processXML = function (err, xml, obj, callback) {
           property['$'].access
         );
       }
-      // TODO: introspect signals
+      for (let s = 0; iface.signal && s < iface.signal.length; ++s) {
+        const sig = iface.signal[s];
+        signature = '';
+        const argNames = [];
+        for (let a = 0; sig.arg && a < sig.arg.length; ++a) {
+          arg = sig.arg[a]['$'];
+          signature += arg.type || '';
+          // A name is optional in the XML, and plenty of services omit it.
+          // Fall back to a positional one so the descriptor is always the
+          // [signature, ...names] shape the service side uses.
+          argNames.push(arg.name || `arg${a}`);
+        }
+        currentIface.$createSignal(sig['$'].name, signature, argNames);
+      }
     }
     callback(null, proxy, nodes);
   });
@@ -80,59 +93,213 @@ function DBusInterface(parent_obj, ifname) {
   this.$parent = parent_obj; // parent DbusObject
   this.$name = ifname; // string interface name
   this.$methods = {}; // dictionary of methods (exposed for test), should we just store signature or use object to store more info?
-  //this.$signals = {};
+  this.$signals = {}; // signal name -> [signature, ...argumentNames]
   this.$properties = {};
-  this.$callbacks = [];
-  this.$sigHandlers = [];
+  // signal name -> Map(listener -> { wrapper, count }), where `wrapper` is
+  // what is registered on bus.signals and `count` is how many times, since
+  // EventEmitter lets the same listener be added more than once.
+  //
+  // Keyed per signal name. This used to be two flat arrays shared by the whole
+  // interface, which could not tell two signals apart: unsubscribing the last
+  // listener of one signal emptied the bookkeeping for every other signal on
+  // the interface, so the next off() built a wrapper it had never registered,
+  // removed nothing, and left the listener firing forever.
+  this.$sigHandlers = new Map();
 }
-DBusInterface.prototype.$getSigHandler = function (callback) {
-  let index;
-  if ((index = this.$callbacks.indexOf(callback)) === -1) {
-    index = this.$callbacks.push(callback) - 1;
-    this.$sigHandlers[index] = function (messageBody) {
-      callback.apply(null, messageBody);
-    };
+
+/**
+ * Find the key under which `callback` is registered.
+ *
+ * once() registers a wrapper rather than the listener itself, and records the
+ * original on `.listener` -- the same arrangement Node's EventEmitter uses --
+ * so that off(name, originalCallback) still cancels it.
+ */
+function findRegistration(handlers, callback) {
+  if (handlers.has(callback)) return callback;
+  for (const registered of handlers.keys()) {
+    if (registered.listener === callback) return registered;
   }
-  return this.$sigHandlers[index];
+  return undefined;
+}
+
+/**
+ * Report a failed AddMatch/RemoveMatch from the fire-and-forget on()/off()
+ * paths, which have nowhere to return it.
+ *
+ * These used to `throw` from inside the reply handler, which the read loop
+ * turned into a connection 'handlerError' (or an asynchronous rethrow when
+ * nobody was listening). Keep exactly that, so existing handlers still see it
+ * -- and use $subscribe()/$unsubscribe() when you would rather handle it.
+ */
+function reportSubscriptionError(bus, err) {
+  const connection = bus.connection;
+  if (connection && connection.listenerCount('handlerError') > 0) {
+    connection.emit('handlerError', err);
+    return;
+  }
+  process.nextTick(() => {
+    throw err;
+  });
+}
+
+const settled = () => maybePromise(undefined, cb => cb(null));
+
+/** The registration for a listener, created on first use. */
+function registrationFor(iface, signame, callback) {
+  let handlers = iface.$sigHandlers.get(signame);
+  if (!handlers) iface.$sigHandlers.set(signame, (handlers = new Map()));
+  let entry = handlers.get(callback);
+  if (!entry) {
+    entry = {
+      wrapper: function (messageBody) {
+        callback.apply(null, messageBody);
+      },
+      count: 0
+    };
+    handlers.set(callback, entry);
+  }
+  return entry;
+}
+
+DBusInterface.prototype.$getSigHandler = function (signame, callback) {
+  return registrationFor(this, signame, callback).wrapper;
 };
-DBusInterface.prototype.addListener = DBusInterface.prototype.on = function (
-  signame,
-  callback
-) {
+
+/**
+ * Subscribe, and report when the match rule is actually in place.
+ *
+ * on() cannot do that: it follows EventEmitter and returns `this`. Await this
+ * instead when you need to know the subscription is live before triggering
+ * whatever produces the signal, or when you want to handle AddMatch failing.
+ */
+DBusInterface.prototype.$subscribe = function (signame, callback) {
   // http://dbus.freedesktop.org/doc/api/html/group__DBusBus.html#ga4eb6401ba014da3dbe3dc4e2a8e5b3ef
   // An example is "type='signal',sender='org.freedesktop.DBus', interface='org.freedesktop.DBus',member='Foo', path='/bar/foo',destination=':452345.34'" ...
   const bus = this.$parent.service.bus;
   const signalFullName = bus.mangle(this.$parent.name, this.$name, signame);
-  if (!bus.signals.listeners(signalFullName).length) {
-    // This is the first time, so call addMatch
-    const match = getMatchRule(this.$parent.name, this.$name, signame);
-    bus.addMatch(match, err => {
+  const first = bus.signals.listenerCount(signalFullName) === 0;
+  const entry = registrationFor(this, signame, callback);
+  entry.count++;
+
+  // Registered before AddMatch is confirmed rather than in its reply: the
+  // daemon starts routing when it processes the rule, which is necessarily
+  // before the reply gets back to us, and a signal arriving in that window
+  // used to be dropped.
+  bus.signals.on(signalFullName, entry.wrapper);
+  if (!first) return settled(); // somebody already has the match rule
+
+  return maybePromise(undefined, cb =>
+    bus.addMatch(getMatchRule(this.$parent.name, this.$name, signame), err => {
       // `err` is a DBusError since 0.7; wrapping it in a plain Error would
       // throw away its name, dbusName and stack.
-      if (err) throw err;
-      bus.signals.on(signalFullName, this.$getSigHandler(callback));
-    });
-  } else {
-    // The match is already there, just add event listener
-    bus.signals.on(signalFullName, this.$getSigHandler(callback));
-  }
+      if (err) {
+        // The subscription never took. Undo exactly what this call added --
+        // not the whole entry, which may hold registrations from other calls
+        // -- so this listener does not sit on a match rule that does not
+        // exist, and a later on() installs the rule again.
+        bus.signals.removeListener(signalFullName, entry.wrapper);
+        if (--entry.count <= 0) this.$forget(signame, callback);
+      }
+      cb(err);
+    })
+  );
 };
+
+/** Unsubscribe, and report when the match rule has been dropped. */
+DBusInterface.prototype.$unsubscribe = function (signame, callback) {
+  const bus = this.$parent.service.bus;
+  const signalFullName = bus.mangle(this.$parent.name, this.$name, signame);
+  const handlers = this.$sigHandlers.get(signame);
+  const registered = handlers && findRegistration(handlers, callback);
+  if (!registered) return settled(); // not ours: nothing to undo
+
+  const entry = handlers.get(registered);
+  // removeListener drops one registration, so mirror that here rather than
+  // discarding the entry: added twice, removed once still means subscribed.
+  bus.signals.removeListener(signalFullName, entry.wrapper);
+  if (--entry.count <= 0) this.$forget(signame, registered);
+  // Other listeners -- possibly on another proxy for the same object -- still
+  // want the signal, so the match rule has to stay.
+  if (bus.signals.listenerCount(signalFullName) > 0) return settled();
+
+  return maybePromise(undefined, cb =>
+    bus.removeMatch(getMatchRule(this.$parent.name, this.$name, signame), cb)
+  );
+};
+
+/** Drop one listener from the bookkeeping, and the signal when it empties. */
+DBusInterface.prototype.$forget = function (signame, callback) {
+  const handlers = this.$sigHandlers.get(signame);
+  if (!handlers) return;
+  handlers.delete(callback);
+  if (handlers.size === 0) this.$sigHandlers.delete(signame);
+};
+
+DBusInterface.prototype.addListener = DBusInterface.prototype.on = function (
+  signame,
+  callback
+) {
+  const bus = this.$parent.service.bus;
+  this.$subscribe(signame, callback).catch(err =>
+    reportSubscriptionError(bus, err)
+  );
+  return this;
+};
+
+DBusInterface.prototype.once = function (signame, callback) {
+  const wrapper = (...args) => {
+    this.off(signame, wrapper);
+    callback.apply(null, args);
+  };
+  wrapper.listener = callback; // so off(signame, callback) cancels it too
+  return this.on(signame, wrapper);
+};
+
 DBusInterface.prototype.removeListener = DBusInterface.prototype.off =
   function (signame, callback) {
     const bus = this.$parent.service.bus;
-    const signalFullName = bus.mangle(this.$parent.name, this.$name, signame);
-    bus.signals.removeListener(signalFullName, this.$getSigHandler(callback));
-    if (!bus.signals.listeners(signalFullName).length) {
-      // There is no event handlers for this match
-      const match = getMatchRule(this.$parent.name, this.$name, signame);
-      bus.removeMatch(match, err => {
-        if (err) throw err;
-        // Now it is safe to empty these arrays
-        this.$callbacks.length = 0;
-        this.$sigHandlers.length = 0;
-      });
-    }
+    this.$unsubscribe(signame, callback).catch(err =>
+      reportSubscriptionError(bus, err)
+    );
+    return this;
   };
+
+DBusInterface.prototype.removeAllListeners = function (signame) {
+  const bus = this.$parent.service.bus;
+  const names =
+    signame === undefined ? [...this.$sigHandlers.keys()] : [signame];
+  for (const name of names) {
+    const handlers = this.$sigHandlers.get(name);
+    if (!handlers) continue;
+    // Snapshot: $unsubscribe mutates the map as it goes. A listener added
+    // more than once needs removing that many times.
+    for (const [listener, entry] of [...handlers.entries()]) {
+      for (let n = entry.count; n > 0; --n) {
+        this.$unsubscribe(name, listener).catch(err =>
+          reportSubscriptionError(bus, err)
+        );
+      }
+    }
+  }
+  return this;
+};
+
+/** How many listeners this proxy has for a signal, counting duplicates. */
+DBusInterface.prototype.listenerCount = function (signame) {
+  const handlers = this.$sigHandlers.get(signame);
+  if (!handlers) return 0;
+  let total = 0;
+  for (const entry of handlers.values()) total += entry.count;
+  return total;
+};
+
+DBusInterface.prototype.$createSignal = function (
+  sigName,
+  signature,
+  argNames
+) {
+  this.$signals[sigName] = [signature, ...argNames];
+};
 DBusInterface.prototype.$createMethod = function (mName, signature) {
   this.$methods[mName] = signature;
   this[mName] = function () {

--- a/test/codegen.js
+++ b/test/codegen.js
@@ -135,7 +135,14 @@ describe('codegen: emitted declarations', () => {
   it('emits signals as typed on() overloads', () => {
     assert.match(
       output,
-      /on\(event: 'StateChanged', listener: \(state: number, error: string\) => void\): void;/
+      /on\(event: 'StateChanged', listener: \(state: number, error: string\) => void\): this;/
+    );
+  });
+
+  it('emits a matching once() overload for each signal', () => {
+    assert.match(
+      output,
+      /once\(event: 'StateChanged', listener: \(state: number, error: string\) => void\): this;/
     );
   });
 

--- a/test/fixtures/introspection/example.json
+++ b/test/fixtures/introspection/example.json
@@ -5,6 +5,9 @@
             "methods": [
                 {"name":"AddContact", "signature":"ss"}
             ],
+            "signals": [
+                {"name":"StateChanged", "descriptor":["is", "state", "error"]}
+            ],
             "properties": [
                 {"name":"Status", "type":"u", "access":"read"}
             ]

--- a/test/integration/codegen.js
+++ b/test/integration/codegen.js
@@ -137,7 +137,11 @@ describe(
       assert.match(out, /Greeting\(\): DBusPromise<string>;/);
       assert.match(
         out,
-        /on\(event: 'Pinged', listener: \(who: string, times: number\) => void\): void;/
+        /on\(event: 'Pinged', listener: \(who: string, times: number\) => void\): this;/
+      );
+      assert.match(
+        out,
+        /once\(event: 'Pinged', listener: \(who: string, times: number\) => void\): this;/
       );
     });
 
@@ -165,8 +169,13 @@ async function main() {
   const pair: [string, number] = await iface.Pair();
   const blob: Buffer = await iface.Blob(Buffer.from([1]));
   const greeting: string = await iface.Greeting();
-  iface.on('Pinged', (who: string, times: number) => void [who, times]);
-  void [echoed, sum, pair, blob, greeting];
+  // the typed overloads return \`this\`, so subscriptions chain
+  iface
+    .on('Pinged', (who: string, times: number) => void [who, times])
+    .once('Pinged', (who: string, times: number) => void [who, times]);
+  const pinged: string[] = iface.$signals.Pinged;
+  await iface.$subscribe('Pinged', () => {});
+  void [echoed, sum, pair, blob, greeting, pinged];
 }
 void main;
 `

--- a/test/integration/signals.js
+++ b/test/integration/signals.js
@@ -1,0 +1,228 @@
+// Signals through an introspected proxy, against a real dbus-daemon.
+//
+// The client half of the properties work in 0.9: a service emits
+// PropertiesChanged, and this is what it takes to receive one.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const dbus = require('../../index');
+
+const NO_BUS =
+  !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
+
+const SERVICE = 'com.github.sidorares.dbusnative.Signals';
+const OBJECT_PATH = '/com/github/sidorares/dbusnative/Signals';
+const IFACE = 'com.github.sidorares.dbusnative.SignalsIface';
+const PROPS = 'org.freedesktop.DBus.Properties';
+
+const ifaceDesc = {
+  name: IFACE,
+  methods: {},
+  signals: {
+    Alpha: ['s', 'which'],
+    Beta: ['s', 'which'],
+    Detailed: ['si', 'who', 'times'],
+    Bare: ['']
+  },
+  properties: {
+    Greeting: 's'
+  }
+};
+
+describe('integration: proxy signals', { timeout: 10000, skip: NO_BUS }, () => {
+  let serviceBus, clientBus, impl, iface, props;
+
+  const whenReady = bus =>
+    new Promise((resolve, reject) =>
+      bus.getId(err => (err ? reject(err) : resolve()))
+    );
+
+  // Every subscription below is awaited, so nothing here depends on a signal
+  // racing an in-flight AddMatch.
+  const nextSignal = (target, name) =>
+    new Promise(resolve => {
+      const cb = (...args) => {
+        target.off(name, cb);
+        resolve(args);
+      };
+      target.on(name, cb);
+    });
+
+  before(async () => {
+    serviceBus = dbus.sessionBus();
+    clientBus = dbus.sessionBus();
+    impl = Object.assign(Object.create(EventEmitter.prototype), {
+      Greeting: 'hello'
+    });
+    EventEmitter.call(impl);
+
+    await Promise.all([whenReady(serviceBus), whenReady(clientBus)]);
+    await new Promise((resolve, reject) =>
+      serviceBus.requestName(SERVICE, 0, err => {
+        if (err) return reject(err);
+        serviceBus.exportInterface(impl, OBJECT_PATH, ifaceDesc);
+        resolve();
+      })
+    );
+
+    const service = clientBus.getService(SERVICE);
+    iface = await service.getInterface(OBJECT_PATH, IFACE);
+    props = await service.getInterface(OBJECT_PATH, PROPS);
+  });
+
+  after(() => {
+    serviceBus.connection.end();
+    clientBus.connection.end();
+  });
+
+  describe('introspection', () => {
+    it('discovers the signals the service declares', () => {
+      assert.deepStrictEqual(iface.$signals, {
+        Alpha: ['s', 'which'],
+        Beta: ['s', 'which'],
+        Detailed: ['si', 'who', 'times'],
+        Bare: ['']
+      });
+    });
+
+    it('round-trips the descriptor the service was exported with', () => {
+      assert.deepStrictEqual(iface.$signals, ifaceDesc.signals);
+    });
+
+    it('discovers PropertiesChanged on the standard interface', () => {
+      assert.deepStrictEqual(props.$signals.PropertiesChanged, [
+        'sa{sv}as',
+        'interface_name',
+        'changed_properties',
+        'invalidated_properties'
+      ]);
+    });
+  });
+
+  describe('delivery', () => {
+    it('delivers a signal with its arguments', async () => {
+      const received = nextSignal(iface, 'Alpha');
+      await new Promise(resolve => setTimeout(resolve, 50));
+      impl.emit('Alpha', 'first');
+      assert.deepStrictEqual(await received, ['first']);
+    });
+
+    it('delivers multiple arguments in order', async () => {
+      await new Promise((resolve, reject) => {
+        const cb = (...args) => {
+          iface.off('Detailed', cb);
+          try {
+            assert.deepStrictEqual(args, ['bob', 3]);
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        };
+        iface
+          .$subscribe('Detailed', cb)
+          .then(() => impl.emit('Detailed', 'bob', 3), reject);
+      });
+    });
+
+    it('delivers a signal that carries no arguments', async () => {
+      await new Promise((resolve, reject) => {
+        const cb = (...args) => {
+          iface.off('Bare', cb);
+          try {
+            assert.deepStrictEqual(args, []);
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        };
+        iface.$subscribe('Bare', cb).then(() => impl.emit('Bare'), reject);
+      });
+    });
+
+    it('is subscribed as soon as $subscribe resolves', async () => {
+      let count = 0;
+      const cb = () => count++;
+      await iface.$subscribe('Alpha', cb);
+      impl.emit('Alpha', 'immediately');
+      await new Promise(resolve => setTimeout(resolve, 200));
+      await iface.$unsubscribe('Alpha', cb);
+      assert.strictEqual(count, 1, 'signal emitted right after subscribing');
+    });
+  });
+
+  describe('unsubscribing', () => {
+    it('stops delivering after off()', async () => {
+      let count = 0;
+      const cb = () => count++;
+      await iface.$subscribe('Alpha', cb);
+      await iface.$unsubscribe('Alpha', cb);
+
+      impl.emit('Alpha', 'ignored');
+      await new Promise(resolve => setTimeout(resolve, 200));
+      assert.strictEqual(count, 0);
+    });
+
+    // Regression: removing the last listener of one signal used to discard the
+    // bookkeeping for every other signal on the interface, so this second
+    // off() removed nothing and Beta kept firing forever.
+    it('can unsubscribe one signal after another was fully removed', async () => {
+      let beta = 0;
+      const onAlpha = () => {};
+      const onBeta = () => beta++;
+
+      await iface.$subscribe('Alpha', onAlpha);
+      await iface.$subscribe('Beta', onBeta);
+      await iface.$unsubscribe('Alpha', onAlpha);
+      await iface.$unsubscribe('Beta', onBeta);
+
+      impl.emit('Beta', 'ignored');
+      await new Promise(resolve => setTimeout(resolve, 200));
+      assert.strictEqual(beta, 0);
+      assert.strictEqual(iface.listenerCount('Beta'), 0);
+    });
+
+    it('fires a once() listener exactly once', async () => {
+      let count = 0;
+      iface.once('Alpha', () => count++);
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      impl.emit('Alpha', 'one');
+      await new Promise(resolve => setTimeout(resolve, 100));
+      impl.emit('Alpha', 'two');
+      await new Promise(resolve => setTimeout(resolve, 200));
+
+      assert.strictEqual(count, 1);
+      assert.strictEqual(iface.listenerCount('Alpha'), 0);
+    });
+  });
+
+  describe('PropertiesChanged', () => {
+    it('reaches a subscriber on the standard Properties interface', async () => {
+      const received = nextSignal(props, 'PropertiesChanged');
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      serviceBus.emitPropertiesChanged(OBJECT_PATH, IFACE, {
+        Greeting: 'hello again'
+      });
+
+      const [ifaceName, changed, invalidated] = await received;
+      assert.strictEqual(ifaceName, IFACE);
+      assert.deepStrictEqual(invalidated, []);
+      // Still the classic variant shape: [name, [signatureTree, [value]]].
+      assert.strictEqual(changed[0][0], 'Greeting');
+      assert.strictEqual(changed[0][1][1][0], 'hello again');
+    });
+
+    it('is emitted by Properties.Set as well', async () => {
+      const received = nextSignal(props, 'PropertiesChanged');
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      await props.Set(IFACE, 'Greeting', ['s', 'set by the client']);
+
+      const [, changed] = await received;
+      assert.strictEqual(changed[0][0], 'Greeting');
+      assert.strictEqual(changed[0][1][1][0], 'set by the client');
+    });
+  });
+});

--- a/test/proxy-signals.js
+++ b/test/proxy-signals.js
@@ -1,0 +1,318 @@
+// Signal subscription on an introspected proxy.
+//
+// Driven through a stub bus rather than a daemon: what is under test is the
+// bookkeeping between the proxy and `bus.signals`, and AddMatch failing is
+// awkward to arrange for real. test/integration/signals.js covers the same
+// surface end to end.
+
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const introspect = require('../lib/introspect');
+
+const IFACE = 'com.example.Iface';
+const PATH = '/com/example/Obj';
+
+const XML = `<node>
+  <interface name="${IFACE}">
+    <method name="Poke"><arg name="how" direction="in" type="s"/></method>
+    <signal name="Alpha"><arg name="which" type="s"/></signal>
+    <signal name="Beta"><arg name="which" type="s"/></signal>
+    <signal name="Bare"/>
+    <signal name="Unnamed"><arg type="s"/><arg type="i"/></signal>
+    <property name="Status" type="u" access="read"/>
+  </interface>
+</node>`;
+
+// A bus with just the surface the proxy touches.
+function stubBus() {
+  const bus = {
+    signals: new EventEmitter(),
+    matches: [],
+    addMatchError: null,
+    removeMatchError: null,
+    mangle: (path, iface, member) =>
+      JSON.stringify({ path, interface: iface, member }),
+    addMatch(match, callback) {
+      if (bus.addMatchError) return queue(callback, bus.addMatchError);
+      bus.matches.push(match);
+      queue(callback, null);
+    },
+    removeMatch(match, callback) {
+      if (bus.removeMatchError) return queue(callback, bus.removeMatchError);
+      bus.matches = bus.matches.filter(m => m !== match);
+      queue(callback, null);
+    }
+  };
+  return bus;
+}
+
+// Replies arrive off a socket, so never synchronously.
+const queue = (callback, err) => setImmediate(() => callback(err));
+
+const proxyFor = bus =>
+  new Promise((resolve, reject) => {
+    const obj = { name: PATH, service: { name: 'com.example', bus } };
+    introspect.processXML(null, XML, obj, (err, proxy) =>
+      err ? reject(err) : resolve(proxy[IFACE])
+    );
+  });
+
+describe('proxy signals', () => {
+  let bus, iface;
+
+  beforeEach(async () => {
+    bus = stubBus();
+    iface = await proxyFor(bus);
+  });
+
+  const key = member => bus.mangle(PATH, IFACE, member);
+  const fire = (member, body) => bus.signals.emit(key(member), body);
+
+  describe('introspection', () => {
+    it('records signals as [signature, ...argumentNames]', () => {
+      assert.deepStrictEqual(iface.$signals.Alpha, ['s', 'which']);
+    });
+
+    it('records a signal with no arguments', () => {
+      assert.deepStrictEqual(iface.$signals.Bare, ['']);
+    });
+
+    it('falls back to positional names when the XML omits them', () => {
+      assert.deepStrictEqual(iface.$signals.Unnamed, ['si', 'arg0', 'arg1']);
+    });
+
+    it('leaves methods and properties alone', () => {
+      assert.strictEqual(iface.$methods.Poke, 's');
+      assert.strictEqual(iface.$properties.Status.type, 'u');
+    });
+  });
+
+  describe('on', () => {
+    it('delivers the signal body as arguments', async () => {
+      const seen = [];
+      await iface.$subscribe('Alpha', (...args) => seen.push(args));
+      fire('Alpha', ['hello']);
+      assert.deepStrictEqual(seen, [['hello']]);
+    });
+
+    it('adds the match rule once per signal', async () => {
+      await iface.$subscribe('Alpha', () => {});
+      await iface.$subscribe('Alpha', () => {});
+      assert.deepStrictEqual(bus.matches, [
+        `type='signal',path='${PATH}',interface='${IFACE}',member='Alpha'`
+      ]);
+    });
+
+    it('returns the interface, so calls chain', () => {
+      assert.strictEqual(
+        iface.on('Alpha', () => {}),
+        iface
+      );
+    });
+
+    it('is subscribed by the time $subscribe resolves', async () => {
+      let count = 0;
+      await iface.$subscribe('Alpha', () => count++);
+      fire('Alpha', ['x']);
+      assert.strictEqual(count, 1);
+    });
+  });
+
+  describe('off', () => {
+    it('stops delivering', async () => {
+      let count = 0;
+      const cb = () => count++;
+      await iface.$subscribe('Alpha', cb);
+      await iface.$unsubscribe('Alpha', cb);
+      fire('Alpha', ['x']);
+      assert.strictEqual(count, 0);
+    });
+
+    it('removes the match rule once nothing is listening', async () => {
+      const cb = () => {};
+      await iface.$subscribe('Alpha', cb);
+      await iface.$unsubscribe('Alpha', cb);
+      assert.deepStrictEqual(bus.matches, []);
+    });
+
+    it('keeps the match rule while another listener remains', async () => {
+      const cb = () => {};
+      await iface.$subscribe('Alpha', cb);
+      await iface.$subscribe('Alpha', () => {});
+      await iface.$unsubscribe('Alpha', cb);
+      assert.strictEqual(bus.matches.length, 1);
+    });
+
+    // The regression this file exists for: unsubscribing the last listener of
+    // one signal used to wipe the bookkeeping for every signal on the
+    // interface, so the next off() removed nothing and the listener kept
+    // firing with no way to stop it.
+    it('still works for one signal after another was fully removed', async () => {
+      let beta = 0;
+      const onAlpha = () => {};
+      const onBeta = () => beta++;
+
+      await iface.$subscribe('Alpha', onAlpha);
+      await iface.$subscribe('Beta', onBeta);
+      await iface.$unsubscribe('Alpha', onAlpha);
+      await iface.$unsubscribe('Beta', onBeta);
+
+      fire('Beta', ['x']);
+      assert.strictEqual(beta, 0);
+      assert.strictEqual(bus.signals.listenerCount(key('Beta')), 0);
+      assert.deepStrictEqual(bus.matches, []);
+    });
+
+    // The same regression through on()/off(), which is what callers use and
+    // what the old implementation left permanently subscribed.
+    it('still works through on()/off() after another signal was removed', async () => {
+      let beta = 0;
+      const onAlpha = () => {};
+      const onBeta = () => beta++;
+      const settle = () => new Promise(resolve => setTimeout(resolve, 10));
+
+      iface.on('Alpha', onAlpha);
+      iface.on('Beta', onBeta);
+      await settle();
+      iface.off('Alpha', onAlpha);
+      await settle();
+      iface.off('Beta', onBeta);
+      await settle();
+
+      fire('Beta', ['x']);
+      assert.strictEqual(beta, 0, 'off() left the listener subscribed');
+      assert.strictEqual(bus.signals.listenerCount(key('Beta')), 0);
+    });
+
+    it('ignores a listener that was never subscribed', async () => {
+      await iface.$unsubscribe('Alpha', () => {});
+      assert.deepStrictEqual(bus.matches, []);
+    });
+
+    it('removes one registration per call when added twice', async () => {
+      let count = 0;
+      const cb = () => count++;
+      await iface.$subscribe('Alpha', cb);
+      await iface.$subscribe('Alpha', cb);
+      assert.strictEqual(iface.listenerCount('Alpha'), 2);
+
+      await iface.$unsubscribe('Alpha', cb);
+      fire('Alpha', ['x']);
+      assert.strictEqual(count, 1, 'added twice, removed once: still firing');
+
+      await iface.$unsubscribe('Alpha', cb);
+      fire('Alpha', ['x']);
+      assert.strictEqual(count, 1);
+      assert.strictEqual(bus.signals.listenerCount(key('Alpha')), 0);
+    });
+  });
+
+  describe('once', () => {
+    it('fires exactly once and drops the match rule', async () => {
+      let count = 0;
+      iface.once('Alpha', () => count++);
+      await new Promise(setImmediate);
+
+      fire('Alpha', ['x']);
+      fire('Alpha', ['x']);
+      assert.strictEqual(count, 1);
+
+      await new Promise(setImmediate);
+      assert.deepStrictEqual(bus.matches, []);
+    });
+
+    it('can be cancelled with the original listener', async () => {
+      let count = 0;
+      const cb = () => count++;
+      iface.once('Alpha', cb);
+      await new Promise(setImmediate);
+      await iface.$unsubscribe('Alpha', cb);
+
+      fire('Alpha', ['x']);
+      assert.strictEqual(count, 0);
+    });
+  });
+
+  describe('removeAllListeners', () => {
+    it('removes every listener for one signal', async () => {
+      await iface.$subscribe('Alpha', () => {});
+      await iface.$subscribe('Alpha', () => {});
+      await iface.$subscribe('Beta', () => {});
+
+      iface.removeAllListeners('Alpha');
+      await new Promise(setImmediate);
+
+      assert.strictEqual(iface.listenerCount('Alpha'), 0);
+      assert.strictEqual(iface.listenerCount('Beta'), 1);
+      assert.strictEqual(bus.matches.length, 1);
+    });
+
+    it('removes every listener on the interface when given no name', async () => {
+      await iface.$subscribe('Alpha', () => {});
+      await iface.$subscribe('Beta', () => {});
+
+      iface.removeAllListeners();
+      await new Promise(setImmediate);
+
+      assert.strictEqual(bus.signals.eventNames().length, 0);
+      assert.deepStrictEqual(bus.matches, []);
+    });
+  });
+
+  describe('when AddMatch fails', () => {
+    beforeEach(() => {
+      bus.addMatchError = Object.assign(new Error('denied'), {
+        name: 'DBusError',
+        dbusName: 'org.freedesktop.DBus.Error.AccessDenied'
+      });
+    });
+
+    it('rejects with the DBusError, keeping its name', async () => {
+      const err = await iface
+        .$subscribe('Alpha', () => {})
+        .then(
+          () => null,
+          e => e
+        );
+      assert.ok(err, 'expected $subscribe to reject');
+      assert.strictEqual(
+        err.dbusName,
+        'org.freedesktop.DBus.Error.AccessDenied'
+      );
+    });
+
+    it('leaves no listener behind on a failed subscription', async () => {
+      await iface.$subscribe('Alpha', () => {}).catch(() => {});
+      assert.strictEqual(bus.signals.listenerCount(key('Alpha')), 0);
+      assert.strictEqual(iface.listenerCount('Alpha'), 0);
+    });
+
+    it('retries the match rule on the next subscribe', async () => {
+      await iface.$subscribe('Alpha', () => {}).catch(() => {});
+      bus.addMatchError = null;
+
+      let count = 0;
+      await iface.$subscribe('Alpha', () => count++);
+      fire('Alpha', ['x']);
+      assert.strictEqual(count, 1);
+      assert.strictEqual(bus.matches.length, 1);
+    });
+
+    it('reports through the connection rather than throwing, via on()', async () => {
+      const connection = new EventEmitter();
+      bus.connection = connection;
+      const errors = [];
+      connection.on('handlerError', e => errors.push(e));
+
+      iface.on('Alpha', () => {});
+      await new Promise(setImmediate);
+
+      assert.strictEqual(errors.length, 1);
+      assert.strictEqual(
+        errors[0].dbusName,
+        'org.freedesktop.DBus.Error.AccessDenied'
+      );
+    });
+  });
+});

--- a/test/test_introspect.js
+++ b/test/test_introspect.js
@@ -69,6 +69,23 @@ function checkIntrospection(test_obj, proxy, _nodes) {
           }`
         );
     }
+    for (let s = 0; s < (testInterface.signals || []).length; ++s) {
+      const signalName = testInterface.signals[s].name;
+      const curSignal = proxy[testInterface.name].$signals[signalName];
+      if (curSignal === undefined)
+        throw new Error(
+          `Failed to introspect signal name ${signalName} of ${
+            testInterface.name
+          }`
+        );
+      const expected = testInterface.signals[s].descriptor;
+      if (curSignal.join(',') !== expected.join(','))
+        throw new Error(
+          `Failed to introspect signal args of ${signalName} of ${
+            testInterface.name
+          }: got ${JSON.stringify(curSignal)}, want ${JSON.stringify(expected)}`
+        );
+    }
     for (let p = 0; p < testInterface.properties.length; ++p) {
       const propName = testInterface.properties[p].name;
       const curProp = proxy[testInterface.name].$properties[propName];


### PR DESCRIPTION
The client half of the properties work in 0.9: a service emits
`PropertiesChanged`, and this is what it takes to receive one.

`lib/introspect.js` parsed methods and properties out of the introspection XML
and dropped `<signal>` on the floor, behind a `// TODO: introspect signals`. So
`dbus-native types` had been emitting typed `on()` overloads for signals the
runtime kept no record of.

Proxies now expose `$signals`, in the same `[signature, ...argumentNames]` shape
a service is exported with:

```js
iface.$signals; // { ActionInvoked: ['us', 'id', 'action_key'] }
```

## Three things this turned up

**`off()` could silently fail to unsubscribe.** The listener bookkeeping was two
flat arrays shared by the whole interface, so it could not tell two signals
apart. Removing the last listener of one signal emptied them for *every* signal
on that interface; the next `off()` then built a wrapper it had never
registered, removed nothing, and left the listener firing with no way to stop
it. Reproduced against a real daemon before the fix:

```
after off() of both:  alpha=1 (was 1) beta=2 (was 1)
BUG: off("Beta") did not remove the listener; it still fires
leftover bus.signals listeners: [["Beta",1]]
```

Now keyed per signal name, with a count so a listener added twice needs removing
twice, as `EventEmitter` does. The regression test fails on the old code with
`off() left the listener subscribed`.

**The subscription was installed one round trip too late.** The listener was
registered in the `AddMatch` *reply* handler, but the daemon starts routing when
it processes the rule — necessarily before the reply gets back to us — so a
signal arriving in that window was dropped. Register first, roll back on
failure.

**A failed `AddMatch` had nowhere to go.** It was a `throw` from inside a reply
handler, which the read loop turns into a connection `handlerError`. That is
still what `on()` does, since anything else would be a break, but
`$subscribe`/`$unsubscribe` now return promises — they reject with the
`DBusError`, and resolving means the rule is really in place:

```js
await iface.$subscribe('ActionInvoked', handler); // then trigger it, no race
```

## Also

`once()`, `removeAllListeners()` and `listenerCount()`; `on()`/`off()` return
the interface so they chain, and the generated overloads say so (plus a matching
`once()` overload per signal).

## Not addressed

The match rule still omits `sender`, so two services exporting the same object
path deliver each other's signals. Fixing that properly means putting the sender
in `bus.mangle`'s dispatch key, which is public API — noted in ROADMAP §4.6 for
the lifecycle release.

## Testing

- `test/proxy-signals.js` — 26 unit tests through a stub bus, including the
  `AddMatch`-refused paths, which are awkward to arrange against a daemon.
- `test/integration/signals.js` — 12 tests end to end against `dbus-daemon`,
  covering `PropertiesChanged` from both `emitPropertiesChanged` and
  `Properties.Set`.
- Generated declarations are type-checked using `once`, chaining, `$signals`
  and `$subscribe`.

397 unit and 92 integration tests pass.

Closes #117, closes #75. Refs #236.