### PR TITLE
refactor: make the library's own reads survive the 2.0 value shapes

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -511,19 +511,49 @@ Related: [#3](https://github.com/sidorares/dbus-native/issues/3),
 "how do I deal with `a{sv}`". A documented, ergonomic dict/variant story would
 close roughly a dozen issues at once.
 
-**Our own call sites**, from `npx dbus-native lint lib index.js` — this is the
-internal half of the 2.0 change, and it is small:
+**Our own call sites** — the internal half of the 2.0 change, found with
+`npx dbus-native lint lib index.js`. **Done**, and they turned out to be more
+than housekeeping:
 
-| site                    | reads               | what it is                             |
-| ----------------------- | ------------------- | -------------------------------------- |
-| `lib/message.js:120`    | `field[1][1][0]`    | header fields                          |
-| `lib/message.js:183`    | `field[1][1][0]`    | header fields                          |
-| `lib/stdifaces.js:148`  | `msg.body[2][1][0]` | the value argument of `Properties.Set` |
-| `lib/introspect.js:194` | `val[1][0]`         | the reply from `Properties.Get`        |
+| site                   | read                | what it is                             |
+| ---------------------- | ------------------- | -------------------------------------- |
+| `lib/message.js:120`   | `field[1][1][0]`    | header fields — **the blocker**        |
+| `lib/message.js:183`   | `field[1][1][0]`    | header fields                          |
+| `lib/stdifaces.js:175` | `msg.body[2][1][0]` | the value argument of `Properties.Set` |
+| `lib/introspect.js`    | `val[1][0]`         | the reply from `Properties.Get`        |
+
+A message header is `a(yv)`, so **header field values are variants**, and the
+`DBusBuffer` that parses them is built with the connection's own options. Flip
+the variant shape and header parsing dies on the first message — not on some
+edge case, on everything. Verified: with these sites reverted, a simulated 2.0
+parser takes the connection down immediately at `message.js:120`.
+
+All four now read through `variantValue()`, which handles either shape. The
+alternative was to parse headers with fixed options so a user-facing value
+option could not reach them; `variantValue()` was preferred because it stays
+correct after 2.0 rather than merely insulating against it, and it costs
+0.018 µs per message against ~1 µs to unmarshall one.
+
+`toPlain()` also now recurses into plain objects. It returned non-arrays
+unchanged, so on the new shape it would have left a nested variant unconverted
+— and the whole point of the 0.6 helpers is that they are the identity there.
+
+Guarded by `test/integration/future-shape.js`, which patches the parser to
+produce the 2.0 shapes and runs a real exchange over a real daemon: headers,
+method calls, `Properties.Get`/`Set`, `GetAll` as a plain object, `toPlain` as
+the identity, and a value read in the new shape written straight back out
+(which §4.2 made possible).
 
 Plus four `ReturnLongjs` branches in `index.js` and `lib/dbus-buffer.js`, which
-§3.2 removes. The linter finds no false positives on this codebase, which is
-the evidence that its rules are worth pointing at consumers.
+§3.2 removes. The two hits the linter still reports are both benign — a `Map`
+iteration it flags as `(possible)`, and the marshaller deliberately reading the
+classic shape — which is about the right false-positive rate for rules pointed
+at consumers.
+
+**What remains** is the option itself: one flag flipping both shapes together,
+opt-in for a release and default in 2.0, exactly as `returnBigInt` did in §3.2.
+Flipping only dicts is not worth shipping — `a{sv}` is the case everyone wants,
+and `{ Name: [tree, ['x']] }` is half-migrated and worse than either end state.
 
 ### 4.2 Marshall JS objects as `a{sv}`
 

--- a/lib/introspect.js
+++ b/lib/introspect.js
@@ -1,5 +1,6 @@
 const xml2js = require('xml2js');
 const { maybePromise } = require('./promisify');
+const { variantValue } = require('./values');
 
 module.exports.introspectBus = function (obj, callback) {
   const bus = obj.service.bus;
@@ -357,8 +358,10 @@ DBusInterface.prototype.$readProp = function (propName, callback) {
       },
       (err, val) => {
         if (err) return cb(err);
-        const signature = val[0];
-        cb(err, signature.length === 1 ? val[1][0] : val[1]);
+        // Properties.Get returns a variant. variantValue() unwraps it in
+        // either shape and applies the same one-value-or-all rule this used to
+        // spell out by indexing into the parsed signature tree.
+        cb(err, variantValue(val));
       }
     )
   );

