### PR TITLE
fix: let a service method return several out arguments

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -775,6 +775,25 @@ belongs with the lifecycle work rather than here.
   so rather than a TODO.
 
 - **Introspect signals** — **done**, see §4.6.
+- **Several out arguments from a service method**
+  ([#114](https://github.com/sidorares/dbus-native/issues/114)) — **done.** The
+  interface descriptor has always accepted an output signature with several
+  complete types, and `interfaceToXML` advertised them, but the reply body was
+  always `[result]` — one value. So the shape was expressible, promised to
+  callers, and impossible to satisfy. Worse, the marshalling failure threw out
+  of a promise continuation, so it took the service process down and the caller
+  waited for a reply that could never arrive.
+
+  Found while auditing the issue tracker, not from a report: the workaround
+  (declare a struct, `(si)`) is close enough to the right answer that nobody
+  seems to have pushed past it. `org.freedesktop.Notifications`'s
+  `GetServerInformation` is the case in the original issue, and declares four.
+
+  Several out arguments now mean "return an array of them"; one still means the
+  value, a struct is still one value, and `null` still means no reply body. A
+  handler that returns the wrong shape gets an error reply naming the method and
+  its declared signature, instead of an unhandled rejection.
+
 - **Double serial increment** — **done**, and it was not harmless. Chasing it
   turned up that nothing ever wrapped `bus.serial`: it was a bare `++` from 1,
   and the serial is a `uint32` in the header, so past 4294967295 the marshaller

--- a/docs/api.md
+++ b/docs/api.md
@@ -339,6 +339,31 @@ error becomes an error reply, using `err.dbusName` if set and
 `org.freedesktop.DBus.Error.Failed` otherwise. Returning `null` sends a reply
 with no body.
 
+### What a method returns
+
+One value per complete type in the output signature:
+
+| output signature | complete types | the handler returns                 |
+| ---------------- | -------------- | ----------------------------------- |
+| `''`             | 0              | anything; no reply body is sent     |
+| `'s'`            | 1              | the value — `'hello'`               |
+| `'(si)'`         | 1 (a struct)   | one array — `['name', 3]`           |
+| `'si'`           | 2              | an array of the two — `['name', 3]` |
+| `'ssss'`         | 4              | an array of the four                |
+
+`'(si)'` and `'si'` take the same JavaScript value and mean different things on
+the wire: one struct, versus two separate arguments. Which you want depends on
+the interface you are implementing — `org.freedesktop.Notifications`'s
+`GetServerInformation`, for instance, declares four separate out arguments.
+
+Returning the wrong shape produces an error reply naming the method and the
+signature it declared, rather than taking the service down:
+
+```
+org.freedesktop.DBus.Error.Failed: com.example.Iface.GetInfo returned a value
+that does not match its declared output signature "ssss": …
+```
+
 `exportInterface` monkey-patches `impl.emit` so a local emit also sends the
 signal. `org.freedesktop.DBus.Introspectable`, `.Properties` and `.Peer` are
 answered for you.

--- a/index.d.ts
+++ b/index.d.ts
@@ -307,6 +307,11 @@ export type InvokeCallback = (err: DBusError | null, ...values: any[]) => void;
 /**
  * A method as declared in an interface descriptor:
  * [inputSignature, outputSignature, inputNames, outputNames]
+ *
+ * The handler returns one value per complete type in `outputSignature`: the
+ * value itself for one, an array for several, and `null` for no reply body at
+ * all. Note `'(si)'` is *one* value — a struct, returned as `[name, count]` —
+ * whereas `'si'` is two.
  */
 export type MethodDescriptor = [string, string, string[], string[]];
 

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -4,6 +4,7 @@ const stdDbusIfaces = require('./stdifaces');
 const introspect = require('./introspect').introspectBus;
 const { maybePromise } = require('./promisify');
 const { assertValidName } = require('./names');
+const parseSignature = require('./signature');
 const {
   TimeoutError,
   AbortError,
@@ -299,6 +300,34 @@ module.exports = function bus(conn, opts) {
     this.connection.message(reply);
   };
 
+  /**
+   * Turn what a method handler returned into a reply body.
+   *
+   * A body is a list of values, one per complete type in the signature. For
+   * the usual single-value method that is `[result]`, which is what this
+   * always did -- so a declared output of several types could never be
+   * satisfied, however the handler returned them. The interface descriptor
+   * happily accepts `['', 'si', [], ['name', 'count']]` and the introspection
+   * XML advertises two out arguments, so the shape was expressible, promised
+   * to callers, and impossible to produce.
+   *
+   * Several out arguments now mean: return them as an array.
+   *
+   * Note this is not the same as declaring a struct. `(si)` is one value and
+   * still takes `[name, count]` as that one value; `si` is two.
+   */
+  function replyBody(signature, result) {
+    // Cached, and a tiny set in practice -- see lib/signature.js.
+    const count = signature ? parseSignature(signature).length : 0;
+    if (count <= 1) return [result];
+    if (!Array.isArray(result)) {
+      throw new Error(
+        `an output signature of "${signature}" declares ${count} values, so the handler must return an array of ${count}, not ${typeof result}`
+      );
+    }
+    return result;
+  }
+
   // route reply/error
   this.connection.on('message', msg => {
     function invoke(impl, func, resultSignature) {
@@ -314,11 +343,30 @@ module.exports = function bus(conn, opts) {
               destination: msg.sender,
               replySerial: msg.serial
             };
-            if (methodReturnResult !== null) {
-              methodReturnReply.signature = resultSignature;
-              methodReturnReply.body = [methodReturnResult];
+            // Building or marshalling a reply can fail -- a handler returning
+            // the wrong shape for what the interface declares. That used to
+            // throw out of this continuation as an unhandled rejection and
+            // take the service down, leaving the caller waiting for a reply
+            // that would never come. (The two-argument `.then` below does not
+            // catch a throw from this handler, which is why the try is here.)
+            // Answer with an error instead: the caller learns what happened
+            // and the service stays up.
+            try {
+              if (methodReturnResult !== null) {
+                methodReturnReply.signature = resultSignature;
+                methodReturnReply.body = replyBody(
+                  resultSignature,
+                  methodReturnResult
+                );
+              }
+              self.connection.message(methodReturnReply);
+            } catch (e) {
+              self.sendError(
+                msg,
+                'org.freedesktop.DBus.Error.Failed',
+                `${msg['interface']}.${msg.member} returned a value that does not match its declared output signature "${resultSignature}": ${e.message}`
+              );
             }
-            self.connection.message(methodReturnReply);
           },
           e => {
             self.sendError(

--- a/test/integration/method-returns.js
+++ b/test/integration/method-returns.js
@@ -1,0 +1,159 @@
+// What a service method may return, and what happens when it returns the
+// wrong thing.
+//
+// The interface descriptor has always accepted an output signature with
+// several complete types -- `['', 'si', [], ['name', 'count']]` -- and the
+// introspection XML advertised two out arguments. But the reply body was
+// always `[result]`, one value, so that shape was expressible, promised to
+// callers, and impossible to satisfy. Worse, the marshalling failure threw
+// out of a promise continuation and took the service process down, so the
+// caller waited for a reply that could never arrive. See #114.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const dbus = require('../../index');
+
+const NO_BUS =
+  !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
+
+const SERVICE = 'com.github.sidorares.dbusnative.Returns';
+const OBJECT_PATH = '/com/github/sidorares/dbusnative/Returns';
+const IFACE = 'com.github.sidorares.dbusnative.ReturnsIface';
+
+const ifaceDesc = {
+  name: IFACE,
+  methods: {
+    Void: ['', '', [], []],
+    One: ['', 's', [], ['only']],
+    Struct: ['', '(si)', [], ['pair']],
+    Two: ['', 'si', [], ['name', 'count']],
+    Four: ['', 'ssss', [], ['name', 'vendor', 'version', 'spec']],
+    ReturnsNull: ['', 's', [], ['only']],
+    // the three ways a handler can be wrong
+    NotAnArray: ['', 'si', [], ['name', 'count']],
+    TooFew: ['', 'si', [], ['name', 'count']],
+    WrongScalar: ['', 's', [], ['only']]
+  },
+  signals: {},
+  properties: {}
+};
+
+describe(
+  'integration: method return values',
+  { timeout: 10000, skip: NO_BUS },
+  () => {
+    let serviceBus, clientBus, iface;
+
+    const whenReady = bus =>
+      new Promise((resolve, reject) =>
+        bus.getId(err => (err ? reject(err) : resolve()))
+      );
+
+    before(async () => {
+      serviceBus = dbus.sessionBus();
+      clientBus = dbus.sessionBus();
+
+      const impl = Object.assign(Object.create(EventEmitter.prototype), {
+        Void: () => undefined,
+        One: () => 'x',
+        Struct: () => ['x', 1],
+        Two: () => ['x', 1],
+        Four: () => ['dbus-native', 'me', '1.0', '1.2'],
+        ReturnsNull: () => null,
+        NotAnArray: () => 'oops',
+        TooFew: () => ['only one'],
+        WrongScalar: () => 42
+      });
+      EventEmitter.call(impl);
+
+      await Promise.all([whenReady(serviceBus), whenReady(clientBus)]);
+      await new Promise((resolve, reject) =>
+        serviceBus.requestName(SERVICE, 0, err => {
+          if (err) return reject(err);
+          serviceBus.exportInterface(impl, OBJECT_PATH, ifaceDesc);
+          resolve();
+        })
+      );
+      iface = await clientBus
+        .getService(SERVICE)
+        .getInterface(OBJECT_PATH, IFACE);
+    });
+
+    after(() => {
+      serviceBus.connection.end();
+      clientBus.connection.end();
+    });
+
+    describe('what a handler may return', () => {
+      it('nothing, for an empty output signature', async () => {
+        assert.strictEqual(await iface.Void(), undefined);
+      });
+
+      it('a single value', async () => {
+        assert.strictEqual(await iface.One(), 'x');
+      });
+
+      it('an array for a struct, which is one value', async () => {
+        assert.deepStrictEqual(await iface.Struct(), ['x', 1]);
+      });
+
+      it('an array for two out arguments, which used to be impossible', async () => {
+        assert.deepStrictEqual(await iface.Two(), ['x', 1]);
+      });
+
+      it('four out arguments, as org.freedesktop.Notifications declares', async () => {
+        assert.deepStrictEqual(await iface.Four(), [
+          'dbus-native',
+          'me',
+          '1.0',
+          '1.2'
+        ]);
+      });
+
+      it('null, which still means no reply body at all', async () => {
+        assert.strictEqual(await iface.ReturnsNull(), undefined);
+      });
+    });
+
+    describe('when a handler returns the wrong thing', () => {
+      // Each of these used to be an unhandled rejection that killed the
+      // service, so the caller hung rather than being told.
+      const cases = [
+        ['NotAnArray', 'declares two values but returns a string'],
+        ['TooFew', 'declares two values but returns one'],
+        ['WrongScalar', 'declares a string but returns a number']
+      ];
+
+      for (const [method, why] of cases) {
+        it(`answers with an error when it ${why}`, async () => {
+          const err = await iface[method]().then(
+            () => null,
+            e => e
+          );
+          assert.ok(err, `${method} should have failed`);
+          assert.strictEqual(err.dbusName, 'org.freedesktop.DBus.Error.Failed');
+          assert.match(err.message, /does not match its declared output/);
+          // the message names the method, since a service may export many
+          assert.match(err.message, new RegExp(`${IFACE}\\.${method}`));
+        });
+      }
+
+      it('leaves the service alive and serving', async () => {
+        const names = await clientBus.listNames();
+        assert.ok(names.includes(SERVICE), 'service is still on the bus');
+        assert.strictEqual(await iface.One(), 'x');
+      });
+    });
+
+    it('advertises the out arguments it can now actually produce', async () => {
+      const xml = await clientBus
+        .getService(SERVICE)
+        .getInterface(OBJECT_PATH, 'org.freedesktop.DBus.Introspectable')
+        .then(i => i.Introspect());
+      const method = xml.match(/<method name="Two">[\s\S]*?<\/method>/)[0];
+      assert.match(method, /<arg type="s" name="name" direction="out"/);
+      assert.match(method, /<arg type="i" name="count" direction="out"/);
+    });
+  }
+);


### PR DESCRIPTION
Closes #114. Found while auditing the issue tracker, not from a report — which is probably why it survived nine years: the workaround is close enough to the right answer that nobody pushed past it.

## The bug

The interface descriptor has always accepted an output signature with several complete types, and `interfaceToXML` advertised them:

```js
methods: { GetServerInformation: ['', 'ssss', [], ['name','vendor','version','spec']] }
```

```xml
<method name="GetServerInformation">
  <arg type="s" name="name" direction="out" />
  <arg type="s" name="vendor" direction="out" />
  …
</method>
```

But the reply body was always `[result]` — **one** value — so nothing a handler returned could satisfy it. The shape was expressible, promised to callers, and impossible to produce.

Worse, the marshalling failure threw out of a promise continuation:

```
Error: message body does not match message signature. Body:[["x",1]], signature:si
    at marshall (lib/marshall.js:34:11)
    at writeMessage (index.js:191:28)
    at lib/bus.js:321:29
```

That is an unhandled rejection — so it took the **service process** down, and the caller waited for a reply that could never arrive.

## The fix

Several out arguments now mean *return an array of them*:

| output signature | complete types | the handler returns |
| --- | --- | --- |
| `''` | 0 | anything; no reply body |
| `'s'` | 1 | the value |
| `'(si)'` | 1 (a struct) | one array — `['name', 3]` |
| `'si'` | 2 | an array of the two — `['name', 3]` |
| `'ssss'` | 4 | an array of the four |

`(si)` and `si` take the same JavaScript value and mean different things on the wire. Nothing that worked before changes, because nothing with more than one out argument *could* work before.

Building and marshalling the reply is now wrapped, so a wrong shape produces an error reply naming the method and its declared signature instead of killing the service:

```
org.freedesktop.DBus.Error.Failed: com.example.Iface.GetInfo returned a value that
does not match its declared output signature "ssss": …
```

One subtlety worth flagging for review: the two-argument `.then(onFulfilled, onRejected)` does **not** catch a throw from its own fulfilment handler, so the `try` sits inside the handler rather than as a trailing `.catch()`.

## Testing

`test/integration/method-returns.js` — 11 tests against a real daemon:

- every arity that already worked (`''`, `'s'`, `'(si)'`, `null`) still does
- two and four out arguments, which used to crash
- all three ways a handler can be wrong, each now an error reply
- the service is still on the bus and serving afterwards
- the introspection XML advertises what can now actually be produced

546 unit and 120 integration tests pass.