### PR TITLE
feat: read the 2.0 value shapes today with `plainValues`

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,25 @@ const props = toPlain(getAllResult); // { Greeting: 'hello', Count: 7 }
 `toPlain()` only converts arrays this library parsed as dicts, so an `a(ss)`
 (array of two-string structs) is left as an array rather than being guessed at.
 
+Or take the 2.0 shapes directly, on a released version, with `plainValues`:
+
+```js
+const bus = dbus.sessionBus({ plainValues: true });
+
+const props = await iface.GetAll(name); // { Greeting: 'hello', Count: 7 }
+const udi = await device.Udi(); // the value, not [tree, [value]]
+```
+
+| signature | default                         | `plainValues`    |
+| --------- | ------------------------------- | ---------------- |
+| `v`       | `[signatureTree, [value]]`      | `value`          |
+| `a{sv}`   | array of pairs, values variants | `{ key: value }` |
+
+Reading only — writing already takes plain objects and `Variant` — so a value
+read this way can be written straight back out. A dict whose keys are not
+strings (`a{us}`) stays as pairs, because a JavaScript object key is always a
+string and converting one would change the key's type.
+
 To find the call sites in your own code that still read the old shapes:
 
 ```shell

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -550,10 +550,36 @@ iteration it flags as `(possible)`, and the marshaller deliberately reading the
 classic shape — which is about the right false-positive rate for rules pointed
 at consumers.
 
-**What remains** is the option itself: one flag flipping both shapes together,
-opt-in for a release and default in 2.0, exactly as `returnBigInt` did in §3.2.
-Flipping only dicts is not worth shipping — `a{sv}` is the case everyone wants,
-and `{ Name: [tree, ['x']] }` is half-migrated and worse than either end state.
+**The option shipped** as `plainValues`: one flag flipping both shapes
+together, opt-in now and the default in 2.0, exactly as `returnBigInt` did in
+§3.2. Flipping only dicts was never worth shipping — `a{sv}` is the case
+everyone wants, and `{ Name: [tree, ['x']] }` is half-migrated and worse than
+either end state, which is also why it is not called `hashAsObject`.
+
+| signature | default                         | `plainValues`               |
+| --------- | ------------------------------- | --------------------------- |
+| `v`       | `[signatureTree, [value]]`      | `value`                     |
+| `a{sv}`   | array of pairs, values variants | `{ key: value }`            |
+| `a{ss}`   | array of pairs                  | `{ key: value }`            |
+| `a{us}`   | array of pairs                  | unchanged — see below       |
+| `a(ss)`   | array of arrays                 | unchanged, it is not a dict |
+
+**Non-string keys stay as pairs.** A JavaScript object key is always a string,
+so `a{us}` read as an object turns the key `1` into `'1'`, and with
+`returnBigInt` a 64-bit key stringifies and loses precision on the way back.
+Quiet corruption is worse than an inconvenient shape, and `toPlain()` still
+converts them for anyone who wants that.
+
+Reading only. #4.2 had already made the marshaller take plain objects and
+`Variant`, so the two halves meet: a value read under this option can be
+written straight back out.
+
+`test/integration/future-shape.js` was written against a monkey-patched parser
+because the option did not exist; it now sets the real option, so the
+simulation is gone and the guarantee is exercised directly.
+
+**What remains for 2.0** is flipping the default, removing the flag, and
+`dbus-native/compat`'s `withClassicTypes()` for code that cannot move yet.
 
 ### 4.2 Marshall JS objects as `a{sv}`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -59,6 +59,7 @@ all three take the same options.
 | `ayBuffer`       | `true \| false \| 'view'` | `true`                                          | how `ay` comes back — see [Values](#values-and-types)          |
 | `maxMessageSize` | `number`                  | 128 MiB                                         | reject a message declaring more than this                      |
 | `returnBigInt`   | `boolean`                 | `false`                                         | read `x`/`t` as native `bigint`, exactly — the 2.0 default     |
+| `plainValues`    | `boolean`                 | `false`                                         | read variants and dicts in the 2.0 shapes — see below          |
 | `ReturnLongjs`   | `boolean`                 | `false`                                         | **deprecated** (`DBUS_DEP0001`) — 64-bit as Long.js            |
 
 Address forms understood by `busAddress`: `unix:path=…`, `unix:abstract=…`,
@@ -554,6 +555,45 @@ Two things to know:
 A class instance is not treated as a dict — only objects whose prototype is
 `Object.prototype` or `null`. Being wrong about that would write a garbled
 message instead of failing.
+
+### Reading the 2.0 shapes today: `plainValues`
+
+The awkward half of the type system is on the **read** side, and it changes in
+2.0. `plainValues: true` gives you that shape now, so code can be migrated on a
+released version instead of on a flag day — the same path `returnBigInt` took:
+
+```js
+const bus = dbus.sessionBus({ plainValues: true });
+```
+
+| signature | default                         | `plainValues`               |
+| --------- | ------------------------------- | --------------------------- |
+| `v`       | `[signatureTree, [value]]`      | `value`                     |
+| `a{sv}`   | array of pairs, values variants | `{ key: value }`            |
+| `a{ss}`   | array of pairs                  | `{ key: value }`            |
+| `a{us}`   | array of pairs                  | **unchanged** — see below   |
+| `a(ss)`   | array of arrays                 | unchanged, it is not a dict |
+
+Reading only. The marshaller already takes plain objects and `Variant`, so a
+value read this way can be written straight back out — including passing one
+from one service to another.
+
+**A dict whose keys are not strings stays as pairs.** A JavaScript object key is
+always a string, so `a{us}` read as an object would turn the key `1` into `'1'`,
+and with `returnBigInt` a 64-bit key would stringify and lose precision on the
+way back. Quiet corruption is worse than an inconvenient shape.
+
+**Reading a variant this way discards its signature**, which is the point of the
+shape — `variantSignature()` returns `undefined` for it. Use `Variant` when
+writing if you need to control the type.
+
+Both sides of a conversation should agree: a service reads its own method
+arguments through the same parser, so set it there too.
+
+`variantValue()` and `toPlain()` read either shape and become the identity under
+this one, so code written against them needs no change when the default flips.
+
+---
 
 A variant read off the wire can also be written straight back, so a value can
 be passed from one service to another without unwrapping it:

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -98,6 +98,18 @@ const { Udi } = await device.props.$all;
 `variantSignature()` gets the signature if you need the type information that
 the flattened form drops.
 
+**You can also have the 2.0 shape itself now**, with `plainValues: true`:
+
+```js
+const bus = dbus.sessionBus({ plainValues: true });
+const udi = variantValue(entry); // already the plain value; this is now a no-op
+```
+
+Reading only — the marshaller has taken plain objects and `Variant` since 0.11,
+so a value read this way can be written straight back out. Set it on a service
+too if it takes variants as arguments, since it reads them through the same
+parser. See [docs/api.md](./api.md#reading-the-20-shapes-today-plainvalues).
+
 Related: [#3](https://github.com/sidorares/dbus-native/issues/3),
 [#67](https://github.com/sidorares/dbus-native/issues/67),
 [#132](https://github.com/sidorares/dbus-native/issues/132),
@@ -131,6 +143,22 @@ a no-op on values that are already plain.
 It only converts arrays this library tagged as dicts while parsing, so `a(ss)`
 (an array of two-string structs) is left alone. A shape-based heuristic cannot
 tell those two apart, which is why the parser tags them instead of guessing.
+
+**You can also have the 2.0 shape itself now**, with `plainValues: true`:
+
+```js
+const bus = dbus.sessionBus({ plainValues: true });
+const props = await iface.GetAll(name); // { Greeting: 'hello', Count: 7 }
+```
+
+One caveat, and it is deliberate: a dict whose keys are **not** strings —
+`a{us}`, `a{ts}` — stays as pairs. A JavaScript object key is always a string,
+so converting those would change the key's type, and a 64-bit key would lose
+precision on the way back. `toPlain()` will still convert them if that is what
+you want.
+
+Writing is unaffected: a plain object has been accepted anywhere a dict is
+expected since 0.11, so this is symmetric.
 
 ---
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -217,6 +217,23 @@ export interface ConnectionOptions {
    */
   returnBigInt?: boolean;
   /**
+   * Read the 2.0 value shapes: a variant comes back as the value itself rather
+   * than `[signatureTree, [value]]`, and a string-keyed dict as a plain object
+   * rather than an array of pairs. This is what they become by default in 2.0 —
+   * opting in now means no change then.
+   *
+   * Affects reading only. The marshaller already accepts plain objects and
+   * `Variant`, so a value read this way can be written straight back out.
+   *
+   * A dict whose keys are not strings (`a{us}`, `a{ts}`) stays as pairs: a
+   * JavaScript object key is always a string, so converting those would change
+   * the key's type and, for 64-bit keys, lose precision.
+   *
+   * Reading a variant this way discards its signature — use `Variant` when
+   * writing if you need to control the type.
+   */
+  plainValues?: boolean;
+  /**
    * @deprecated DBUS_DEP0001 -- 64-bit values become BigInt in 2.0; use
    * `returnBigInt`. Note the capital R: this one option predates the rest and
    * is the only PascalCase name in the API. It cannot be corrected without

--- a/lib/dbus-buffer.js
+++ b/lib/dbus-buffer.js
@@ -6,8 +6,18 @@ const { VARIANT, DICT, tag } = require('./values');
 const DEFAULT_OPTIONS = {
   ayBuffer: true,
   ReturnLongjs: false,
-  returnBigInt: false
+  returnBigInt: false,
+  plainValues: false
 };
+
+// Dict key types that survive becoming JavaScript object keys.
+//
+// A JS object key is always a string, so `a{us}` read as an object turns the
+// key 1 into '1', and with returnBigInt a 64-bit key would stringify and lose
+// precision on the way back. Those dicts stay as pairs even under
+// `plainValues`: converting them would be quiet corruption rather than a
+// convenience, and `toPlain()` is there for anyone who wants it anyway.
+const STRING_KEYS = new Set(['s', 'o', 'g']);
 
 // Buffer + position + global start position ( used in alignment )
 //
@@ -27,6 +37,9 @@ function DBusBuffer(buffer, startPos, options, endianness) {
   // property the caller never set.
   this.ayBuffer =
     this.options.ayBuffer === undefined ? true : this.options.ayBuffer;
+  // The 2.0 value shapes, available now so code can be migrated on a released
+  // version rather than on a flag day. See RELEASE_PLAN.md.
+  this.plainValues = this.options.plainValues === true;
   this.buffer = buffer;
   this.startPos = startPos ? startPos : 0;
   this.pos = 0;
@@ -136,9 +149,14 @@ DBusBuffer.prototype.read = function read(signature) {
 DBusBuffer.prototype.readVariant = function readVariant() {
   const signature = this.readSimpleType('g');
   const tree = parseSignature(signature);
+  const values = this.readStruct(tree);
+  // Under `plainValues` the wrapper is gone and the signature with it, which
+  // is the 2.0 shape. A variant holds exactly one complete type, so the
+  // length check is belt and braces -- it mirrors variantValue().
+  if (this.plainValues) return values.length === 1 ? values[0] : values;
   // Tagged so variantValue()/toPlain() can recognise this without guessing
   // from shape. The tag is non-enumerable and invisible to consumers.
-  return tag([tree, this.readStruct(tree)], VARIANT);
+  return tag([tree, values], VARIANT);
 };
 
 DBusBuffer.prototype.readStruct = function readStruct(struct) {
@@ -184,9 +202,19 @@ DBusBuffer.prototype.readArray = function readArray(eleType, arrayBlobSize) {
   const end = this.pos + arrayBlobSize;
   const result = [];
   while (this.pos < end) result.push(this.readTree(eleType));
+  if (eleType.type !== '{') return result;
+
+  // A dict whose keys are strings becomes a plain object under `plainValues`.
+  // Duplicate keys collapse to the last one -- the spec calls a message with
+  // repeated keys corrupt, and does not require a receiver to reject it.
+  if (this.plainValues && STRING_KEYS.has(eleType.child[0].type)) {
+    const out = {};
+    for (const [key, value] of result) out[key] = value;
+    return out;
+  }
   // A dict is an array of dict-entry structs. Tagging it here is what lets
   // toPlain() tell `a{ss}` from `a(ss)`, which are otherwise identical.
-  return eleType.type === '{' ? tag(result, DICT) : result;
+  return tag(result, DICT);
 };
 
 // A 64-bit value is two 32-bit words. Each word is byte-swapped by readInt32

--- a/test/integration/future-shape.js
+++ b/test/integration/future-shape.js
@@ -1,24 +1,18 @@
-// A canary for the 2.0 read shape.
+// The 2.0 read shape, on a real daemon, with `plainValues` actually on.
 //
-// In 2.0 a variant unmarshals as the value itself and a dict as a plain
+// A variant unmarshals as the value itself and a string-keyed dict as a plain
 // object. The library reads its *own* messages through the same parser, so
 // anything inside it that unwraps a variant by index breaks the moment that
 // happens -- on every message, because a message header is `a(yv)` and its
-// field values are variants.
+// field values are variants. That is what this exists to catch.
 //
-// Nothing here implements the option. It patches the parser to produce the
-// flipped shapes and then runs a real exchange over a real daemon, which is
-// the only way to be sure the internals are ready before committing to it.
-//
-// If the parser's variant or dict representation changes, update the patch
-// below alongside it -- a stale patch makes this test meaningless rather than
-// loud.
+// It used to monkey-patch the parser to simulate the shapes, because the
+// option did not exist yet. It does now, so the simulation is gone and this
+// exercises the real thing.
 
 const { describe, it, before, after } = require('node:test');
 const assert = require('assert');
 const { EventEmitter } = require('events');
-const DBusBuffer = require('../../lib/dbus-buffer');
-const parseSignature = require('../../lib/signature');
 const { toPlain } = require('../../lib/values');
 const dbus = require('../../index');
 
@@ -37,30 +31,6 @@ const ifaceDesc = {
   properties: { Greeting: 's' }
 };
 
-// node:test runs each file in its own process, so patching a prototype here
-// cannot leak into the rest of the suite.
-const original = {
-  readVariant: DBusBuffer.prototype.readVariant,
-  readArray: DBusBuffer.prototype.readArray
-};
-
-function useFutureShape() {
-  DBusBuffer.prototype.readVariant = function () {
-    const tree = parseSignature(this.readSimpleType('g'));
-    const values = this.readStruct(tree);
-    // 2.0: the value, not [tree, [value]]
-    return values.length === 1 ? values[0] : values;
-  };
-  DBusBuffer.prototype.readArray = function (eleType, arrayBlobSize) {
-    const result = original.readArray.call(this, eleType, arrayBlobSize);
-    if (eleType.type !== '{') return result;
-    // 2.0: a plain object, not an array of pairs
-    const out = {};
-    for (const [key, value] of result) out[key] = value;
-    return out;
-  };
-}
-
 describe(
   'integration: the 2.0 read shape',
   { timeout: 10000, skip: NO_BUS },
@@ -73,10 +43,10 @@ describe(
       );
 
     before(async () => {
-      useFutureShape();
-
-      serviceBus = dbus.sessionBus();
-      clientBus = dbus.sessionBus();
+      // Both sides opt in: a service reads its own arguments through the
+      // same parser, so the shape has to work in both directions.
+      serviceBus = dbus.sessionBus({ plainValues: true });
+      clientBus = dbus.sessionBus({ plainValues: true });
       impl = Object.assign(Object.create(EventEmitter.prototype), {
         Greeting: 'hello',
         Echo: input => input
@@ -99,8 +69,6 @@ describe(
     });
 
     after(() => {
-      DBusBuffer.prototype.readVariant = original.readVariant;
-      DBusBuffer.prototype.readArray = original.readArray;
       if (serviceBus) serviceBus.connection.end();
       if (clientBus) clientBus.connection.end();
     });

--- a/test/plain-values.js
+++ b/test/plain-values.js
@@ -1,0 +1,156 @@
+// The `plainValues` option: the 2.0 read shapes, available now.
+//
+// A variant reads as the value itself, and a string-keyed dict as a plain
+// object. Writing is unaffected -- the marshaller has taken plain objects and
+// `Variant` since 0.11, so a value read under this option can be written
+// straight back out.
+
+const { describe, it } = require('node:test');
+const assert = require('assert');
+const marshall = require('../lib/marshall');
+const unmarshall = require('../lib/unmarshall');
+const { Variant, toPlain, variantSignature } = require('../lib/values');
+
+const PLAIN = { plainValues: true };
+
+/** Read a value back both ways, from identical bytes. */
+function bothShapes(signature, value) {
+  const buf = marshall(signature, [value]);
+  return {
+    classic: unmarshall(buf, signature)[0],
+    plain: unmarshall(buf, signature, undefined, PLAIN)[0]
+  };
+}
+
+describe('plainValues', () => {
+  describe('variants', () => {
+    it('reads as the value, not [signatureTree, [value]]', () => {
+      const { classic, plain } = bothShapes('v', new Variant('s', 'x'));
+      assert.strictEqual(plain, 'x');
+      assert.ok(Array.isArray(classic), 'classic shape is unchanged');
+    });
+
+    it('unwraps a container value too', () => {
+      assert.deepStrictEqual(
+        bothShapes('v', new Variant('ai', [1, 2])).plain,
+        [1, 2]
+      );
+    });
+
+    it('loses the signature, which is the point of the shape', () => {
+      const { classic, plain } = bothShapes('v', new Variant('u', 7));
+      assert.strictEqual(variantSignature(classic), 'u');
+      assert.strictEqual(variantSignature(plain), undefined);
+    });
+  });
+
+  describe('dicts', () => {
+    it('reads a{sv} as a plain object of plain values', () => {
+      assert.deepStrictEqual(
+        bothShapes('a{sv}', { Greeting: 'hi', N: 3 }).plain,
+        { Greeting: 'hi', N: 3 }
+      );
+    });
+
+    it('reads a{ss} as a plain object', () => {
+      assert.deepStrictEqual(bothShapes('a{ss}', { a: 'b' }).plain, { a: 'b' });
+    });
+
+    it('reads an empty dict as an empty object', () => {
+      assert.deepStrictEqual(bothShapes('a{sv}', {}).plain, {});
+    });
+
+    it('handles nesting', () => {
+      const data = { outer: { inner: 'deep', n: 2 } };
+      assert.deepStrictEqual(bothShapes('a{sv}', data).plain, data);
+    });
+
+    it('accepts object-path and signature keys, which are also strings', () => {
+      assert.deepStrictEqual(bothShapes('a{os}', { '/a/b': 'x' }).plain, {
+        '/a/b': 'x'
+      });
+    });
+  });
+
+  describe('what it deliberately leaves alone', () => {
+    // A JS object key is always a string, so `a{us}` as an object turns 1 into
+    // '1' -- and a 64-bit key would stringify and lose precision on the way
+    // back. Quiet corruption is worse than an inconvenient shape.
+    it('keeps a numerically-keyed dict as pairs', () => {
+      const { classic, plain } = bothShapes('a{us}', { 1: 'a', 2: 'b' });
+      assert.deepStrictEqual(plain, [
+        [1, 'a'],
+        [2, 'b']
+      ]);
+      assert.deepStrictEqual(plain, classic);
+      assert.strictEqual(typeof plain[0][0], 'number', 'key keeps its type');
+    });
+
+    it('keeps a 64-bit-keyed dict as pairs, exactly', () => {
+      const [dict] = unmarshall(
+        marshall('a{ts}', [{ '9007199254740993': 'a' }]),
+        'a{ts}',
+        undefined,
+        { plainValues: true, returnBigInt: true }
+      );
+      assert.strictEqual(dict[0][0], 9007199254740993n);
+    });
+
+    it('does not turn an array of two-string structs into an object', () => {
+      // a{ss} and a(ss) are identical on the wire apart from the signature;
+      // only the dict becomes an object.
+      assert.deepStrictEqual(bothShapes('a(ss)', [['a', 'b']]).plain, [
+        ['a', 'b']
+      ]);
+    });
+
+    it('leaves ordinary arrays and scalars alone', () => {
+      assert.deepStrictEqual(bothShapes('as', ['x', 'y']).plain, ['x', 'y']);
+      assert.strictEqual(bothShapes('s', 'x').plain, 'x');
+      assert.ok(Buffer.isBuffer(bothShapes('ay', Buffer.from([1, 2])).plain));
+    });
+
+    it('writes identical bytes either way -- this is a read option', () => {
+      assert.deepStrictEqual(
+        marshall('a{sv}', [{ a: 1 }]),
+        marshall('a{sv}', [{ a: 1 }])
+      );
+    });
+  });
+
+  describe('the forward-compatible helpers', () => {
+    it('toPlain is the identity on the new shape', () => {
+      const { plain } = bothShapes('a{sv}', { Greeting: 'hi', N: 3 });
+      assert.deepStrictEqual(toPlain(plain), plain);
+    });
+
+    it('toPlain gives the same answer in both shapes', () => {
+      const { classic, plain } = bothShapes('a{sv}', {
+        outer: { inner: 'deep' }
+      });
+      assert.deepStrictEqual(toPlain(classic), toPlain(plain));
+    });
+  });
+
+  it('round-trips: a value read this way can be written straight back', () => {
+    const data = { Greeting: 'hi', N: 3, tags: ['a', 'b'] };
+    const read = unmarshall(
+      marshall('a{sv}', [data]),
+      'a{sv}',
+      undefined,
+      PLAIN
+    )[0];
+    const again = unmarshall(
+      marshall('a{sv}', [read]),
+      'a{sv}',
+      undefined,
+      PLAIN
+    )[0];
+    assert.deepStrictEqual(again, data);
+  });
+
+  it('is off by default', () => {
+    const [dict] = unmarshall(marshall('a{ss}', [{ a: 'b' }]), 'a{ss}');
+    assert.ok(Array.isArray(dict));
+  });
+});


### PR DESCRIPTION
The remaining half of #3, and the follow-up to #338.

```js
const bus = dbus.sessionBus({ plainValues: true });