--- a/lib/marshall.js
+++ b/lib/marshall.js
@@ -3,7 +3,7 @@ const assert = require('assert');
 const parseSignature = require('./signature');
 const Marshallers = require('./marshallers');
 const Writer = require('./writer');
-const { Variant, dumpSignature } = require('./values');
+const { Variant, dumpSignature, isPlainObject } = require('./values');
 
 // Element types whose array body starts on an 8-byte boundary. The padding
 // between the length and the first element is not counted in the length.
@@ -66,17 +66,6 @@ const INT32_MAX = 2147483647;
 // 'x' and 't' are left alone -- their marshaller already parses strings, and
 // going through Number() would lose precision above 2^53.
 const NUMERIC_KEYS = new Set(['y', 'n', 'q', 'i', 'u', 'd']);
-
-function isPlainObject(value) {
-  if (value === null || typeof value !== 'object') return false;
-  if (Array.isArray(value) || ArrayBuffer.isView(value)) return false;
-  if (value instanceof Variant) return false;
-  // Deliberately strict: a class instance is not silently treated as a dict,
-  // because being wrong about that writes a garbled message rather than
-  // failing.
-  const proto = Object.getPrototypeOf(value);
-  return proto === Object.prototype || proto === null;
-}
 
 /**
  * The d-bus signature for a JavaScript value.

--- a/lib/message.js
+++ b/lib/message.js
@@ -1,6 +1,7 @@
 const marshall = require('./marshall');
 const constants = require('./constants');
 const DBusBuffer = require('./dbus-buffer');
+const { variantValue } = require('./values');
 
 const headerSignature = require('./header-signature.json');
 
@@ -117,7 +118,12 @@ module.exports.unmarshalMessages = function messageParser(
 
     for (const field of unmarshalledHeader) {
       const headerName = constants.headerTypeName[field[0]];
-      message[headerName] = field[1][1][0];
+      // A header field value is a variant, and this buffer was built with the
+      // connection's own options -- so once a value-shape option can flip what
+      // a variant looks like, `field[1][1][0]` reads the wrong thing on every
+      // message. variantValue() reads either shape, and costs 0.018 us per
+      // message against ~1 us to unmarshall one.
+      message[headerName] = variantValue(field[1]);
     }
 
     message.type = header[1];
@@ -180,7 +186,8 @@ module.exports.unmarshall = function unmarshall(buff, opts) {
   const message = {};
   for (let i = 0; i < headers[6].length; ++i) {
     const headerName = constants.headerTypeName[headers[6][i][0]];
-    message[headerName] = headers[6][i][1][1][0];
+    // As in the streaming path above: a header field value is a variant.
+    message[headerName] = variantValue(headers[6][i][1]);
   }
   message.type = headers[1];
   message.flags = headers[2];

--- a/lib/stdifaces.js
+++ b/lib/stdifaces.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const constants = require('./constants');
 const parseSignature = require('./signature');
 const properties = require('./properties');
+const { variantValue } = require('./values');
 
 // org.freedesktop.DBus.Peer.GetMachineId must return the same 32-char hex id
 // for the lifetime of the machine. Prefer the real one written by dbus/systemd,
@@ -169,10 +170,12 @@ module.exports = function (msg, bus) {
           );
           return 1;
         }
-        // Set takes (interface_name, property_name, value) where the value is a
-        // variant. An unmarshalled variant is [signatureTree, [value]], so the
-        // value we want to assign lives at body[2][1][0].
-        const value = msg.body[2][1][0];
+        // Set takes (interface_name, property_name, value) where the value is
+        // a variant. Read through variantValue() rather than by index: this
+        // runs on a message the library parsed with the connection's own
+        // options, so it has to keep working when a value-shape option makes
+        // an unmarshalled variant the plain value instead of [tree, [value]].
+        const value = variantValue(msg.body[2]);
         impl[propertyName] = value;
         // Tell subscribers. A write-only property has no value to broadcast,
         // so it is reported as invalidated instead -- which is what the spec

--- a/lib/values.js
+++ b/lib/values.js
@@ -50,6 +50,21 @@ function isTaggedVariant(value) {
   return Array.isArray(value) && value[VARIANT] === true;
 }
 
+/**
+ * An object that can stand in for a dict.
+ *
+ * Deliberately strict: a class instance is not one, because treating it as a
+ * dict writes a garbled message rather than failing. Shared with the
+ * marshaller so that what `toPlain` produces is exactly what it accepts back.
+ */
+function isPlainObject(value) {
+  if (value === null || typeof value !== 'object') return false;
+  if (Array.isArray(value) || ArrayBuffer.isView(value)) return false;
+  if (value instanceof Variant) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
 // Fallback for values that did not come from this library's parser -- hand
 // built fixtures, or anything constructed by a caller. Deliberately strict.
 function looksLikeClassicVariant(value) {
@@ -129,6 +144,16 @@ function toPlain(value) {
     }
     return value.map(toPlain);
   }
+  // Recursed into rather than returned as-is: this is what a dict already
+  // looks like when it is read in the 2.0 shape, and the promise of this
+  // helper is that it is the identity there. Returning early would leave any
+  // variant nested inside it unconverted -- which is exactly the half-migrated
+  // state a mixed read shape produces.
+  if (isPlainObject(value)) {
+    const out = {};
+    for (const key of Object.keys(value)) out[key] = toPlain(value[key]);
+    return out;
+  }
   return value;
 }
 
