### PR TITLE
fix: do not crash when a match call loses the race with a closing connection

### DIFF
--- a/lib/introspect.js
+++ b/lib/introspect.js
@@ -1,6 +1,7 @@
 const xml2js = require('xml2js');
 const { maybePromise } = require('./promisify');
 const { variantValue } = require('./values');
+const { ConnectionClosedError } = require('./errors');
 
 module.exports.introspectBus = function (obj, callback) {
   const bus = obj.service.bus;
@@ -133,6 +134,13 @@ function findRegistration(handlers, callback) {
  * -- and use $subscribe()/$unsubscribe() when you would rather handle it.
  */
 function reportSubscriptionError(bus, err) {
+  // A match rule on a connection that has gone away is not worth reporting,
+  // let alone crashing over: there is nothing left to subscribe to. Ending a
+  // connection shortly after off() is an ordinary shutdown, and RemoveMatch
+  // losing the race with the close used to take the whole process down --
+  // intermittently, since it depends on which arrives first.
+  if (err instanceof ConnectionClosedError) return;
+
   const connection = bus.connection;
   if (connection && connection.listenerCount('handlerError') > 0) {
     connection.emit('handlerError', err);

--- a/test/proxy-signals.js
+++ b/test/proxy-signals.js
@@ -9,6 +9,7 @@ const { describe, it, beforeEach } = require('node:test');
 const assert = require('assert');
 const { EventEmitter } = require('events');
 const introspect = require('../lib/introspect');
+const { ConnectionClosedError } = require('../lib/errors');
 
 const IFACE = 'com.example.Iface';
 const PATH = '/com/example/Obj';
@@ -297,6 +298,57 @@ describe('proxy signals', () => {
       fire('Alpha', ['x']);
       assert.strictEqual(count, 1);
       assert.strictEqual(bus.matches.length, 1);
+    });
+
+    // Ending a connection shortly after off() is an ordinary shutdown, and
+    // RemoveMatch losing the race with the close used to reach the "nobody is
+    // listening, so rethrow" path and take the process down -- intermittently,
+    // which is how it showed up: one CI leg out of six.
+    it('stays quiet when the match call fails because the connection closed', async () => {
+      const quiet = stubBus();
+      const ifaceQuiet = await proxyFor(quiet);
+      const connection = new EventEmitter();
+      quiet.connection = connection;
+      const reported = [];
+      connection.on('handlerError', e => reported.push(e));
+
+      const thrown = [];
+      const onUncaught = e => thrown.push(e);
+      process.on('uncaughtException', onUncaught);
+
+      quiet.addMatchError = new ConnectionClosedError({});
+      ifaceQuiet.on('Alpha', () => {});
+      await new Promise(setImmediate);
+
+      quiet.addMatchError = null;
+      quiet.removeMatchError = new ConnectionClosedError({});
+      const cb = () => {};
+      await ifaceQuiet.$subscribe('Beta', cb);
+      ifaceQuiet.off('Beta', cb);
+      await new Promise(setImmediate);
+
+      process.removeListener('uncaughtException', onUncaught);
+      assert.deepStrictEqual(
+        reported,
+        [],
+        'nothing to report on a dead connection'
+      );
+      assert.deepStrictEqual(thrown, [], 'and nothing rethrown');
+    });
+
+    it('still reports a match failure that is not the connection closing', async () => {
+      const connection = new EventEmitter();
+      bus.connection = connection;
+      const errors = [];
+      connection.on('handlerError', e => errors.push(e));
+
+      iface.on('Alpha', () => {});
+      await new Promise(setImmediate);
+      assert.strictEqual(errors.length, 1);
+      assert.strictEqual(
+        errors[0].dbusName,
+        'org.freedesktop.DBus.Error.AccessDenied'
+      );
     });
 
     it('reports through the connection rather than throwing, via on()', async () => {


### PR DESCRIPTION
Investigating the CI flake on master — [run 30425231489](https://github.com/sidorares/dbus-native/actions/runs/30425231489), one leg of six (`test (node 22, macos-latest)`, while Node 20 and 24 on the same OS passed).

```
Test hook "before" at test/integration/signals.js:52:3 generated asynchronous activity
after the test ended. This activity created the error "ConnectionClosedError: Connection
closed before a reply to org.freedesktop.DBus.RemoveMatch on org.freedesktop.DBus" and
would have caused the test to fail, but instead triggered an uncaughtException event.
```

**This is not a test bug.**

`off()` sends `RemoveMatch` fire-and-forget, and #331 routes a failure from that path to a connection `handlerError` — or, when nothing is listening, to an asynchronous rethrow, which is Node's default for a throwing listener. So *unsubscribing and then closing the connection* — an entirely ordinary shutdown sequence — takes the process down whenever the close beats the reply.

## Repro

Not reproducible by running the test file on its own (109/110 passed, and six local runs were clean); under CI load the reply loses the race. Forcing the ordering makes it deterministic:

```js
await iface.$subscribe('NameOwnerChanged', cb);
iface.off('NameOwnerChanged', cb);      // RemoveMatch in flight
bus.connection.stream.destroy();        // connection dies before the reply
```

```
UNCAUGHT: ConnectionClosedError: Connection closed before a reply to
org.freedesktop.DBus.RemoveMatch on org.freedesktop.DBus
```

## Fix

A match rule on a connection that has gone away is not worth reporting, let alone crashing over — there is nothing left to subscribe to. `ConnectionClosedError` is now ignored in that path.

Every other failure still reports exactly as before. Both halves are pinned:

- `stays quiet when the match call fails because the connection closed` — fails on the current code with `nothing rethrown`.
- `still reports a match failure that is not the connection closing` — `AccessDenied` on `AddMatch` still reaches `handlerError`.

## Note

Worth calling out that this shipped in #331 and only ever failed intermittently, because it is a race — which is why it took a CI leg rather than a local run to surface. The same shape as the handshake race fixed in #329, which also took one leg in seven.

529 unit and 109 integration tests pass; integration run three times over to check for residual flakiness.