### PR TITLE
feat: say why UNIX_FD is unsupported, and scope what it would take

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -352,15 +352,99 @@ to something unrelated would collide with it.
 
 **Severity: feature gap — blocks whole categories of users.**
 
-`signature.js` parses `h`, but both directions throw: `Unknown data type
-format: h` and `Unsupported type: h`. There is no SCM_RIGHTS handling anywhere.
-systemd, the XDG desktop portals and PipeWire all pass file descriptors, so
-those APIs are simply unreachable from this library.
+`signature.js` parses `h`, but both directions throw. There is no SCM_RIGHTS
+handling anywhere. systemd, the XDG desktop portals and PipeWire all pass file
+descriptors, so those APIs are simply unreachable from this library.
 
-This is the largest item in this section and needs design first: Node has no
-public SCM_RIGHTS API, so it likely means a small native addon or a
-`child_process`-mediated hack — which would undo the "no native dependencies"
-property this package is valued for. Worth scoping before committing.
+**Scoped 2026-07-29. Conclusion: not buildable today, and it does not need a
+major when it is.** Every option below was measured, not read about.
+
+#### It is additive, so it needs no major
+
+We never send `NEGOTIATE_UNIX_FD`, so nothing changes for anyone until we do,
+and the daemon already agrees when asked:
+
+```
+daemon: OK a6343c06f036b0dfc55635016a69a2eb
+daemon: AGREE_UNIX_FD
+```
+
+The protocol side is small: the SASL command above, header field 9
+(`UNIX_FDS`, a `u` — note `constants.headerTypeName` stops at 8 today), and `h`
+as an index into the received fd array. None of it is a breaking change. This
+can land in any minor, whenever a transport exists.
+
+#### The transport does not exist
+
+| option                                                                | result                                                                                                                                                                                                |
+| --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Node built-in                                                         | No public ancillary-data API. [nodejs/node#53391](https://github.com/nodejs/node/issues/53391) is **closed as not planned**. libuv supports it; Node never wired it to `net`                          |
+| `process.binding('pipe_wrap')`                                        | **Aborts the process** for the fds d-bus carries — see below                                                                                                                                          |
+| [`node-unix-socket`](https://github.com/xushengfeng/node-unix-socket) | N-API prebuilds for 7 platforms, installs in 719 ms with no compiler, loads fine on Node 26 — but SOCK_SEQPACKET/SOCK_DGRAM only. Against d-bus's SOCK_STREAM socket: `Error: Protocol not supported` |
+| [`usocket`](https://www.npmjs.com/package/usocket)                    | Right socket type, fd passing verified working — but `nan` + `node-gyp`, so it compiles on install and pulls 26 packages (`node-gyp`, `tar`, `undici`) into the runtime tree. No prebuilds            |
+| [`csocket`](https://www.npmjs.com/package/csocket)                    | Last published 2022; prebuilds target Node 4/6/8                                                                                                                                                      |
+
+The near-miss is worth recording. libuv's IPC-mode pipe _does_ read ancillary
+data — it is how `child_process` passes handles — and it can be pointed at an
+existing socket with no addon at all:
+
+```js
+const { Pipe, constants } = process.binding('pipe_wrap');
+const pipe = new Pipe(constants.IPC);
+pipe.open(existingSocket._handle.fd);
+pipe.onread = () => {
+  const handle = pipe.pendingHandle; /* ... */
+};
+pipe.readStart();
+```
+
+But libuv classifies the incoming handle, and d-bus does not pass handles — it
+passes **arbitrary file descriptors**: regular files, memfds, pipes, DRM
+buffers. Tested both ways, on macOS/Node 26 and Linux/Node 24:
+
+```
+socket fd -> got a pendingHandle, read through it: "hello through the passed socket"
+file fd   -> Assertion failed: (type) == (UV_UNKNOWN_HANDLE)   [Aborted]
+```
+
+That is a `CHECK` in Node's own C++ (`stream_wrap.cc:277`), so it is an
+uncatchable abort rather than an error we could fall back from. The technique
+works for the case it was published for — handing TCP sockets between
+processes — and fails on precisely the case d-bus needs. `process.binding` is
+also internal and deprecated.
+
+#### What to do before 3.0/4.0
+
+Do not build it; there is nothing safe to depend on. But **shape the transport
+seam**, because that is the part that would otherwise force a major later.
+
+Everything today assumes `createStream()` returns a byte `Duplex` and that a
+message is a `Buffer`. Carrying descriptors means a message is
+`{ bytes, fds }` in both directions, which touches:
+
+- `connection.message()` and the write path, including the cork/uncork
+  batching from §2.7 — fds must stay attached to _their_ message across a
+  batched `_writev`.
+- `unmarshalMessages()`, which would need to associate received fds with the
+  message whose `UNIX_FDS` header claims them, not merely with the chunk they
+  arrived in.
+- `opts.stream`, which lets a caller supply their own transport. That is the
+  seam to define: an optional capability on the stream object
+  (`stream.writeWithFds?`, `stream.on('fds')`) rather than a new option, so a
+  caller — or a future optional dependency — can provide it without the core
+  depending on anything.
+- `bus.invoke` and the service surface, where a handler receives or returns an
+  fd alongside the body.
+
+Defining that seam now, even with no implementation behind it, is what keeps
+UNIX_FD a minor when it becomes possible. Implementing it now is not worth the
+cost: the only viable dependency needs a compiler on every install, which
+undoes the property §1 spent three releases building and that #342 and #343
+just strengthened further.
+
+Until then, `h` fails with a message that says why, names the Node issue, and
+lists the APIs it costs you — so nobody has to rediscover this. See
+`test/unix-fd.js`.
 
 ### 2.9 Small non-canonical cleanups — DONE
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -56,5 +56,27 @@ module.exports = {
   // sending us a protocol error, and we must not try to buffer it.
   // https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-messages
   maxMessageSize: 134217728, // 128 MiB
-  maxArraySize: 67108864 // 64 MiB
+  maxArraySize: 67108864, // 64 MiB
+
+  /**
+   * Why a type is refused, said the same way in both directions.
+   *
+   * `h` gets its own explanation because "unknown type" is misleading: the
+   * signature parses, the type is real, and the reason it cannot be carried
+   * has nothing to do with this library not recognising it. People rediscover
+   * that repeatedly, so the message says it outright.
+   */
+  unsupportedType(type, direction) {
+    if (type === 'h') {
+      return (
+        `UNIX_FD ('h') is not supported, so this message cannot be ${direction}. ` +
+        'A file descriptor does not travel in the message body -- it is passed ' +
+        'as ancillary data (SCM_RIGHTS) alongside it, and Node has no API for ' +
+        'that: https://github.com/nodejs/node/issues/53391 is closed as not ' +
+        'planned. See ROADMAP.md section 2.8 for what it would take. This ' +
+        'affects systemd, the XDG desktop portals and PipeWire.'
+      );
+    }
+    return `Unknown data type format: ${type}`;
+  }
 };

--- a/lib/dbus-buffer.js
+++ b/lib/dbus-buffer.js
@@ -294,7 +294,7 @@ DBusBuffer.prototype.readSimpleType = function readSimpleType(t) {
     case 'd':
       return this.readDouble();
     default:
-      throw new Error(`Unsupported type: ${t}`);
+      throw new Error(constants.unsupportedType(t, 'read'));
   }
 };
 

--- a/lib/marshallers.js
+++ b/lib/marshallers.js
@@ -1,4 +1,5 @@
 const parseSignature = require('./signature');
+const constants = require('./constants');
 const { isValidObjectPath } = require('./names');
 
 // The validation helpers are shared by every marshaller and do not depend on
@@ -323,7 +324,7 @@ const marshallers = {
 const MakeSimpleMarshaller = function (signature) {
   const marshaller = marshallers[signature];
   if (!marshaller) {
-    throw new Error(`Unknown data type format: ${signature}`);
+    throw new Error(constants.unsupportedType(signature, 'written'));
   }
   return marshaller;
 };

--- a/test/unix-fd.js
+++ b/test/unix-fd.js
@@ -1,0 +1,75 @@
+// UNIX_FD ('h') is not supported, and the error says why.
+//
+// "Unknown data type format: h" was accurate but misleading: the signature
+// parses, the type is real, and the reason it cannot be carried has nothing to
+// do with this library failing to recognise it. A file descriptor is passed as
+// ancillary data (SCM_RIGHTS) alongside the message rather than inside it, and
+// Node has no API for that.
+//
+// See ROADMAP.md §2.8 for the options that were measured, and why none of them
+// works today.
+
+const { describe, it } = require('node:test');
+const assert = require('assert');
+const marshall = require('../lib/marshall');
+const unmarshall = require('../lib/unmarshall');
+const parseSignature = require('../lib/signature');
+
+describe("UNIX_FD ('h')", () => {
+  it('parses as a signature, since it is a real type', () => {
+    assert.deepStrictEqual(parseSignature('h'), [{ type: 'h', child: [] }]);
+  });
+
+  it('cannot be written, and says why', () => {
+    assert.throws(
+      () => marshall('h', [0]),
+      err => {
+        assert.match(err.message, /UNIX_FD \('h'\) is not supported/);
+        assert.match(err.message, /cannot be written/);
+        assert.match(err.message, /ancillary data \(SCM_RIGHTS\)/);
+        return true;
+      }
+    );
+  });
+
+  it('cannot be read, and says why', () => {
+    assert.throws(
+      () => unmarshall(Buffer.alloc(4), 'h'),
+      err => {
+        assert.match(err.message, /UNIX_FD \('h'\) is not supported/);
+        assert.match(err.message, /cannot be read/);
+        return true;
+      }
+    );
+  });
+
+  it('points at the reason rather than at this library', () => {
+    // Someone hitting this should not have to work out whether it is our bug.
+    const message = (() => {
+      try {
+        marshall('h', [0]);
+      } catch (e) {
+        return e.message;
+      }
+    })();
+    assert.match(message, /nodejs\/node\/issues\/53391/);
+    assert.match(message, /ROADMAP/);
+    // and which real-world APIs it costs them
+    assert.match(message, /systemd|portals|PipeWire/);
+  });
+
+  it('is reported the same way inside a container', () => {
+    assert.throws(() => marshall('ah', [[0]]), /UNIX_FD/);
+    assert.throws(() => marshall('(sh)', [['x', 0]]), /UNIX_FD/);
+  });
+
+  it('leaves other unsupported types with the generic message', () => {
+    // A type code the signature parser rejects never reaches the marshaller,
+    // so this is the fallback for anything that parses but has no marshaller.
+    const constants = require('../lib/constants');
+    assert.strictEqual(
+      constants.unsupportedType('Z', 'written'),
+      'Unknown data type format: Z'
+    );
+  });
+});


### PR DESCRIPTION
Two things: a better error for `h`, and ROADMAP §2.8 rewritten from speculation to measurement.

## The error

`h` failed with `Unknown data type format: h` — accurate and misleading. The signature parses, the type is real, and the reason it cannot be carried has nothing to do with this library failing to recognise it. Both directions now say so:

```
UNIX_FD ('h') is not supported, so this message cannot be written. A file
descriptor does not travel in the message body -- it is passed as ancillary
data (SCM_RIGHTS) alongside it, and Node has no API for that:
https://github.com/nodejs/node/issues/53391 is closed as not planned. See
ROADMAP.md section 2.8 for what it would take. This affects systemd, the XDG
desktop portals and PipeWire.
```

## The scoping — two conclusions

**It needs no major.** We never send `NEGOTIATE_UNIX_FD`, so nothing changes for anyone until we do, and the daemon already agrees when asked:

```
daemon: OK a6343c06f036b0dfc55635016a69a2eb
daemon: AGREE_UNIX_FD
```

Header field 9 and `h`-as-index are additive. This can land in any minor, whenever a transport exists. That was worth establishing before the majors, since the opposite would have forced it into one.

**It is not buildable today.** Every option tested, not read about:

| option | result |
| --- | --- |
| Node built-in | No public API. [nodejs/node#53391](https://github.com/nodejs/node/issues/53391) **closed as not planned**; libuv supports it, Node never wired it up |
| `process.binding('pipe_wrap')` | **Aborts the process** for the fds d-bus carries |
| [`node-unix-socket`](https://github.com/xushengfeng/node-unix-socket) | N-API prebuilds for 7 platforms, installs in 719 ms, no compiler, loads on Node 26 — but SEQPACKET/DGRAM only → `Protocol not supported` against d-bus's SOCK_STREAM |
| [`usocket`](https://www.npmjs.com/package/usocket) | Right socket type, fd passing verified — but `nan` + `node-gyp`, compiles on install, 26 packages into the runtime tree |
| [`csocket`](https://www.npmjs.com/package/csocket) | Last published 2022, prebuilds target Node 4/6/8 |

### The near-miss worth recording

libuv's IPC-mode pipe *does* read ancillary data, and can be pointed at an existing socket with no addon:

```js
const { Pipe, constants } = process.binding('pipe_wrap');
const pipe = new Pipe(constants.IPC);
pipe.open(existingSocket._handle.fd);
```

But libuv classifies the incoming handle, and d-bus passes **arbitrary descriptors** — files, memfds, pipes, DRM buffers — not handles. Tested on macOS/Node 26 and Linux/Node 24, identically:

```
socket fd -> got a pendingHandle, read through it: "hello through the passed socket"
file fd   -> Assertion failed: (type) == (UV_UNKNOWN_HANDLE)   [Aborted]
```

That is a `CHECK` in Node's own C++ (`stream_wrap.cc:277`) — an uncatchable abort, not something to fall back from. The technique works for the case it was published for (handing TCP sockets between processes) and fails on precisely the case d-bus needs.

## What remains is a design note, not code

Shape the transport seam before 3.0/4.0 so a message can be `{ bytes, fds }` in both directions. That touches `connection.message()`, the cork/uncork batching from §2.7 (fds must stay with *their* message across a batched `_writev`), associating received fds with the message whose `UNIX_FDS` header claims them, and `opts.stream` — which should gain an *optional capability* (`stream.writeWithFds?`) rather than a new option, so a caller or a future optional dependency can supply it without the core depending on anything.

Defining that seam now, with nothing behind it, is what keeps UNIX_FD a minor when it becomes possible. Implementing it now would mean a compiler on every install — undoing what §1 spent three releases building and what #342 and #343 just strengthened.

## Testing

`test/unix-fd.js` — 6 tests: `h` still parses as a signature, both directions explain themselves, the message points at the Node issue rather than at us, containers report the same way, and genuinely unknown types keep the generic message.

573 unit and 120 integration tests pass.