### PR TITLE
feat: accept a plain JS object anywhere a dict is expected

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,39 @@ bus.invoke({
 });
 ```
 
+### Writing dicts: just pass an object
+
+Anywhere a dict is expected, a plain object will do — the most-asked question
+about this library, and no longer a chore:
+
+```js
+await iface.SetOptions({ Name: 'widget', Count: 3, Enabled: true });
+```
+
+That writes exactly the same bytes as spelling every value out as a variant,
+which still works and is unchanged. Inside an object, values are inferred:
+strings to `s`, booleans to `b`, integers to `i` (or `x` when they do not fit),
+other numbers to `d`, `Buffer` to `ay`, arrays to `a` + their element type, and
+nested objects to `a{sv}`.
+
+`Variant` overrides the guess, and reaches the types inference cannot produce:
+
+```js
+await iface.SetOptions({ Count: new Variant('u', 3) }); // uint32, not int32
+```
+
+Two things to know. **Inside an object an array is an array**, never a
+`[signature, value]` pair — use `Variant` for an explicitly typed value. And
+inference **refuses to guess** rather than picking something arbitrary: an
+empty array, a mixed array like `[1, 'a']`, `null` and `NaN` all throw and say
+what to do instead.
+
+A variant read off the wire can also be written straight back, so a value can be
+passed from one service to another without unwrapping it.
+
+See [docs/api.md](docs/api.md#writing-a-dict-as-a-plain-object) for the full
+table.
+
 ### Errors
 
 A failed call passes a `DBusError` to the callback and rejects the promise with

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -527,9 +527,49 @@ the evidence that its rules are worth pointing at consumers.
 
 ### 4.2 Marshall JS objects as `a{sv}`
 
-There is a `// TODO: serialise JS objects as a{sv}` in `lib/marshall.js` and a
+**Issues:** [#3](https://github.com/sidorares/dbus-native/issues/3),
+[#91](https://github.com/sidorares/dbus-native/issues/91),
+[#132](https://github.com/sidorares/dbus-native/issues/132)
+
+There was a `// TODO: serialise JS objects as a{sv}` in `lib/marshall.js` and a
 disabled test (`test/js-types.js`) waiting for it. Combined with 3.1 this is the
 "just let me pass a plain object" story users keep asking for.
+
+**Done.** A plain object is accepted anywhere a dict is expected, and writes
+byte-identical output to the array-of-pairs form, which is untouched. Inside an
+object, `a{sv}` values get an inferred signature; `Variant` overrides it and
+reaches the types inference cannot produce (`u`, `y`, `o`, structs, `av`).
+
+Three decisions worth recording:
+
+- **Inference only inside a plain object.** The pairs form stays explicit and
+  infers nothing. This is what makes the rule "inside an object, an array is an
+  array" safe to state: there is no position where `['s', 'hello']` could be
+  either a two-string array or a classic variant pair, so nothing has to guess.
+  Values reached through the pairs form keep meaning exactly what they did.
+- **Refuse rather than guess.** An empty array, a mixed array, `null`, `NaN`
+  and unrecognised objects throw with a message naming the fix, instead of
+  picking a plausible type. A d-bus array is homogeneous, so `[1, 'a']` has no
+  signature; saying so beats writing `ai` and truncating.
+- **Only `Object.prototype`/`null` prototypes count as dicts.** A class
+  instance is rejected, because being wrong there writes a garbled message
+  rather than failing.
+
+Two things the implementation turned up:
+
+- **A variant could not be written back after being read.** The reader produces
+  `[parsedTree, [value]]` but the writer wanted a signature _string_ in that
+  first slot, so handing a value from one service straight to another failed
+  with a confusing complaint about type `'g'`. It had nothing to do with plain
+  objects — it just showed up immediately once a test tried to echo a dict.
+  The writer now accepts the reader's shape, recursively.
+- **The disabled test could never have passed.** It asserted that a plain
+  object came _back_ out of `unmarshall`, which is the 2.0 read shape and not
+  part of this change. Rewritten to round-trip through `toPlain()`, which is
+  the 0.6 helper for exactly this and becomes the identity in 2.0.
+
+Not done: the read side. `hashAsObject` — the option the old test's name
+referred to — belongs with §4.1 and the rest of the 2.0 type change.
 
 ### 4.3 High-level client/service API
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -464,22 +464,22 @@ re-thrown asynchronously, matching Node's default for a throwing listener.
 
 ### Type mapping
 
-| D-Bus          | code    | JavaScript                                                                               |
-| -------------- | ------- | ---------------------------------------------------------------------------------------- |
-| byte           | `y`     | `number`                                                                                 |
-| boolean        | `b`     | `boolean`                                                                                |
-| int16 / uint16 | `n` `q` | `number`                                                                                 |
-| int32 / uint32 | `i` `u` | `number`                                                                                 |
-| int64 / uint64 | `x` `t` | `number`, lossy above 2⁵³ — `bigint` with `returnBigInt`, or Long.js with `ReturnLongjs` |
-| double         | `d`     | `number`                                                                                 |
-| string         | `s`     | `string`                                                                                 |
-| object path    | `o`     | `string`                                                                                 |
-| signature      | `g`     | `string`                                                                                 |
-| array          | `a`     | `Array`                                                                                  |
-| byte array     | `ay`    | `Buffer` — see `ayBuffer`                                                                |
-| struct         | `()`    | `Array`                                                                                  |
-| dict           | `a{}`   | `Array` of `[key, value]` pairs                                                          |
-| variant        | `v`     | `[parsedSignature, [value]]`                                                             |
+| D-Bus          | code    | JavaScript                                                                                        |
+| -------------- | ------- | ------------------------------------------------------------------------------------------------- |
+| byte           | `y`     | `number`                                                                                          |
+| boolean        | `b`     | `boolean`                                                                                         |
+| int16 / uint16 | `n` `q` | `number`                                                                                          |
+| int32 / uint32 | `i` `u` | `number`                                                                                          |
+| int64 / uint64 | `x` `t` | `number`, lossy above 2⁵³ — `bigint` with `returnBigInt`, or Long.js with `ReturnLongjs`          |
+| double         | `d`     | `number`                                                                                          |
+| string         | `s`     | `string`                                                                                          |
+| object path    | `o`     | `string`                                                                                          |
+| signature      | `g`     | `string`                                                                                          |
+| array          | `a`     | `Array`                                                                                           |
+| byte array     | `ay`    | `Buffer` — see `ayBuffer`                                                                         |
+| struct         | `()`    | `Array`                                                                                           |
+| dict           | `a{}`   | read: `Array` of `[key, value]` pairs · write: that, **or a plain object**                        |
+| variant        | `v`     | read: `[parsedSignature, [value]]` · write: `Variant`, `[signature, value]`, or either read shape |
 
 `h` (UNIX_FD) is not supported.
 
@@ -489,6 +489,67 @@ and your code survives that change untouched.
 
 **Writing** 64-bit values accepts a `number` up to 53 bits, a decimal or
 `0x`-prefixed string for the full range, or a Long.js object.
+
+### Writing a dict as a plain object
+
+Anywhere a dict is expected, a plain object will do:
+
+```js
+await iface.SetOptions({ Name: 'widget', Count: 3, Enabled: true });
+
+// the same thing, spelled out
+await iface.SetOptions([
+  ['Name', new Variant('s', 'widget')],
+  ['Count', new Variant('i', 3)],
+  ['Enabled', new Variant('b', true)]
+]);
+```
+
+Both write identical bytes. The array-of-pairs form is unchanged, and nothing
+about it infers — only values reached through a plain object do.
+
+Inside an object, the signature of an `a{sv}` value is inferred:
+
+| JavaScript              | inferred           |
+| ----------------------- | ------------------ |
+| `string`                | `s`                |
+| `boolean`               | `b`                |
+| integer within int32    | `i`                |
+| integer outside int32   | `x`                |
+| any other `number`      | `d`                |
+| `bigint`                | `x`                |
+| `Buffer` / `TypedArray` | `ay`               |
+| `Array` (homogeneous)   | `a` + element type |
+| plain object            | `a{sv}`            |
+
+`Variant` overrides it, and is how you reach the types inference does not
+produce — `u`, `y`, `o`, `g`, structs, `av`:
+
+```js
+await iface.SetOptions({ Count: new Variant('u', 3) }); // uint32, not int32
+```
+
+Two things to know:
+
+- **Inside an object an array is an array**, never a `[signature, value]` pair.
+  `{ v: ['s', 'hello'] }` is an array of two strings; use
+  `new Variant('s', 'hello')` for an explicitly typed value.
+- **Inference refuses to guess** rather than picking something arbitrary: an
+  empty array, a mixed array, `null`, `undefined`, `NaN` and anything it does
+  not recognise all throw, naming what to do instead. A d-bus array is
+  homogeneous, so `[1, 'a']` has no signature.
+
+A class instance is not treated as a dict — only objects whose prototype is
+`Object.prototype` or `null`. Being wrong about that would write a garbled
+message instead of failing.
+
+A variant read off the wire can also be written straight back, so a value can
+be passed from one service to another without unwrapping it:
+
+```js
+const opts = await source.GetOptions();
+await sink.SetOptions(opts); // the [parsedSignature, [value]] shape is accepted
+```
 
 **`ayBuffer`** controls byte arrays: `true` (default) copies into a `Buffer`;
 `'view'` returns a `Buffer` sharing memory with the message, which avoids the

--- a/lib/marshall.js
+++ b/lib/marshall.js
@@ -3,7 +3,7 @@ const assert = require('assert');
 const parseSignature = require('./signature');
 const Marshallers = require('./marshallers');
 const Writer = require('./writer');
-const { Variant } = require('./values');
+const { Variant, dumpSignature } = require('./values');
 
 // Element types whose array body starts on an 8-byte boundary. The padding
 // between the length and the first element is not counted in the length.
@@ -42,7 +42,149 @@ module.exports = function marshall(signature, data, offset = 0) {
   return writer.result();
 };
 
-// TODO: serialise JS objects as a{sv}
+// ---------------------------------------------------------------------------
+// Plain objects as dicts
+// ---------------------------------------------------------------------------
+//
+// A dict has always been written as an array of [key, value] pairs, with every
+// `a{sv}` value spelled out as a variant. That is a lot of ceremony for what is
+// usually a bag of settings, and it is the single most-asked question about
+// this library (#3, #91, #132).
+//
+// So a plain object is accepted anywhere a dict is expected. Inside one, values
+// are inferred -- and an array is just an array, never a [signature, value]
+// pair. Wrap a value in `Variant` when the inferred type is not what you want,
+// which is also how you write a type inference cannot reach.
+//
+// The array-of-pairs form is untouched: it stays the explicit spelling, and
+// nothing about it infers.
+
+const INT32_MIN = -2147483648;
+const INT32_MAX = 2147483647;
+
+// Object keys are strings, so a numerically-keyed dict needs converting back.
+// 'x' and 't' are left alone -- their marshaller already parses strings, and
+// going through Number() would lose precision above 2^53.
+const NUMERIC_KEYS = new Set(['y', 'n', 'q', 'i', 'u', 'd']);
+
+function isPlainObject(value) {
+  if (value === null || typeof value !== 'object') return false;
+  if (Array.isArray(value) || ArrayBuffer.isView(value)) return false;
+  if (value instanceof Variant) return false;
+  // Deliberately strict: a class instance is not silently treated as a dict,
+  // because being wrong about that writes a garbled message rather than
+  // failing.
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * The d-bus signature for a JavaScript value.
+ *
+ * Only reached for values inside a plain object, where there is nothing else
+ * the value could mean. `Variant` overrides it.
+ */
+function inferSignature(value) {
+  if (value instanceof Variant) return value.signature;
+
+  switch (typeof value) {
+    case 'string':
+      return 's';
+    case 'boolean':
+      return 'b';
+    case 'bigint':
+      return 'x';
+    case 'number':
+      if (!Number.isFinite(value)) {
+        throw new Error(
+          `Cannot infer a d-bus type for ${value} -- d-bus has no infinity or NaN`
+        );
+      }
+      // A non-integer is a double; an integer is the smallest of i/x that
+      // holds it. Use Variant to ask for 'u', 'y' or a double integer.
+      if (!Number.isInteger(value)) return 'd';
+      return value >= INT32_MIN && value <= INT32_MAX ? 'i' : 'x';
+    case 'undefined':
+      throw new Error(
+        "Serialisation of JS 'undefined' type is not supported by d-bus"
+      );
+  }
+
+  if (value === null) {
+    throw new Error('Serialisation of null value is not supported by d-bus');
+  }
+  if (ArrayBuffer.isView(value)) return 'ay';
+  if (Array.isArray(value)) return inferArraySignature(value);
+  if (isPlainObject(value)) return 'a{sv}';
+
+  throw new Error(
+    `Cannot infer a d-bus type for ${inferenceLabel(
+      value
+    )} -- wrap it in a Variant to say what it is`
+  );
+}
+
+/**
+ * Name a value that has no d-bus type.
+ *
+ * `describe` goes through JSON, which renders a function or a symbol as
+ * `undefined` -- and "cannot infer a type for undefined" points at the wrong
+ * problem entirely.
+ */
+function inferenceLabel(value) {
+  if (typeof value === 'function') return 'a function';
+  if (typeof value === 'symbol') return 'a symbol';
+  const name = value?.constructor?.name;
+  const rendered = describe(value);
+  if (rendered === undefined) return name ? `a ${name}` : String(value);
+  return name && name !== 'Object' ? `a ${name} (${rendered})` : rendered;
+}
+
+function inferArraySignature(value) {
+  if (value.length === 0) {
+    throw new Error(
+      "Cannot infer a d-bus type for an empty array -- use a Variant, e.g. new Variant('as', [])"
+    );
+  }
+  const first = inferSignature(value[0]);
+  for (let i = 1; i < value.length; ++i) {
+    const next = inferSignature(value[i]);
+    if (next !== first) {
+      throw new Error(
+        `Cannot infer a d-bus type for a mixed array (element 0 is '${first}', element ${i} is '${next}') -- d-bus arrays are homogeneous, so use a Variant, or an array of Variants for 'av'`
+      );
+    }
+  }
+  return `a${first}`;
+}
+
+/** Turn a plain object into the [key, value] pairs the writer expects. */
+function dictEntries(entryNode, obj) {
+  const [keyNode, valueNode] = entryNode.child;
+  const inferValues = valueNode.type === 'v';
+
+  return Object.keys(obj).map(key => {
+    const value = obj[key];
+    return [
+      NUMERIC_KEYS.has(keyNode.type) ? numericKey(keyNode.type, key) : key,
+      // Only a variant needs a signature attached; `a{ss}` values are written
+      // as declared, exactly as they are from the pairs form.
+      inferValues && !(value instanceof Variant)
+        ? new Variant(inferSignature(value), value)
+        : value
+    ];
+  });
+}
+
+function numericKey(type, key) {
+  const n = Number(key);
+  if (!Number.isFinite(n)) {
+    throw new Error(
+      `Dict key ${JSON.stringify(key)} is not a number, but the signature says 'a{${type}...}'`
+    );
+  }
+  return n;
+}
 
 function writeStruct(writer, tree, data) {
   if (tree.length !== data.length) {
@@ -64,16 +206,30 @@ function write(writer, ele, data) {
       writeArray(writer, ele, data);
       break;
     case 'v': {
-      // A Variant instance is the forward-compatible spelling of the
-      // [signature, value] pair; both are accepted.
-      const signature = data instanceof Variant ? data.signature : data[0];
-      const value = data instanceof Variant ? data.value : data[1];
-      if (!(data instanceof Variant)) {
+      let signature, value;
+      if (data instanceof Variant) {
+        // The forward-compatible spelling, and the only one that survives 2.0.
+        signature = data.signature;
+        value = data.value;
+      } else {
         assert.equal(
           data.length,
           2,
           'variant data should be [signature, data]'
         );
+        if (Array.isArray(data[0])) {
+          // The reader's own shape, [parsedTree, [value]] -- a variant that
+          // came back off the wire. Passing one straight to another service
+          // used to fail with a confusing complaint about type 'g', because
+          // the writer wanted a signature string where the reader had put a
+          // tree. Nested variants inside `value` are in the same shape and
+          // are handled when write() recurses onto them.
+          signature = dumpSignature(data[0]);
+          value = data[1].length === 1 ? data[1][0] : data[1];
+        } else {
+          signature = data[0];
+          value = data[1];
+        }
       }
       writeSimple(writer, 'g', signature);
       const tree = parseSignature(signature);
@@ -88,6 +244,12 @@ function write(writer, ele, data) {
 
 function writeArray(writer, ele, data) {
   const child = ele.child[0];
+
+  // A dict may be given as a plain object instead of an array of pairs. Done
+  // before the length is reserved so the two forms write identical bytes.
+  if (child.type === '{' && isPlainObject(data)) {
+    data = dictEntries(child, data);
+  }
 
   // The length counts the body only, so it is written first and patched once
   // we know how far the elements reached.
@@ -107,7 +269,9 @@ function writeArray(writer, ele, data) {
   } else {
     if (!Array.isArray(data) && typeof data?.length !== 'number') {
       throw new Error(
-        `Expected an array for signature 'a${child.type}', got ${describe(data)}`
+        child.type === '{'
+          ? `Expected an array of [key, value] pairs, or a plain object, for a dict, got ${describe(data)}`
+          : `Expected an array for signature 'a${child.type}', got ${describe(data)}`
       );
     }
     for (let i = 0; i < data.length; ++i) write(writer, child, data[i]);

--- a/lib/values.js
+++ b/lib/values.js
@@ -140,5 +140,6 @@ module.exports = {
   // internal
   VARIANT,
   DICT,
-  tag
+  tag,
+  dumpSignature
 };

--- a/test/integration/dicts.js
+++ b/test/integration/dicts.js
@@ -1,0 +1,163 @@
+// Passing a plain object where a dict is expected, over a real daemon.
+//
+// The unit tests in test/js-types.js check the bytes; this checks that a
+// service actually receives what the object described, which is the question
+// behind #3, #91 and #132.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const dbus = require('../../index');
+const { Variant, toPlain } = require('../../lib/values');
+
+const NO_BUS =
+  !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
+
+const SERVICE = 'com.github.sidorares.dbusnative.Dicts';
+const OBJECT_PATH = '/com/github/sidorares/dbusnative/Dicts';
+const IFACE = 'com.github.sidorares.dbusnative.DictsIface';
+
+const ifaceDesc = {
+  name: IFACE,
+  methods: {
+    // takes a dict, hands back what it saw as a printable string
+    Describe: ['a{sv}', 's', ['options'], ['description']],
+    // takes a dict and echoes it straight back
+    Echo: ['a{sv}', 'a{sv}', ['options'], ['same']],
+    Strings: ['a{ss}', 's', ['options'], ['description']]
+  },
+  signals: {},
+  properties: {}
+};
+
+describe(
+  'integration: dicts from plain objects',
+  { timeout: 10000, skip: NO_BUS },
+  () => {
+    let serviceBus, clientBus, iface, received;
+
+    const whenReady = bus =>
+      new Promise((resolve, reject) =>
+        bus.getId(err => (err ? reject(err) : resolve()))
+      );
+
+    before(async () => {
+      serviceBus = dbus.sessionBus();
+      clientBus = dbus.sessionBus();
+
+      const impl = Object.assign(Object.create(EventEmitter.prototype), {
+        Describe(options) {
+          received = options;
+          return JSON.stringify(toPlain(options));
+        },
+        Echo(options) {
+          received = options;
+          // Handed straight back, in the shape the reader produced it.
+          return options;
+        },
+        Strings(options) {
+          received = options;
+          return JSON.stringify(toPlain(options));
+        }
+      });
+      EventEmitter.call(impl);
+
+      await Promise.all([whenReady(serviceBus), whenReady(clientBus)]);
+      await new Promise((resolve, reject) =>
+        serviceBus.requestName(SERVICE, 0, err => {
+          if (err) return reject(err);
+          serviceBus.exportInterface(impl, OBJECT_PATH, ifaceDesc);
+          resolve();
+        })
+      );
+
+      iface = await clientBus
+        .getService(SERVICE)
+        .getInterface(OBJECT_PATH, IFACE);
+    });
+
+    after(() => {
+      serviceBus.connection.end();
+      clientBus.connection.end();
+    });
+
+    it('delivers a plain object as a{sv}', async () => {
+      const description = await iface.Describe({
+        Name: 'widget',
+        Count: 3,
+        Enabled: true,
+        Ratio: 0.5
+      });
+      assert.deepStrictEqual(JSON.parse(description), {
+        Name: 'widget',
+        Count: 3,
+        Enabled: true,
+        Ratio: 0.5
+      });
+    });
+
+    it('delivers a nested object', async () => {
+      const description = await iface.Describe({
+        outer: { inner: 'value', n: 1 }
+      });
+      assert.deepStrictEqual(JSON.parse(description), {
+        outer: { inner: 'value', n: 1 }
+      });
+    });
+
+    it('delivers an array value', async () => {
+      const description = await iface.Describe({ tags: ['a', 'b'] });
+      assert.deepStrictEqual(JSON.parse(description), { tags: ['a', 'b'] });
+    });
+
+    it('the service sees the types the client asked for', async () => {
+      await iface.Describe({
+        n: 1,
+        d: 1.5,
+        s: 'x',
+        b: true,
+        u: new Variant('u', 9)
+      });
+      // The service reads variants in the classic shape, so the parsed
+      // signature tree is right there on each value.
+      const signatures = {};
+      for (const [key, value] of received) signatures[key] = value[0][0].type;
+      assert.deepStrictEqual(signatures, {
+        n: 'i',
+        d: 'd',
+        s: 's',
+        b: 'b',
+        u: 'u'
+      });
+    });
+
+    it('round-trips a dict through a service that echoes it', async () => {
+      const sent = { a: 1, b: 'two' };
+      const back = await iface.Echo(sent);
+      assert.deepStrictEqual(toPlain(back), sent);
+    });
+
+    it('works for a dict of plain strings', async () => {
+      const description = await iface.Strings({ a: 'x', b: 'y' });
+      assert.deepStrictEqual(JSON.parse(description), { a: 'x', b: 'y' });
+    });
+
+    it('still accepts the array-of-pairs form', async () => {
+      const description = await iface.Describe([
+        ['Name', new Variant('s', 'widget')]
+      ]);
+      assert.deepStrictEqual(JSON.parse(description), { Name: 'widget' });
+    });
+
+    it('reports an unrepresentable value without sending anything', async () => {
+      await assert.rejects(
+        async () => iface.Describe({ when: new Date() }),
+        /wrap it in a Variant/
+      );
+      // the connection is still usable
+      assert.deepStrictEqual(JSON.parse(await iface.Describe({ ok: 1 })), {
+        ok: 1
+      });
+    });
+  }
+);

--- a/test/js-types.js
+++ b/test/js-types.js
@@ -1,25 +1,196 @@
+// Writing a plain JavaScript object where a dict is expected.
+//
+// The read side still returns an array of pairs until 2.0, so a round trip
+// goes back through `toPlain()` -- the forward-compatible helper from 0.6,
+// which becomes the identity once dicts unmarshal as objects. The skipped test
+// this file replaces asserted a plain object came *back*, which is why it
+// could never have passed: it was waiting on the read half too.
+
 const { describe, it } = require('node:test');
+const assert = require('assert');
 const marshall = require('../lib/marshall');
 const unmarshall = require('../lib/unmarshall');
-const assert = require('assert');
+const { Variant, toPlain, variantSignature } = require('../lib/values');
 
-function test(signature, data) {
-  const marshalledBuffer = marshall(signature, data);
-  const result = unmarshall(marshalledBuffer, signature);
-  try {
-    assert.deepStrictEqual(data, result);
-  } catch (e) {
-    console.log('signature   :', signature);
-    console.log('orig        :', data);
-    console.log('unmarshalled:', result);
-    throw new Error("results don't match", { cause: e });
-  }
+/** marshall, unmarshall, and flatten to plain JS. */
+function roundTrip(signature, data) {
+  return toPlain(unmarshall(marshall(signature, data), signature));
 }
 
-describe('when signature is a{sX} and hashAsObject is used', () => {
-  it.skip('serialises to expected value', () => {
-    test('a{sv}', {
+/** The signature a single inferred value actually got on the wire. */
+function inferred(value) {
+  const [dict] = unmarshall(marshall('a{sv}', [{ v: value }]), 'a{sv}');
+  return variantSignature(dict[0][1]);
+}
+
+describe('a plain object as a dict', () => {
+  it('round-trips a nested object, the case the old skipped test described', () => {
+    const data = {
       test1: { subobj: { a1: 10, a2: 'qqq', a3: 1.11 }, test2: 12 }
+    };
+    assert.deepStrictEqual(roundTrip('a{sv}', [data]), [data]);
+  });
+
+  it('writes the same bytes as the equivalent array of pairs', () => {
+    const asObject = marshall('a{sv}', [{ Greeting: 'hello', Count: 3 }]);
+    const asPairs = marshall('a{sv}', [
+      [
+        ['Greeting', new Variant('s', 'hello')],
+        ['Count', new Variant('i', 3)]
+      ]
+    ]);
+    assert.deepStrictEqual(asObject, asPairs);
+  });
+
+  it('accepts an empty object', () => {
+    assert.deepStrictEqual(roundTrip('a{sv}', [{}]), [{}]);
+  });
+
+  it('still accepts the array-of-pairs form unchanged', () => {
+    const pairs = [[['Greeting', new Variant('s', 'hello')]]];
+    assert.deepStrictEqual(roundTrip('a{sv}', pairs), [{ Greeting: 'hello' }]);
+  });
+
+  it('works for a dict whose values are not variants', () => {
+    assert.deepStrictEqual(roundTrip('a{ss}', [{ a: 'x', b: 'y' }]), [
+      { a: 'x', b: 'y' }
+    ]);
+  });
+
+  it('works as one argument among several', () => {
+    assert.deepStrictEqual(roundTrip('sa{sv}u', ['name', { a: 1 }, 7]), [
+      'name',
+      { a: 1 },
+      7
+    ]);
+  });
+
+  it('works nested inside an array of dicts', () => {
+    assert.deepStrictEqual(roundTrip('aa{ss}', [[{ a: 'x' }, { b: 'y' }]]), [
+      [{ a: 'x' }, { b: 'y' }]
+    ]);
+  });
+
+  it('converts numeric keys back from the strings JS makes them', () => {
+    assert.deepStrictEqual(roundTrip('a{us}', [{ 1: 'a', 2: 'b' }]), [
+      { 1: 'a', 2: 'b' }
+    ]);
+  });
+
+  it('keeps 64-bit keys exact, by leaving them as the strings they are', () => {
+    // Note the key is written as a string. A numeric literal this large is
+    // already rounded by JavaScript before it ever becomes a key, so
+    // { 9007199254740993: 'a' } is a different (smaller) key entirely -- which
+    // is why these types are not put through Number().
+    const [dict] = unmarshall(
+      marshall('a{ts}', [{ '9007199254740993': 'a' }]),
+      'a{ts}',
+      undefined,
+      { returnBigInt: true }
+    );
+    assert.strictEqual(dict[0][0], 9007199254740993n);
+  });
+
+  // The writer wanted a signature string exactly where the reader puts a
+  // parsed tree, so handing a value from one service straight to another
+  // failed with a complaint about type 'g'.
+  it('can write back a dict it just read', () => {
+    const read = unmarshall(marshall('a{sv}', [{ a: 'x', n: 5 }]), 'a{sv}')[0];
+    assert.deepStrictEqual(roundTrip('a{sv}', [read]), [{ a: 'x', n: 5 }]);
+  });
+
+  it('can write back a nested dict it just read', () => {
+    const data = { outer: { inner: 'deep', n: 2 } };
+    const read = unmarshall(marshall('a{sv}', [data]), 'a{sv}')[0];
+    assert.deepStrictEqual(roundTrip('a{sv}', [read]), [data]);
+  });
+
+  it('can write back a single variant it just read', () => {
+    const read = unmarshall(marshall('v', [new Variant('s', 'x')]), 'v')[0];
+    assert.deepStrictEqual(roundTrip('v', [read]), ['x']);
+  });
+
+  it('does not treat a class instance as a dict', () => {
+    class Config {
+      constructor() {
+        this.a = 1;
+      }
+    }
+    assert.throws(() => marshall('a{sv}', [new Config()]), {
+      message: /Expected an array of \[key, value\] pairs, or a plain object/
+    });
+  });
+});
+
+describe('inferring a signature inside a dict', () => {
+  const cases = [
+    ['a string', 'hello', 's'],
+    ['a boolean', true, 'b'],
+    ['an integer', 10, 'i'],
+    ['a negative integer', -10, 'i'],
+    ['a non-integer', 1.11, 'd'],
+    ['an integer beyond int32', 2147483648, 'x'],
+    ['an integer below int32', -2147483649, 'x'],
+    ['a bigint', 42n, 'x'],
+    ['a Buffer', Buffer.from([1, 2]), 'ay'],
+    ['an array of strings', ['a', 'b'], 'as'],
+    ['an array of integers', [1, 2], 'ai'],
+    ['a nested array', [[1], [2]], 'aai'],
+    ['a nested object', { a: 1 }, 'a{sv}']
+  ];
+
+  for (const [what, value, signature] of cases) {
+    it(`infers '${signature}' for ${what}`, () => {
+      assert.strictEqual(inferred(value), signature);
+    });
+  }
+
+  it('lets a Variant override the inferred type', () => {
+    assert.strictEqual(inferred(new Variant('u', 10)), 'u');
+    assert.strictEqual(inferred(new Variant('d', 10)), 'd');
+  });
+
+  it('keeps a Variant nested inside an inferred object', () => {
+    const written = unmarshall(
+      marshall('a{sv}', [{ outer: { inner: new Variant('u', 7) } }]),
+      'a{sv}'
+    );
+    assert.deepStrictEqual(toPlain(written), [{ outer: { inner: 7 } }]);
+  });
+
+  it('treats an array as an array, never as a [signature, value] pair', () => {
+    // The one thing to know about the object form: this is 'as', not a
+    // classic variant pair meaning the string 'hello' typed as 's'.
+    assert.strictEqual(inferred(['s', 'hello']), 'as');
+    assert.deepStrictEqual(roundTrip('a{sv}', [{ v: ['s', 'hello'] }]), [
+      { v: ['s', 'hello'] }
+    ]);
+  });
+
+  describe('refuses to guess', () => {
+    const rejects = [
+      ['an empty array', [], /empty array/],
+      ['a mixed array', [1, 'a'], /mixed array/],
+      ['null', null, /null value is not supported/],
+      ['undefined', undefined, /'undefined' type is not supported/],
+      ['NaN', NaN, /no infinity or NaN/],
+      ['Infinity', Infinity, /no infinity or NaN/],
+      ['a function', () => {}, /type for a function -- wrap it in a Variant/],
+      ['a Date', new Date(), /type for a Date \(/],
+      ['a Map', new Map(), /type for a Map \(/],
+      ['a symbol', Symbol('x'), /type for a symbol --/]
+    ];
+
+    for (const [what, value, message] of rejects) {
+      it(`rejects ${what}`, () => {
+        assert.throws(() => marshall('a{sv}', [{ v: value }]), { message });
+      });
+    }
+
+    it('names both element types when an array is mixed', () => {
+      assert.throws(() => marshall('a{sv}', [{ v: [1, 'a'] }]), {
+        message: /element 0 is 'i', element 1 is 's'/
+      });
     });
   });
 });


### PR DESCRIPTION
Closes #3, closes #132. Refs #91. ROADMAP §4.2.

Writing an `a{sv}` meant an array of `[key, value]` pairs with every value
spelled out as a variant — a lot of ceremony for what is usually a bag of
settings, and the most-asked question about this library. There was a
`// TODO: serialise JS objects as a{sv}` in `lib/marshall.js` waiting for it.

```js
await iface.SetOptions({ Name: 'widget', Count: 3, Enabled: true });

// the same bytes, spelled out — still works, unchanged
await iface.SetOptions([
  ['Name', new Variant('s', 'widget')],
  ['Count', new Variant('i', 3)],
  ['Enabled', new Variant('b', true)]
]);
```

## Inference

Inside a plain object, an `a{sv}` value gets a signature:

| JavaScript              | inferred           |
| ----------------------- | ------------------ |
| `string`                | `s`                |
| `boolean`               | `b`                |
| integer within int32    | `i`                |
| integer outside int32   | `x`                |
| any other `number`      | `d`                |
| `bigint`                | `x`                |
| `Buffer` / `TypedArray` | `ay`               |
| `Array` (homogeneous)   | `a` + element type |
| plain object            | `a{sv}`            |

`Variant` overrides it, and reaches what inference cannot produce — `u`, `y`,
`o`, structs, `av`.

## Three decisions worth review

**Inference only inside a plain object.** The pairs form stays explicit and
infers nothing. That is what makes the rule *inside an object, an array is an
array* safe to state: there is no position where `['s', 'hello']` could be
either a two-string array or a classic variant pair, so nothing has to guess.
Existing code keeps meaning exactly what it did.

**Refuse rather than guess.** An empty array, a mixed array, `null`, `NaN` and
unrecognised objects all throw with a message naming the fix:

```
Cannot infer a d-bus type for a mixed array (element 0 is 'i', element 1 is 's')
-- d-bus arrays are homogeneous, so use a Variant, or an array of Variants for 'av'
```

A d-bus array is homogeneous, so `[1, 'a']` genuinely has no signature; saying
so beats writing `ai` and truncating.

**Only `Object.prototype`/`null` prototypes count as dicts.** A class instance
is rejected — being wrong there writes a garbled message rather than failing.

## Two things this turned up

**A variant could not be written back after being read.** The reader produces
`[parsedTree, [value]]`, but the writer wanted a signature *string* in that
first slot, so passing a value from one service straight to another failed with
a confusing complaint about type `'g'`. Nothing to do with plain objects — it
showed up the moment a test tried to echo a dict, and I confirmed it predates
this branch. The writer now accepts the reader's shape, recursively:

```js
const opts = await source.GetOptions();
await sink.SetOptions(opts); // used to throw
```

**The disabled test could never have passed.** `test/js-types.js` asserted that
a plain object came *back* out of `unmarshall` — that is the 2.0 read shape, not
part of this change, so it was waiting on the read half too. Rewritten to
round-trip through `toPlain()`, the 0.6 forward-compatible helper for exactly
this, which becomes the identity in 2.0.

## Not in scope

The read side. Dicts still unmarshal as pairs until 2.0; `hashAsObject` — the
option the old test's name referred to — belongs with §4.1.

## Testing

- `test/js-types.js` — 38 tests, replacing the one skipped test: byte-identical
  output against the pairs form, every inference rule, every refusal, nesting,
  numeric and 64-bit keys, and the read-back-what-you-wrote cases.
- `test/integration/dicts.js` — 8 tests against a real daemon, asserting the
  service receives the *types* the client asked for, not just the values.

512 unit and 100 integration tests pass.