@@ -137,6 +162,7 @@ module.exports = {
   variantValue,
   variantSignature,
   toPlain,
+  isPlainObject,
   // internal
   VARIANT,
   DICT,

--- a/test/integration/future-shape.js
+++ b/test/integration/future-shape.js
@@ -1,0 +1,174 @@
+// A canary for the 2.0 read shape.
+//
+// In 2.0 a variant unmarshals as the value itself and a dict as a plain
+// object. The library reads its *own* messages through the same parser, so
+// anything inside it that unwraps a variant by index breaks the moment that
+// happens -- on every message, because a message header is `a(yv)` and its
+// field values are variants.
+//
+// Nothing here implements the option. It patches the parser to produce the
+// flipped shapes and then runs a real exchange over a real daemon, which is
+// the only way to be sure the internals are ready before committing to it.
+//
+// If the parser's variant or dict representation changes, update the patch
+// below alongside it -- a stale patch makes this test meaningless rather than
+// loud.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const DBusBuffer = require('../../lib/dbus-buffer');
+const parseSignature = require('../../lib/signature');
+const { toPlain } = require('../../lib/values');
+const dbus = require('../../index');
+
+const NO_BUS =
+  !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
+
+const SERVICE = 'com.github.sidorares.dbusnative.FutureShape';
+const OBJECT_PATH = '/com/github/sidorares/dbusnative/FutureShape';
+const IFACE = 'com.github.sidorares.dbusnative.FutureShapeIface';
+const PROPS = 'org.freedesktop.DBus.Properties';
+
+const ifaceDesc = {
+  name: IFACE,
+  methods: { Echo: ['s', 's', ['input'], ['output']] },
+  signals: {},
+  properties: { Greeting: 's' }
+};
+
+// node:test runs each file in its own process, so patching a prototype here
+// cannot leak into the rest of the suite.
+const original = {
+  readVariant: DBusBuffer.prototype.readVariant,
+  readArray: DBusBuffer.prototype.readArray
+};
+
+function useFutureShape() {
+  DBusBuffer.prototype.readVariant = function () {
+    const tree = parseSignature(this.readSimpleType('g'));
+    const values = this.readStruct(tree);
+    // 2.0: the value, not [tree, [value]]
+    return values.length === 1 ? values[0] : values;
+  };
+  DBusBuffer.prototype.readArray = function (eleType, arrayBlobSize) {
+    const result = original.readArray.call(this, eleType, arrayBlobSize);
+    if (eleType.type !== '{') return result;
+    // 2.0: a plain object, not an array of pairs
+    const out = {};
+    for (const [key, value] of result) out[key] = value;
+    return out;
+  };
+}
+
+describe(
+  'integration: the 2.0 read shape',
+  { timeout: 10000, skip: NO_BUS },
+  () => {
+    let serviceBus, clientBus, impl, iface;
+
+    const whenReady = bus =>
+      new Promise((resolve, reject) =>
+        bus.getId(err => (err ? reject(err) : resolve()))
+      );
+
+    before(async () => {
+      useFutureShape();
+
+      serviceBus = dbus.sessionBus();
+      clientBus = dbus.sessionBus();
+      impl = Object.assign(Object.create(EventEmitter.prototype), {
+        Greeting: 'hello',
+        Echo: input => input
+      });
+      EventEmitter.call(impl);
+
+      // Getting this far already proves header parsing survives: getId is a
+      // real round trip whose reply headers were parsed in the flipped shape.
+      await Promise.all([whenReady(serviceBus), whenReady(clientBus)]);
+      await new Promise((resolve, reject) =>
+        serviceBus.requestName(SERVICE, 0, err => {
+          if (err) return reject(err);
+          serviceBus.exportInterface(impl, OBJECT_PATH, ifaceDesc);
+          resolve();
+        })
+      );
+      iface = await clientBus
+        .getService(SERVICE)
+        .getInterface(OBJECT_PATH, IFACE);
+    });
+
+    after(() => {
+      DBusBuffer.prototype.readVariant = original.readVariant;
+      DBusBuffer.prototype.readArray = original.readArray;
+      if (serviceBus) serviceBus.connection.end();
+      if (clientBus) clientBus.connection.end();
+    });
+
+    it('parses message headers', () => {
+      // lib/message.js read every header field as field[1][1][0]; before this
+      // was fixed the connection died on the first message with
+      // "Cannot read properties of undefined".
+      assert.match(clientBus.name, /^:\d+\.\d+$/);
+    });
+
+    it('completes a method call', async () => {
+      assert.strictEqual(await iface.Echo('ping'), 'ping');
+    });
+
+    it('reads a property through the proxy', async () => {
+      // lib/introspect.js $readProp indexed into the parsed signature tree.
+      assert.strictEqual(await iface.Greeting(), 'hello');
+    });
+
+    it('writes a property', async () => {
+      // lib/stdifaces.js took the value from body[2][1][0].
+      await iface.$writeProp('Greeting', 'updated');
+      await new Promise(resolve => setTimeout(resolve, 100));
+      assert.strictEqual(impl.Greeting, 'updated');
+      assert.strictEqual(await iface.Greeting(), 'updated');
+    });
+
+    it('returns a{sv} as a plain object', async () => {
+      const all = await clientBus.invoke({
+        destination: SERVICE,
+        path: OBJECT_PATH,
+        interface: PROPS,
+        member: 'GetAll',
+        signature: 's',
+        body: [IFACE]
+      });
+      assert.ok(!Array.isArray(all), 'a dict is an object in this shape');
+      assert.strictEqual(all.Greeting, 'updated');
+    });
+
+    it('leaves toPlain as the identity', async () => {
+      const all = await clientBus.invoke({
+        destination: SERVICE,
+        path: OBJECT_PATH,
+        interface: PROPS,
+        member: 'GetAll',
+        signature: 's',
+        body: [IFACE]
+      });
+      // The whole 0.6 forward-compatibility promise: code written against
+      // toPlain() behaves the same before and after the change.
+      assert.deepStrictEqual(toPlain(all), { Greeting: 'updated' });
+    });
+
+    it('round-trips a value read in this shape back onto the wire', async () => {
+      // #335 made the marshaller take plain objects, so a value read here can
+      // be sent straight back out without unwrapping.
+      const all = await clientBus.invoke({
+        destination: SERVICE,
+        path: OBJECT_PATH,
+        interface: PROPS,
+        member: 'GetAll',
+        signature: 's',
+        body: [IFACE]
+      });
+      const echoed = await iface.Echo(all.Greeting);
+      assert.strictEqual(echoed, 'updated');
+    });
+  }
+);


### PR DESCRIPTION
Groundwork for reading dicts as plain objects and variants as plain values.
**No option yet** — this is what has to be true before one can exist. ROADMAP
§4.1.

## The blocker

The library reads its own messages through the same parser as everyone else, so
anything inside it that unwraps a variant by index breaks the moment that shape
changes. `npx dbus-native lint lib index.js` found four sites:

| site | read | what it is |
| --- | --- | --- |
| `lib/message.js:120` | `field[1][1][0]` | header fields — **the blocker** |
| `lib/message.js:183` | `field[1][1][0]` | header fields |
| `lib/stdifaces.js:175` | `msg.body[2][1][0]` | `Properties.Set`'s value argument |
| `lib/introspect.js` | `val[1][0]` | `Properties.Get`'s reply |

A message header is `a(yv)`, so **header field values are variants**, and the
`DBusBuffer` parsing them is built with the connection's own options. Flip the
variant shape and header parsing dies on the *first message* — not on an edge
case, on everything.

That is not a guess. With these sites reverted and the parser patched to the
2.0 shapes, the connection goes down immediately:

```
    at readBody (lib/message.js:120:40)
    at Socket.onReadable (lib/message.js:141:19)
```

## The fix

All four read through `variantValue()`, which handles either shape.

The alternative was parsing headers with *fixed* options so a user-facing value
option could not reach them. I preferred `variantValue()` because it stays
correct **after** 2.0 rather than merely insulating against it — and because it
is exactly what we tell users to do. Measured on the header path: **0.018 µs per
message**, against ~1 µs to unmarshall one.

`toPlain()` now recurses into plain objects. It returned non-arrays unchanged,
so on the new shape it would leave a nested variant unconverted — and the whole
promise of the 0.6 helpers is that they are the identity there. `isPlainObject`
moved to `lib/values.js` so the reader and the marshaller cannot drift on what
counts as a dict.

## Proving it

`test/integration/future-shape.js` patches the parser to produce the 2.0 shapes
and runs a real exchange over a real daemon — headers, method calls,
`Properties.Get`/`Set`, `GetAll` as a plain object, `toPlain` as the identity,
and a value read in the new shape written straight back out (only possible
because #335 taught the marshaller to take plain objects).

It is a canary, not a spec: if the parser's variant or dict representation
changes, the patch must be updated alongside it. That is called out in the file,
because a stale patch would make the test meaningless rather than loud.

## What remains

The option itself: **one flag flipping both shapes together**, opt-in for a
release and default in 2.0, exactly as `returnBigInt` did. Flipping only dicts
is not worth shipping — `a{sv}` is the case everyone wants, and
`{ Name: [tree, ['x']] }` is half-migrated and worse than either end state.

527 unit and 109 integration tests pass.