const props = await iface.GetAll(name);  // { Greeting: 'hello', Count: 7 }
const udi = await device.Udi();          // the value, not [tree, [value]]
```

Opt-in now, the default in 2.0 — the same path `returnBigInt` took, so the migration happens on a released version instead of on a flag day.

| signature | default | `plainValues` |
| --- | --- | --- |
| `v` | `[signatureTree, [value]]` | `value` |
| `a{sv}` | array of pairs, values variants | `{ key: value }` |
| `a{ss}` | array of pairs | `{ key: value }` |
| `a{us}` | array of pairs | **unchanged** |
| `a(ss)` | array of arrays | unchanged, it is not a dict |

## One option, both shapes

Not `hashAsObject`. Flipping only dicts is not worth shipping: `a{sv}` is the case everyone wants, and `{ Name: [tree, ['x']] }` is half-migrated and worse than either end state. The name says what it does.

## Non-string keys deliberately stay as pairs

A JavaScript object key is always a string. So `a{us}` read as an object turns the key `1` into `'1'`, and with `returnBigInt` a 64-bit key stringifies and loses precision on the way back:

```js
// stays exact, as pairs
dict[0][0] === 9007199254740993n
```

Quiet corruption is worse than an inconvenient shape. `toPlain()` still converts them for anyone who wants that — this is about what the *parser* does by default.

## Reading only

#335 had already taught the marshaller to take plain objects and `Variant`, so the two halves meet: a value read under this option can be written straight back out, including handing one from one service to another. Identical bytes either way.

## The nice part

`test/integration/future-shape.js` was written in #338 against a **monkey-patched parser**, because the option did not exist yet — and I flagged at the time that a stale patch would make it go quiet instead of loud. It now sets the real option, so the simulation is deleted, and it passes unchanged. That is the check that #338 predicted the right things: headers, method calls, `Properties.Get`/`Set`, `GetAll`, `toPlain` as the identity, and the write-back round trip.

## Testing

- `test/plain-values.js` — 17 tests: both shapes from identical bytes, nesting, the signature genuinely being dropped, everything left alone (numeric keys, 64-bit keys exactly, `a(ss)`, `ay`, scalars), `toPlain` as the identity, the round trip, and that it is off by default.
- `test/integration/future-shape.js` — 7 tests against a real daemon with the option on, on both the client and the service.

546 unit and 109 integration tests pass.

## What remains for 2.0

Flipping the default, removing the flag, and `dbus-native/compat`'s `withClassicTypes()` for code that cannot move yet.