### PR TITLE
feat: support launchd: addresses, so sessionBus() works on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,11 @@ the examples at it. `npm run test:integration` starts and stops one of these
 automatically, so it never touches your real session bus. The integration tests
 skip themselves when no bus address is set.
 
+If you run a system-wide bus on macOS instead (`brew services start dbus`),
+`sessionBus()` finds it without any environment variable: macOS advertises the
+session bus through launchd rather than `DBUS_SESSION_BUS_ADDRESS`, and that is
+now the fallback. `launchd:env=…` addresses work anywhere a `busAddress` does.
+
 To exercise Linux-only services (BlueZ, NetworkManager, systemd), use a
 container:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -679,9 +679,20 @@ belongs with the lifecycle work rather than here.
 ## 5. Lower priority / opportunistic
 
 - **`launchd:` address family** ([#95](https://github.com/sidorares/dbus-native/issues/95))
-  — how macOS actually advertises its session bus. Now that macOS is a
-  first-class CI target this is cheap to add and makes `sessionBus()` work
-  out of the box on a Mac.
+  — **done.** `launchd:env=VAR` names an environment variable rather than a
+  path, and the socket is looked up with `launchctl getenv`, falling back to
+  our own environment when launchd has no answer. On macOS `sessionBus()` now
+  defaults to `launchd:env=DBUS_LAUNCHD_SESSION_BUS_SOCKET` when
+  `DBUS_SESSION_BUS_ADDRESS` is unset — which is the normal state there — so it
+  works with no setup beyond a running bus.
+
+  The lookup is `spawnSync`, measured at 4 ms, once per connection and before
+  any I/O. Making it async would have turned `createConnection()` — and so
+  `sessionBus()` — async for every caller on every platform, to fix one
+  transport on one of them. Reading `process.env` alone would have been free
+  but wrong: the point of the transport is that the variable lives in the
+  launchd session, not necessarily in ours.
+
 - **Activatable service lookup** ([#133](https://github.com/sidorares/dbus-native/issues/133))
   — `StartServiceByName` exists but the new API never consults it.
 - **`dbus-send` equivalent** ([#56](https://github.com/sidorares/dbus-native/issues/56))

--- a/docs/api.md
+++ b/docs/api.md
@@ -62,7 +62,19 @@ all three take the same options.
 | `ReturnLongjs`   | `boolean`                 | `false`                                         | **deprecated** (`DBUS_DEP0001`) — 64-bit as Long.js            |
 
 Address forms understood by `busAddress`: `unix:path=…`, `unix:abstract=…`,
-`unix:socket=…`, `tcp:host=…,port=…`, and `unixexec:path=…,arg1=…`.
+`unix:socket=…`, `tcp:host=…,port=…`, `unixexec:path=…,arg1=…`, and
+`launchd:env=…`.
+
+**`launchd:env=VAR`** is how macOS advertises its session bus. The address names
+an environment variable rather than a path; the socket is looked up with
+`launchctl getenv VAR`, falling back to this process's own environment when
+launchd has no answer for it. The lookup runs once, synchronously, during
+connection setup and costs about 4 ms.
+
+On macOS, `sessionBus()` falls back to
+`launchd:env=DBUS_LAUNCHD_SESSION_BUS_SOCKET` when `DBUS_SESSION_BUS_ADDRESS`
+is unset, which is the normal state there — so it works without any setup
+beyond a running bus.
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const { EventEmitter } = require('events');
 const net = require('net');
-const { spawn } = require('child_process');
+const { spawn, spawnSync } = require('child_process');
 const { Duplex } = require('stream');
 
 const constants = require('./lib/constants');
@@ -31,6 +31,36 @@ function parseAddressParams(address) {
   return { family: family.toLowerCase(), params };
 }
 
+/**
+ * The socket path behind a `launchd:env=VAR` address.
+ *
+ * macOS keeps the session bus socket in the *launchd* environment, which is
+ * not necessarily ours -- a process that was not started from a shell holding
+ * the variable still needs to find it. So the spec names a variable to look up
+ * with `launchctl getenv` rather than a path.
+ * https://dbus.freedesktop.org/doc/dbus-specification.html#transports-launchd
+ */
+function launchdSocketPath(varName) {
+  // spawnSync blocks, which is acceptable exactly once during connection setup
+  // and before any I/O has happened. The alternative is making createStream()
+  // async, which would make createConnection() -- and so sessionBus() -- async
+  // for every caller on every platform, to fix one transport on one of them.
+  //
+  // No shell is involved (args are passed as an array), so the variable name
+  // out of the address string cannot turn into a command.
+  const result = spawnSync('launchctl', ['getenv', varName], {
+    encoding: 'utf8'
+  });
+  const fromLaunchd =
+    !result.error && result.status === 0 ? result.stdout.trim() : '';
+
+  // `launchctl getenv` exits 0 with no output for a variable that is not set,
+  // and off macOS it is not there at all. Either way our own environment is
+  // worth a look before giving up -- it is where the variable usually is when
+  // the process came from a shell.
+  return fromLaunchd || process.env[varName] || '';
+}
+
 function connectToAddress(address) {
   const { family, params } = parseAddressParams(address);
 
@@ -48,6 +78,20 @@ function connectToAddress(address) {
       throw new Error(
         "not enough parameters for 'unix' connection - you need to specify 'socket' or 'abstract' or 'path' parameter"
       );
+    case 'launchd': {
+      if (!params.env) {
+        throw new Error(
+          "not enough parameters for 'launchd' connection - you need to specify the 'env' parameter"
+        );
+      }
+      const path = launchdSocketPath(params.env);
+      if (!path) {
+        throw new Error(
+          `launchd address names ${params.env}, which is set neither in the launchd environment nor in this process. Is dbus running? (brew services start dbus)`
+        );
+      }
+      return net.createConnection(path);
+    }
     case 'unixexec': {
       const args = [];
       for (let n = 1; params[`arg${n}`]; n++) args.push(params[`arg${n}`]);
@@ -59,13 +103,25 @@ function connectToAddress(address) {
   }
 }
 
+// macOS does not set DBUS_SESSION_BUS_ADDRESS -- dbus there advertises the
+// session bus through launchd instead, which is what dbus's own client library
+// falls back to. Without this, sessionBus() on a Mac fails with 'unknown bus
+// address' even when a session bus is running perfectly well.
+const DEFAULT_SESSION_ADDRESS =
+  process.platform === 'darwin'
+    ? 'launchd:env=DBUS_LAUNCHD_SESSION_BUS_SOCKET'
+    : undefined;
+
 function createStream(opts) {
   if (opts.stream) return opts.stream;
   const { host, port, socket } = opts;
   if (socket) return net.createConnection(socket);
   if (port) return net.createConnection(port, host);
 
-  const busAddress = opts.busAddress || process.env.DBUS_SESSION_BUS_ADDRESS;
+  const busAddress =
+    opts.busAddress ||
+    process.env.DBUS_SESSION_BUS_ADDRESS ||
+    DEFAULT_SESSION_ADDRESS;
   if (!busAddress) throw new Error('unknown bus address');
 
   const addresses = busAddress.split(';');

--- a/test/address-launchd.js
+++ b/test/address-launchd.js
@@ -1,0 +1,150 @@
+// The launchd: transport, which is how macOS advertises its session bus.
+//
+// https://dbus.freedesktop.org/doc/dbus-specification.html#transports-launchd
+//
+// `launchctl` is stubbed by putting a script earlier on PATH rather than by
+// calling `launchctl setenv`, which would change the user's real login session
+// and outlive the test run.
+
+const { describe, it, before, after, beforeEach } = require('node:test');
+const assert = require('assert');
+const fs = require('fs');
+const net = require('net');
+const os = require('os');
+const path = require('path');
+const dbus = require('../index');
+
+let tmp, socketPath, server;
+const realPath = process.env.PATH;
+const realAddress = process.env.DBUS_SESSION_BUS_ADDRESS;
+
+/** Put a fake `launchctl getenv` on PATH, answering from `vars`. */
+function stubLaunchctl(vars) {
+  const script = `#!/bin/sh
+# getenv <name>: print the value, or nothing at all -- which is what the real
+# launchctl does for a variable that is not set, exit code 0 either way.
+if [ "$1" = "getenv" ]; then
+  case "$2" in
+${Object.entries(vars)
+  .map(([name, value]) => `    ${name}) echo "${value}" ;;`)
+  .join('\n')}
+    *) ;;
+  esac
+fi
+exit 0
+`;
+  const bin = path.join(tmp, 'bin');
+  fs.mkdirSync(bin, { recursive: true });
+  fs.writeFileSync(path.join(bin, 'launchctl'), script, { mode: 0o755 });
+  process.env.PATH = `${bin}${path.delimiter}${realPath}`;
+}
+
+/** PATH with no launchctl at all, as on Linux. */
+function noLaunchctl() {
+  const empty = path.join(tmp, 'empty');
+  fs.mkdirSync(empty, { recursive: true });
+  process.env.PATH = empty;
+}
+
+describe('launchd: addresses', () => {
+  before(async () => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dbus-launchd-'));
+    // A short path: a unix socket path is limited to ~104 bytes on macOS.
+    socketPath = path.join(tmp, 's');
+    server = net.createServer(conn => conn.end());
+    await new Promise(resolve => server.listen(socketPath, resolve));
+  });
+
+  after(() => {
+    process.env.PATH = realPath;
+    if (realAddress === undefined) delete process.env.DBUS_SESSION_BUS_ADDRESS;
+    else process.env.DBUS_SESSION_BUS_ADDRESS = realAddress;
+    server.close();
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    process.env.PATH = realPath;
+    delete process.env.DBUS_LAUNCHD_TEST_SOCKET;
+  });
+
+  const connect = busAddress =>
+    new Promise((resolve, reject) => {
+      let stream;
+      try {
+        stream = dbus.createConnection({ busAddress }).stream;
+      } catch (e) {
+        return reject(e);
+      }
+      stream.once('connect', () => {
+        stream.destroy();
+        resolve();
+      });
+      stream.once('error', reject);
+    });
+
+  it('resolves the socket through launchctl getenv', async () => {
+    stubLaunchctl({ DBUS_LAUNCHD_TEST_SOCKET: socketPath });
+    await connect('launchd:env=DBUS_LAUNCHD_TEST_SOCKET');
+  });
+
+  it('falls back to our own environment when launchctl has no answer', async () => {
+    stubLaunchctl({});
+    process.env.DBUS_LAUNCHD_TEST_SOCKET = socketPath;
+    await connect('launchd:env=DBUS_LAUNCHD_TEST_SOCKET');
+  });
+
+  it('falls back to our own environment when launchctl is absent', async () => {
+    noLaunchctl();
+    process.env.DBUS_LAUNCHD_TEST_SOCKET = socketPath;
+    await connect('launchd:env=DBUS_LAUNCHD_TEST_SOCKET');
+  });
+
+  it('prefers launchctl over our environment, as the spec intends', async () => {
+    stubLaunchctl({ DBUS_LAUNCHD_TEST_SOCKET: socketPath });
+    process.env.DBUS_LAUNCHD_TEST_SOCKET = path.join(tmp, 'wrong');
+    await connect('launchd:env=DBUS_LAUNCHD_TEST_SOCKET');
+  });
+
+  it('says what is missing when the variable is set nowhere', async () => {
+    stubLaunchctl({});
+    await assert.rejects(
+      () => connect('launchd:env=DBUS_LAUNCHD_TEST_SOCKET'),
+      {
+        message:
+          /DBUS_LAUNCHD_TEST_SOCKET, which is set neither in the launchd environment nor in this process/
+      }
+    );
+  });
+
+  it('rejects an address with no env parameter', async () => {
+    await assert.rejects(() => connect('launchd:'), {
+      message: /not enough parameters for 'launchd' connection/
+    });
+  });
+
+  it('is tried after an earlier address in the list fails', async () => {
+    stubLaunchctl({ DBUS_LAUNCHD_TEST_SOCKET: socketPath });
+    await connect('unix:;launchd:env=DBUS_LAUNCHD_TEST_SOCKET');
+  });
+});
+
+describe('the default session bus address', () => {
+  it('falls back to launchd on macOS, and nothing elsewhere', () => {
+    const saved = process.env.DBUS_SESSION_BUS_ADDRESS;
+    delete process.env.DBUS_SESSION_BUS_ADDRESS;
+    try {
+      assert.throws(
+        () => dbus.createConnection({}),
+        process.platform === 'darwin'
+          ? // Reaching the launchd lookup at all is the point: on a Mac with
+            // no bus running this is as far as it can get.
+            /DBUS_LAUNCHD_SESSION_BUS_SOCKET|ENOENT|connect/
+          : /unknown bus address/
+      );
+    } finally {
+      if (saved === undefined) delete process.env.DBUS_SESSION_BUS_ADDRESS;
+      else process.env.DBUS_SESSION_BUS_ADDRESS = saved;
+    }
+  });
+});

--- a/test/integration/launchd.js
+++ b/test/integration/launchd.js
@@ -1,0 +1,88 @@
+// A real connection to a real daemon, reached through a launchd: address.
+//
+// test/address-launchd.js checks the lookup against a bare socket; this checks
+// that a bus reached that way actually completes the SASL handshake and serves
+// calls, which is the thing #95 asked for.
+//
+// The daemon is the one the integration suite already runs -- its address is
+// re-expressed as launchd:env=... with `launchctl` stubbed on PATH, so nothing
+// touches the user's real login session.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const dbus = require('../../index');
+
+const NO_BUS =
+  !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
+
+// The suite's daemon listens on a unix socket; a tcp: address has no path to
+// hand to launchd, so there would be nothing to test.
+const socketOf = address => {
+  const match = /^unix:(?:path|socket)=([^,;]+)/.exec(address || '');
+  return match && match[1];
+};
+
+const SOCKET = socketOf(process.env.DBUS_SESSION_BUS_ADDRESS);
+const SKIP = NO_BUS || (!SOCKET && 'session bus is not on a unix socket');
+
+describe(
+  'integration: launchd transport',
+  { timeout: 10000, skip: SKIP },
+  () => {
+    let tmp;
+    const realPath = process.env.PATH;
+
+    before(() => {
+      tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dbus-launchd-int-'));
+      const bin = path.join(tmp, 'bin');
+      fs.mkdirSync(bin, { recursive: true });
+      fs.writeFileSync(
+        path.join(bin, 'launchctl'),
+        `#!/bin/sh
+[ "$1" = "getenv" ] && [ "$2" = "DBUS_LAUNCHD_TEST_BUS" ] && echo "${SOCKET}"
+exit 0
+`,
+        { mode: 0o755 }
+      );
+      process.env.PATH = `${bin}${path.delimiter}${realPath}`;
+    });
+
+    after(() => {
+      process.env.PATH = realPath;
+      fs.rmSync(tmp, { recursive: true, force: true });
+    });
+
+    it('completes the handshake and serves calls', async () => {
+      const bus = dbus.sessionBus({
+        busAddress: 'launchd:env=DBUS_LAUNCHD_TEST_BUS'
+      });
+      try {
+        const id = await bus.getId();
+        assert.match(id, /^[0-9a-f]+$/);
+
+        const names = await bus.listNames();
+        assert.ok(
+          names.includes('org.freedesktop.DBus'),
+          'the daemon is on the bus we reached'
+        );
+      } finally {
+        bus.connection.end();
+      }
+    });
+
+    it('gets a unique name, so Hello went through', async () => {
+      const bus = dbus.sessionBus({
+        busAddress: 'launchd:env=DBUS_LAUNCHD_TEST_BUS'
+      });
+      try {
+        await bus.getId();
+        assert.match(bus.name, /^:\d+\.\d+$/);
+      } finally {
+        bus.connection.end();
+      }
+    });
+  }
+);


### PR DESCRIPTION
Closes #95. ROADMAP §5.

macOS does not set `DBUS_SESSION_BUS_ADDRESS` — it advertises the session bus
through launchd instead. So `sessionBus()` on a Mac failed with `unknown bus
address` even with a bus running perfectly well, and the workaround in the issue
was to dig the socket out of the environment by hand:

```js
dbus.sessionBus({
  busAddress: 'unix:path=' + process.env.DBUS_LAUNCHD_SESSION_BUS_SOCKET
});
```

## Two parts

**`launchd:env=VAR` is now a transport.** Per the
[spec](https://dbus.freedesktop.org/doc/dbus-specification.html#transports-launchd)
it names an environment *variable* rather than a path, looked up with `launchctl
getenv`. That indirection is the point of the transport: the variable lives in
the launchd session, which is not necessarily ours — a process not started from
a shell holding it still needs to find it. When launchd has no answer (or is not
there at all, off macOS) our own environment is consulted before giving up.

**`sessionBus()` falls back to it on darwin** when `DBUS_SESSION_BUS_ADDRESS` is
unset, which is the normal state there. So a Mac with `brew services start dbus`
needs no setup at all.

Both are additive — that path previously threw.

## Cost

The lookup is `spawnSync`, measured at **4 ms**, once per connection and before
any I/O.

Making it async would have turned `createConnection()` — and so `sessionBus()` —
async for every caller on every platform, to fix one transport on one of them.
Reading `process.env` alone would have been free but wrong, for the reason
above. No shell is involved (args go as an array), so the variable name out of
the address string cannot become a command.

## Testing

`launchctl` is stubbed by putting a script earlier on `PATH` rather than by
calling `launchctl setenv`, which would change the user's real login session and
outlive the test run.

- `test/address-launchd.js` — 8 tests: resolution through `launchctl`, both
  fallbacks (no answer, and no `launchctl` at all), that `launchctl` wins over
  our environment as the spec intends, the error when the variable is set
  nowhere, a missing `env` parameter, and use in a `;`-separated address list.
- `test/integration/launchd.js` — re-expresses the integration suite's own
  daemon as a `launchd:` address and checks a real SASL handshake, `Hello` and
  method calls go through it. Skips when the session bus is not on a unix
  socket.

520 unit and 102 integration tests pass.

Note the interesting half only runs on macOS in practice, but the tests
themselves are platform-independent — the stub makes the `launchctl` path
exercisable on the Linux CI legs too.