### PR TITLE
feat: validate names against the D-Bus rules before sending them

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,35 @@ rest rather than guessing. See
 [`dbus-native/compat`](docs/migrating-to-0.7.md#the-escape-hatch) if you need the
 old shape while you migrate.
 
+### Names
+
+Object paths, interface names, error names and member names each have their own
+rules, and a name that breaks them produces a message no peer can route. Those
+you **send** are now checked — `exportInterface` (the path, the interface name
+and every member name), `sendSignal`, `sendError`, and any `o` value, which
+covers the path header of every outgoing message. Each throws an `Error` naming
+the rule that was broken:
+
+```
+Invalid interface name for the interface descriptor: "MyIface" -- must be two or
+more dot-separated elements of [A-Za-z_][A-Za-z0-9_]*, at most 255 bytes
+```
+
+This matters most for signals: a method call with a bad name comes back as an
+error from the daemon or the peer, but a signal gets no reply and simply
+vanishes.
+
+Names that arrive from a peer are not checked — strict in what you send,
+lenient in what you accept. For names built at runtime, the predicates are
+exported so you can check rather than catch:
+
+```js
+const { isValidObjectPath } = require('dbus-native');
+isValidObjectPath(`/com/example/${deviceId}`); // a '-' in deviceId would throw at export
+```
+
+See [docs/api.md](docs/api.md#names) for the full rules.
+
 ### 64-bit values: INT64 'x' and UINT64 't'
 
 By default these are unmarshalled into a `number`, which **loses precision

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -646,6 +646,27 @@ belongs with the lifecycle work rather than here.
   — `StartServiceByName` exists but the new API never consults it.
 - **`dbus-send` equivalent** ([#56](https://github.com/sidorares/dbus-native/issues/56))
   — a small CLI on top of the library; good first issue.
+- **Name validation** ([#309](https://github.com/sidorares/dbus-native/issues/309))
+  — **done.** `lib/names.js` implements the four rule sets, and the predicates
+  are exported. Enforced on what we send: `exportInterface` (path, interface
+  name, every member name), `sendSignal`, `sendError`, and the `o` marshaller,
+  which covers the path header of every outgoing message and closes the
+  `// TODO: verify object path for 'o'`.
+
+  Three decisions worth recording. **Throw rather than warn** — the issue left
+  this open; an invalid name yields a message no peer can route, so the code
+  was already broken and the useful place to say so is where the name was
+  written. **Signals get validated but ordinary calls do not**: a bad interface
+  or member on a method call comes back as an error from the daemon or the
+  peer, whereas a signal gets no reply and simply vanishes. Validating all four
+  header fields on every message measured 0.135 µs against a 4.13 µs marshall
+  (3.3%) and is still available if the silent-failure argument ever extends to
+  calls. **Incoming names are not checked** — the spec only requires that a
+  receiver _can_ reject one, `readString` already bounds-checks, and refusing
+  a sloppy peer's path would break interop over something we pass through
+  harmlessly. The commented-out check in `dbus-buffer.js` is now a note saying
+  so rather than a TODO.
+
 - **Introspect signals** — **done**, see §4.6.
 - **Double serial increment** — `exportInterface`'s patched `emit()` does
   `self.serial++` a second time after sending, burning a serial number per

--- a/docs/api.md
+++ b/docs/api.md
@@ -530,6 +530,52 @@ tell those two apart, which is why the parser tags them rather than guessing.
 
 ---
 
+## Names
+
+Object paths, interface names, error names, member names and bus names each
+have their own rules in the
+[specification](https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names),
+and they are easy to confuse:
+
+| kind           | shape                                              | notes                                   |
+| -------------- | -------------------------------------------------- | --------------------------------------- |
+| object path    | `/`, or `/`-separated `[A-Za-z0-9_]` elements      | elements may start with a digit; no `.` |
+| interface name | two or more `.`-separated `[A-Za-z_][A-Za-z0-9_]*` | no `-`, no leading digit, ≤ 255 bytes   |
+| error name     | as interface names                                 |                                         |
+| member name    | one `[A-Za-z_][A-Za-z0-9_]*` element               | no dots, ≤ 255 bytes                    |
+| bus name       | `:1.23`, or an interface name that may contain `-` | ≤ 255 bytes                             |
+
+These are enforced on what you **send**, because an invalid name produces a
+message no peer can route — and for a signal, which gets no reply, that fails
+silently:
+
+| where                   | checks                                          |
+| ----------------------- | ----------------------------------------------- |
+| `bus.exportInterface()` | the path, `iface.name`, and every member name   |
+| `bus.sendSignal()`      | the interface and member name                   |
+| `bus.sendError()`       | the error name                                  |
+| marshalling an `o`      | the object path, including every message's path |
+
+All of them throw an `Error` naming the rule that was broken. Incoming names
+are not checked — be strict in what you send, lenient in what you accept.
+
+The predicates are exported for names built at runtime, where checking beats
+catching:
+
+```js
+const { isValidInterfaceName, isValidObjectPath } = require('dbus-native');
+
+if (!isValidObjectPath(`/com/example/${deviceId}`)) {
+  // a device id with a '-' in it would be rejected at export
+}
+```
+
+`isValidObjectPath`, `isValidInterfaceName`, `isValidErrorName`,
+`isValidMemberName` and `isValidBusName` all take any value and return a
+boolean.
+
+---
+
 ## Errors
 
 Every failure is an `Error`. All of these extend `DBusError`, which extends

--- a/index.d.ts
+++ b/index.d.ts
@@ -80,6 +80,35 @@ export function variantSignature(value: unknown): string | undefined;
 export function toPlain<T = unknown>(value: unknown): T;
 
 // ---------------------------------------------------------------------------
+// Names
+// ---------------------------------------------------------------------------
+
+/**
+ * The D-Bus naming rules.
+ *
+ * https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names
+ *
+ * `exportInterface`, `sendSignal`, `sendError` and the `o` marshaller enforce
+ * these on what you send. Use them directly when a name is built at runtime and
+ * you would rather check than catch.
+ */
+
+/** `/`, or `/`-separated non-empty elements of `[A-Za-z0-9_]`. */
+export function isValidObjectPath(path: unknown): boolean;
+
+/** Two or more `.`-separated `[A-Za-z_][A-Za-z0-9_]*` elements, ≤ 255 bytes. */
+export function isValidInterfaceName(name: unknown): boolean;
+
+/** Error names follow the interface-name rules. */
+export function isValidErrorName(name: unknown): boolean;
+
+/** A single `[A-Za-z_][A-Za-z0-9_]*` element with no dots, ≤ 255 bytes. */
+export function isValidMemberName(name: unknown): boolean;
+
+/** A unique name like `:1.23`, or a well-known name (which may contain `-`). */
+export function isValidBusName(name: unknown): boolean;
+
+// ---------------------------------------------------------------------------
 // Errors
 // ---------------------------------------------------------------------------
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const server = require('./lib/server');
 const deprecate = require('./lib/deprecate');
 const values = require('./lib/values');
 const errors = require('./lib/errors');
+const names = require('./lib/names');
 const { publishSend, publishReceive } = require('./lib/diagnostics');
 
 // A d-bus address is `family:key=value,key=value`, and DBUS_SESSION_BUS_ADDRESS
@@ -249,6 +250,16 @@ module.exports.Variant = values.Variant;
 module.exports.variantValue = values.variantValue;
 module.exports.variantSignature = values.variantSignature;
 module.exports.toPlain = values.toPlain;
+
+// The D-Bus naming rules, exported because anything building names at runtime
+// -- from a config file, a device id, a user-supplied string -- wants to check
+// before it exports rather than catch the throw afterwards.
+module.exports.isValidObjectPath = names.isValidObjectPath;
+module.exports.isValidInterfaceName = names.isValidInterfaceName;
+module.exports.isValidErrorName = names.isValidErrorName;
+module.exports.isValidMemberName = names.isValidMemberName;
+module.exports.isValidBusName = names.isValidBusName;
+
 module.exports.createConnection = createConnection;
 
 module.exports.createServer = server.createServer;

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -3,6 +3,7 @@ const constants = require('./constants');
 const stdDbusIfaces = require('./stdifaces');
 const introspect = require('./introspect').introspectBus;
 const { maybePromise } = require('./promisify');
+const { assertValidName } = require('./names');
 const {
   TimeoutError,
   AbortError,
@@ -175,6 +176,11 @@ module.exports = function bus(conn, opts) {
   };
 
   this.sendSignal = function (path, iface, name, signature, args) {
+    // A signal gets no reply, so an unroutable one fails silently -- unlike a
+    // method call, where the daemon or the peer would tell you. The path goes
+    // through the 'o' marshaller, which validates it; these two do not.
+    assertValidName('interface name', iface, 'the signal interface');
+    assertValidName('member name', name, 'the signal name');
     const signalMsg = {
       type: constants.messageType.signal,
       serial: self.serial++,
@@ -242,8 +248,11 @@ module.exports = function bus(conn, opts) {
     );
   };
 
-  // Warning: errorName must respect the same rules as interface names (must contain a dot)
   this.sendError = function (msg, errorName, errorText) {
+    // Error names follow the interface-name rules. An invalid one is a
+    // protocol violation the peer cannot route, so it is better to fail here
+    // than to put it on the wire.
+    assertValidName('error name', errorName);
     const reply = {
       type: constants.messageType.error,
       serial: self.serial++,
@@ -379,6 +388,17 @@ module.exports = function bus(conn, opts) {
   };
 
   this.exportInterface = function (obj, path, iface) {
+    // Checked here rather than at the first method call: an object exported
+    // under a name a peer cannot route to is unreachable, and the useful place
+    // to say so is where the mistake was made.
+    assertValidName('object path', path);
+    assertValidName('interface name', iface.name, 'the interface descriptor');
+    for (const kind of ['methods', 'signals', 'properties']) {
+      for (const member of Object.keys(iface[kind] || {})) {
+        assertValidName('member name', member, `${kind}.${member}`);
+      }
+    }
+
     let entry;
     if (!self.exportedObjects[path]) {
       entry = self.exportedObjects[path] = {};

--- a/lib/dbus-buffer.js
+++ b/lib/dbus-buffer.js
@@ -241,9 +241,11 @@ DBusBuffer.prototype.readSimpleType = function readSimpleType(t) {
     case 'o':
       len = this.readInt32();
       return this.readString(len);
-    // TODO: validate object path here
-    //if (t === 'o' && !isValidObjectPath(str))
-    //  throw new Error('string is not a valid object path'));
+    // An incoming object path is deliberately not validated, though what we
+    // send is (see lib/names.js). The spec only requires a receiver to be
+    // able to reject one, a malformed path is not a memory-safety problem --
+    // readString already bounds-checks -- and refusing one would break
+    // interop with a sloppy peer over a name we can pass through harmlessly.
     // 64-bit. `returnBigInt` is the forward-compatible option and wins over
     // `ReturnLongjs` when both are set: BigInt is what these become in 2.0,
     // and silently preferring the deprecated one would be the wrong default

--- a/lib/marshallers.js
+++ b/lib/marshallers.js
@@ -1,4 +1,5 @@
 const parseSignature = require('./signature');
+const { isValidObjectPath } = require('./names');
 const Long = require('long');
 
 // The validation helpers are shared by every marshaller and do not depend on
@@ -180,10 +181,22 @@ const checkLong = function (data, signed) {
  * `marshall` writes it into a Writer.
  */
 const marshallers = {
-  // STRING and OBJECT_PATH
-  // TODO: verify object path for 'o'
+  // STRING
   s: {
     check: checkValidString,
+    marshall: (writer, data) => writer.string(data)
+  },
+  // OBJECT_PATH -- written exactly like a string, but not any string will do.
+  // This runs on the path header field of every outgoing message.
+  o: {
+    check(data) {
+      checkValidString(data);
+      if (!isValidObjectPath(data)) {
+        throw new Error(
+          `Data: ${data} is not a valid object path -- must start with "/" and contain only [A-Za-z0-9_] elements`
+        );
+      }
+    },
     marshall: (writer, data) => writer.string(data)
   },
   // SIGNATURE
@@ -271,7 +284,6 @@ const marshallers = {
     marshall: (writer, data) => writer.double(data)
   }
 };
-marshallers.o = marshallers.s;
 
 /**
  * MakeSimpleMarshaller

--- a/lib/names.js
+++ b/lib/names.js
@@ -1,0 +1,134 @@
+// The D-Bus naming rules.
+//
+// https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names
+//
+// Four kinds of name, with four different rule sets that are easy to confuse:
+// object paths use `/` and allow leading digits, interface and error names use
+// `.` and do not, member names allow neither, and bus names are interface names
+// that additionally allow `-` (and, when unique, a leading `:` and digits).
+//
+// These are applied to what we *send*. Incoming names are left alone -- be
+// strict in what you emit and lenient in what you accept, which is also what
+// the spec allows a receiver to do.
+
+const MAX_NAME_LENGTH = 255;
+
+// Each of these has a forced boundary between repetitions -- the separator is
+// never a member of the element character class -- so they match in linear time
+// and cannot be made to backtrack.
+const INTERFACE_NAME = /^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+$/;
+const MEMBER_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const WELL_KNOWN_BUS_NAME =
+  /^[A-Za-z_-][A-Za-z0-9_-]*(?:\.[A-Za-z_-][A-Za-z0-9_-]*)+$/;
+// Unique names are ':' followed by elements that may start with a digit.
+const UNIQUE_BUS_NAME = /^:[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)*$/;
+
+/**
+ * An object path: '/', or '/'-separated non-empty elements of [A-Za-z0-9_].
+ *
+ * Scanned rather than matched: this runs on the path header of every outgoing
+ * message, and a hand-rolled loop is both quicker and obviously free of
+ * backtracking. The spec sets no length limit on paths.
+ */
+function isValidObjectPath(path) {
+  if (typeof path !== 'string' || path.length === 0) return false;
+  if (path[0] !== '/') return false;
+  if (path.length === 1) return true; // the root path
+  if (path[path.length - 1] === '/') return false; // no trailing slash
+
+  let elementLength = 0;
+  for (let i = 1; i < path.length; ++i) {
+    const c = path[i];
+    if (c === '/') {
+      if (elementLength === 0) return false; // empty element, i.e. '//'
+      elementLength = 0;
+      continue;
+    }
+    const isAllowed =
+      (c >= 'A' && c <= 'Z') ||
+      (c >= 'a' && c <= 'z') ||
+      (c >= '0' && c <= '9') ||
+      c === '_';
+    if (!isAllowed) return false;
+    elementLength++;
+  }
+  return elementLength > 0;
+}
+
+/** An interface name: two or more '.'-separated elements, max 255 bytes. */
+function isValidInterfaceName(name) {
+  return (
+    typeof name === 'string' &&
+    name.length > 0 &&
+    name.length <= MAX_NAME_LENGTH &&
+    INTERFACE_NAME.test(name)
+  );
+}
+
+/** An error name. The spec gives these the same rules as interface names. */
+const isValidErrorName = isValidInterfaceName;
+
+/** A member name: one element, no dots, max 255 bytes. */
+function isValidMemberName(name) {
+  return (
+    typeof name === 'string' &&
+    name.length > 0 &&
+    name.length <= MAX_NAME_LENGTH &&
+    MEMBER_NAME.test(name)
+  );
+}
+
+/** A bus name: well-known like an interface name, or a unique ':1.23'. */
+function isValidBusName(name) {
+  if (typeof name !== 'string') return false;
+  if (name.length === 0 || name.length > MAX_NAME_LENGTH) return false;
+  return name[0] === ':'
+    ? UNIQUE_BUS_NAME.test(name)
+    : WELL_KNOWN_BUS_NAME.test(name);
+}
+
+// Why each kind of name is rejected, so the error says what to fix rather than
+// just restating the input.
+const RULES = {
+  'object path': 'must start with "/" and contain only [A-Za-z0-9_] elements',
+  'interface name':
+    'must be two or more dot-separated elements of [A-Za-z_][A-Za-z0-9_]*, at most 255 bytes',
+  'error name':
+    'must be two or more dot-separated elements of [A-Za-z_][A-Za-z0-9_]*, at most 255 bytes',
+  'member name':
+    'must be a single element of [A-Za-z_][A-Za-z0-9_]* with no dots, at most 255 bytes',
+  'bus name':
+    'must be a unique name like ":1.23", or two or more dot-separated elements, at most 255 bytes'
+};
+
+const VALIDATORS = {
+  'object path': isValidObjectPath,
+  'interface name': isValidInterfaceName,
+  'error name': isValidErrorName,
+  'member name': isValidMemberName,
+  'bus name': isValidBusName
+};
+
+/**
+ * Throw unless `value` is a valid name of `kind`.
+ *
+ * `context` names where it came from, since by the time an interface name is
+ * rejected the caller may have passed several.
+ */
+function assertValidName(kind, value, context) {
+  if (VALIDATORS[kind](value)) return value;
+  const where = context ? ` for ${context}` : '';
+  throw new Error(
+    `Invalid ${kind}${where}: ${JSON.stringify(value)} -- ${RULES[kind]}`
+  );
+}
+
+module.exports = {
+  MAX_NAME_LENGTH,
+  isValidObjectPath,
+  isValidInterfaceName,
+  isValidErrorName,
+  isValidMemberName,
+  isValidBusName,
+  assertValidName
+};

--- a/test/exports.js
+++ b/test/exports.js
@@ -36,6 +36,20 @@ describe('public exports', () => {
     }
   });
 
+  it('exports the name validators', () => {
+    for (const name of [
+      'isValidObjectPath',
+      'isValidInterfaceName',
+      'isValidErrorName',
+      'isValidMemberName',
+      'isValidBusName'
+    ]) {
+      assert.strictEqual(typeof dbus[name], 'function', `${name} is exported`);
+    }
+    assert.strictEqual(dbus.isValidInterfaceName('org.example.Iface'), true);
+    assert.strictEqual(dbus.isValidObjectPath('/org/example'), true);
+  });
+
   it('exports the entry points', () => {
     for (const name of [
       'createClient',

--- a/test/names.js
+++ b/test/names.js
@@ -1,0 +1,343 @@
+// The D-Bus naming rules, and the places we enforce them.
+//
+// https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names
+
+const { describe, it } = require('node:test');
+const assert = require('assert');
+const { Duplex } = require('stream');
+const marshall = require('../lib/marshall');
+const dbus = require('../index');
+const {
+  isValidObjectPath,
+  isValidInterfaceName,
+  isValidErrorName,
+  isValidMemberName,
+  isValidBusName,
+  assertValidName
+} = require('../lib/names');
+
+const longName = `a.${'b'.repeat(300)}`;
+
+describe('names', () => {
+  describe('object paths', () => {
+    const valid = [
+      '/',
+      '/a',
+      '/org/freedesktop/DBus',
+      '/com/example/Obj_1',
+      '/0', // elements may start with a digit, unlike interface names
+      `/${'a'.repeat(1000)}` // no length limit in the spec
+    ];
+    const invalid = [
+      ['', 'empty'],
+      ['a/b', 'no leading slash'],
+      ['/a/', 'trailing slash'],
+      ['//', 'empty element'],
+      ['/a//b', 'empty element in the middle'],
+      ['/a.b', 'dot is not allowed'],
+      ['/a-b', 'hyphen is not allowed'],
+      ['/a b', 'space is not allowed'],
+      [42, 'not a string'],
+      [null, 'null'],
+      [undefined, 'undefined']
+    ];
+
+    for (const path of valid) {
+      it(`accepts ${JSON.stringify(path).slice(0, 30)}`, () =>
+        assert.strictEqual(isValidObjectPath(path), true));
+    }
+    for (const [path, why] of invalid) {
+      it(`rejects ${JSON.stringify(path)} (${why})`, () =>
+        assert.strictEqual(isValidObjectPath(path), false));
+    }
+  });
+
+  describe('interface and error names', () => {
+    const valid = [
+      'a.b',
+      'org.freedesktop.DBus',
+      'com.example.My_Iface',
+      '_a._b',
+      `a.${'b'.repeat(252)}` // exactly 255 bytes
+    ];
+    const invalid = [
+      ['', 'empty'],
+      ['NoDot', 'a single element'],
+      ['.a.b', 'leading dot'],
+      ['a.b.', 'trailing dot'],
+      ['a..b', 'empty element'],
+      ['1a.b', 'element starting with a digit'],
+      ['a.1b', 'later element starting with a digit'],
+      ['a-b.c', 'hyphen (allowed in bus names, not here)'],
+      [longName, 'over 255 bytes'],
+      [42, 'not a string']
+    ];
+
+    for (const name of valid) {
+      it(`accepts ${name.slice(0, 30)}`, () =>
+        assert.strictEqual(isValidInterfaceName(name), true));
+    }
+    for (const [name, why] of invalid) {
+      it(`rejects ${JSON.stringify(name).slice(0, 30)} (${why})`, () =>
+        assert.strictEqual(isValidInterfaceName(name), false));
+    }
+
+    it('applies the same rules to error names', () => {
+      assert.strictEqual(
+        isValidErrorName('org.freedesktop.DBus.Error.Failed'),
+        true
+      );
+      assert.strictEqual(isValidErrorName('Failed'), false);
+    });
+  });
+
+  describe('member names', () => {
+    for (const name of ['a', 'Ping', '_private', 'Get2'])
+      it(`accepts ${name}`, () =>
+        assert.strictEqual(isValidMemberName(name), true));
+
+    const invalid = [
+      ['', 'empty'],
+      ['a.b', 'dots are not allowed'],
+      ['1a', 'starting with a digit'],
+      ['a-b', 'hyphen'],
+      ['b'.repeat(256), 'over 255 bytes']
+    ];
+    for (const [name, why] of invalid)
+      it(`rejects ${JSON.stringify(name).slice(0, 20)} (${why})`, () =>
+        assert.strictEqual(isValidMemberName(name), false));
+  });
+
+  describe('bus names', () => {
+    const valid = [
+      'org.freedesktop.DBus',
+      'com.example.my-service', // hyphens are allowed here but not in interfaces
+      ':1.23', // unique name
+      ':1.0',
+      ':a'
+    ];
+    const invalid = [
+      ['', 'empty'],
+      ['NoDot', 'a single element'],
+      ['1a.b', 'well-known element starting with a digit'],
+      ['.a.b', 'leading dot'],
+      [':', 'just a colon'],
+      [':1..2', 'empty element']
+    ];
+
+    for (const name of valid)
+      it(`accepts ${name}`, () =>
+        assert.strictEqual(isValidBusName(name), true));
+    for (const [name, why] of invalid)
+      it(`rejects ${JSON.stringify(name)} (${why})`, () =>
+        assert.strictEqual(isValidBusName(name), false));
+  });
+
+  describe('assertValidName', () => {
+    it('returns the value when it is valid', () => {
+      assert.strictEqual(assertValidName('interface name', 'a.b'), 'a.b');
+    });
+
+    it('names the rule that was broken', () => {
+      assert.throws(() => assertValidName('interface name', 'NoDot'), {
+        message: /Invalid interface name: "NoDot" -- must be two or more/
+      });
+    });
+
+    it('includes the context when given one', () => {
+      assert.throws(
+        () => assertValidName('member name', '1bad', 'methods.1bad'),
+        { message: /for methods\.1bad/ }
+      );
+    });
+  });
+});
+
+describe('marshalling an object path', () => {
+  it('accepts a valid path', () => {
+    assert.doesNotThrow(() => marshall('o', ['/a/b']));
+  });
+
+  it('rejects a path with no leading slash', () => {
+    assert.throws(() => marshall('o', ['invalid/object/path']), {
+      message: /is not a valid object path/
+    });
+  });
+
+  it('rejects a path with a trailing slash', () => {
+    assert.throws(() => marshall('o', ['/a/']), {
+      message: /is not a valid object path/
+    });
+  });
+
+  it('rejects a path containing a dot', () => {
+    assert.throws(() => marshall('o', ['/com.example/Obj']), {
+      message: /is not a valid object path/
+    });
+  });
+
+  it('still rejects a non-string, with the same error a plain string gives', () => {
+    assert.throws(() => marshall('o', [42]), {
+      message: /Expected string or buffer argument, got 42 of type 'o'/
+    });
+  });
+
+  it('does not constrain plain strings', () => {
+    assert.doesNotThrow(() => marshall('s', ['invalid/object/path']));
+  });
+});
+
+class FakeSocket extends Duplex {
+  _write(chunk, enc, cb) {
+    cb();
+  }
+  _read() {}
+}
+
+// Complete the SASL handshake by hand so the bus reaches 'connect'. `direct`
+// skips the Hello call, which needs a daemon to answer.
+function connectBus() {
+  return new Promise(resolve => {
+    const socket = new FakeSocket();
+    const bus = dbus.createClient({ stream: socket, direct: true });
+    setImmediate(() => socket.push('OK 0123456789abcdef\r\n'));
+    bus.connection.once('connect', () => resolve(bus));
+  });
+}
+
+const okDesc = {
+  name: 'com.example.Iface',
+  methods: { Ping: ['', ''] },
+  signals: { Pinged: ['s', 'who'] },
+  properties: { Greeting: 's' }
+};
+
+describe('exportInterface validates what it is given', () => {
+  const withDesc = overrides => ({ ...okDesc, ...overrides });
+
+  it('accepts a well-formed export', async () => {
+    const bus = await connectBus();
+    assert.doesNotThrow(() =>
+      bus.exportInterface({}, '/com/example/Obj', okDesc)
+    );
+    bus.connection.end();
+  });
+
+  const cases = [
+    [
+      'an invalid object path',
+      'com/example/Obj',
+      okDesc,
+      /Invalid object path/
+    ],
+    [
+      'an interface name with no dot',
+      '/com/example/Obj',
+      withDesc({ name: 'Iface' }),
+      /Invalid interface name for the interface descriptor/
+    ],
+    [
+      'a method name containing a dot',
+      '/com/example/Obj',
+      withDesc({ methods: { 'a.b': ['', ''] } }),
+      /Invalid member name for methods\.a\.b/
+    ],
+    [
+      'a signal name starting with a digit',
+      '/com/example/Obj',
+      withDesc({ signals: { '1Pinged': ['s', 'who'] } }),
+      /Invalid member name for signals\.1Pinged/
+    ],
+    [
+      'a property name with a hyphen',
+      '/com/example/Obj',
+      withDesc({ properties: { 'my-prop': 's' } }),
+      /Invalid member name for properties\.my-prop/
+    ]
+  ];
+
+  for (const [why, path, desc, message] of cases) {
+    it(`rejects ${why}`, async () => {
+      const bus = await connectBus();
+      assert.throws(() => bus.exportInterface({}, path, desc), { message });
+      bus.connection.end();
+    });
+  }
+
+  it('does not half-export an object it then rejects', async () => {
+    const bus = await connectBus();
+    assert.throws(() =>
+      bus.exportInterface({}, '/com/example/Obj', withDesc({ name: 'Iface' }))
+    );
+    assert.strictEqual(bus.exportedObjects['/com/example/Obj'], undefined);
+    bus.connection.end();
+  });
+});
+
+describe('sendSignal validates what it emits', () => {
+  // Signals get no reply, so an unroutable one is silent -- worth catching
+  // even though the equivalent method call would produce an error.
+  it('accepts a well-formed signal', async () => {
+    const bus = await connectBus();
+    assert.doesNotThrow(() =>
+      bus.sendSignal('/com/example/Obj', 'com.example.Iface', 'Pinged', 's', [
+        'hi'
+      ])
+    );
+    bus.connection.end();
+  });
+
+  it('rejects an interface name with no dot', async () => {
+    const bus = await connectBus();
+    assert.throws(() => bus.sendSignal('/com/example/Obj', 'Iface', 'Pinged'), {
+      message: /Invalid interface name for the signal interface/
+    });
+    bus.connection.end();
+  });
+
+  it('rejects a member name containing a dot', async () => {
+    const bus = await connectBus();
+    assert.throws(
+      () => bus.sendSignal('/com/example/Obj', 'com.example.Iface', 'a.b'),
+      { message: /Invalid member name for the signal name/ }
+    );
+    bus.connection.end();
+  });
+
+  it('rejects an invalid object path, through the marshaller', async () => {
+    const bus = await connectBus();
+    assert.throws(
+      () => bus.sendSignal('bad/path', 'com.example.Iface', 'Pinged'),
+      { message: /is not a valid object path/ }
+    );
+    bus.connection.end();
+  });
+});
+
+describe('sendError validates the error name', () => {
+  const aCall = { serial: 1, sender: ':1.2' };
+
+  it('accepts a well-formed error name', async () => {
+    const bus = await connectBus();
+    assert.doesNotThrow(() =>
+      bus.sendError(aCall, 'com.example.Error.Failed', 'boom')
+    );
+    bus.connection.end();
+  });
+
+  it('rejects a name with no dot, which a peer could not route', async () => {
+    const bus = await connectBus();
+    assert.throws(() => bus.sendError(aCall, 'Failed', 'boom'), {
+      message: /Invalid error name: "Failed"/
+    });
+    bus.connection.end();
+  });
+
+  it('rejects a missing name rather than sending it', async () => {
+    const bus = await connectBus();
+    assert.throws(() => bus.sendError(aCall, undefined, 'boom'), {
+      message: /Invalid error name/
+    });
+    bus.connection.end();
+  });
+});

--- a/test/unmarshall-basic.js
+++ b/test/unmarshall-basic.js
@@ -167,7 +167,11 @@ describe('marshall/unmarshall', () => {
       ['s', ['short string']],
       ['s', [str30000chars]],
       ['o', ['/object/path']],
-      ['o', ['invalid/object/path'], false],
+      // 'invalid/object/path' used to sit here marked `false`, which in this
+      // table means "does not round-trip", not "throws" -- the two branches
+      // below are identical, so it was only ever asserting a round trip. Now
+      // that 'o' is validated it belongs with the other rejections, in
+      // test/names.js.
       ['g', ['xxxtt(t)s{u}uuiibb']],
       ['g', ['signature'], false], // TODO: validate on input
       //['g', [str300chars], false],  // max 255 chars


### PR DESCRIPTION
Closes #309.

`exportInterface()` took any string as an interface name and `sendError()` any
string as an error name. Neither was checked, so an invalid name was only caught
later by the daemon — or, for a signal, never, because a signal gets no reply.
`lib/bus.js` carried a comment acknowledging the gap, and `lib/marshallers.js` a
`// TODO: verify object path for 'o'`.

## The rules

`lib/names.js` implements the four rule sets, which are easy to confuse:

| kind           | shape                                              | notes                                   |
| -------------- | -------------------------------------------------- | --------------------------------------- |
| object path    | `/`, or `/`-separated `[A-Za-z0-9_]` elements      | elements may start with a digit; no `.` |
| interface name | two or more `.`-separated `[A-Za-z_][A-Za-z0-9_]*` | no `-`, no leading digit, ≤ 255 bytes   |
| error name     | as interface names                                 |                                         |
| member name    | one `[A-Za-z_][A-Za-z0-9_]*` element               | no dots, ≤ 255 bytes                    |
| bus name       | `:1.23`, or an interface name that may contain `-` | ≤ 255 bytes                             |

## Where they are enforced

| where                   | checks                                          |
| ----------------------- | ----------------------------------------------- |
| `bus.exportInterface()` | the path, `iface.name`, and every member name   |
| `bus.sendSignal()`      | the interface and member name                   |
| `bus.sendError()`       | the error name                                  |
| marshalling an `o`      | the object path, including every message's path |

Each throws an `Error` naming the rule that was broken rather than restating the
input:

```
Invalid interface name for the interface descriptor: "MyIface" -- must be two or
more dot-separated elements of [A-Za-z_][A-Za-z0-9_]*, at most 255 bytes
```

## Three decisions worth review

**Throw, not warn.** The issue left this open. An invalid name yields a message
no peer can route, so the code was already broken; the useful place to say so is
where the name was written.

**Signals are validated, ordinary calls are not.** A bad interface or member on
a method call comes back as an error from the daemon or the peer. A signal gets
no reply and simply vanishes — that is the case worth catching. Validating all
four header fields on *every* message measured 0.135 µs against a 4.13 µs
marshall (3.3%); it is available if the silent-failure argument ever extends to
calls, but not paid for by default.

**Incoming names are not checked.** The spec only requires that a receiver *can*
reject one, `readString` already bounds-checks, and refusing a sloppy peer's
path would break interop over something we pass through harmlessly. The
commented-out check in `dbus-buffer.js` is now a note saying so rather than a
TODO.

## Also

The predicates are exported (`isValidObjectPath`, `isValidInterfaceName`,
`isValidErrorName`, `isValidMemberName`, `isValidBusName`), since anything
building a name at runtime — from a config file, a device id — would rather
check than catch.

## One test changed meaning

`['o', ['invalid/object/path'], false]` sat in the marshall/unmarshall table
marked `false`, which in *that* table means "does not round-trip", not "throws"
— both branches of the loop consuming it are identical, so it had only ever
asserted a round trip. It now lives in `test/names.js` as the rejection it was
meant to be.

## Testing

- `test/names.js` — 76 tests: the rule sets themselves (including the cases that
  differ between kinds, like `-` and leading digits), the marshaller, and each
  enforcement point, including that a rejected `exportInterface` leaves no
  partial state behind.
- Checked every name the library and its examples emit against the new rules
  before landing; none is affected.

473 unit and 92 integration tests pass.