### PR TITLE
docs: correct the ReturnLongjs deprecation status in ROADMAP 3.2

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -564,11 +564,19 @@ merely nonsense: `{}` is not a "Longjs object" of any signedness.
 
 One line of code, gated on a break. In order:
 
-1. **Deprecate louder (any minor).** `ReturnLongjs` is `DBUS_DEP0001` and
-   documentation-only today. It is a _runtime_ deprecation — the trigger is an
-   option the caller passes — so it can warn once per process via
-   `deprecate()`, which makes `node --throw-deprecation` locate the call site.
-   Nothing else in the plan needs this, so it can go whenever.
+1. ~~**Deprecate louder (any minor).**~~ **Already done, since 0.6** — this step
+   was written here in error. `ReturnLongjs` is a _runtime_ deprecation, not a
+   documentation-only one, and `index.js` has warned on it all along:
+
+   ```
+   (node:32313) [DBUS_DEP0001] DeprecationWarning: The 'ReturnLongjs' option is
+   deprecated. 64-bit values (x/t) become native BigInt in 2.0, ...
+   ```
+
+   Once per process, and `node --throw-deprecation` locates the call site.
+   Nothing to do here; the warning has been running for five releases, which is
+   as much notice as the option is going to get.
+
 2. **2.0: delete the option.** Remove `ReturnLongjs` from `DBusBuffer`, delete
    `readLong()`, drop `long` from `package.json`. **Runtime dependencies go to
    one** (`xml2js`). This is the whole cost now — the surrounding code stopped


### PR DESCRIPTION
The `long` removal plan added in #343 listed *"make `ReturnLongjs` warn at runtime"* as step 1, describing it as documentation-only today.

That is wrong. It has been a **runtime** deprecation since 0.6, and `index.js` warns on it:

```
$ node -e "dbus.createClient({ stream, direct: true, ReturnLongjs: true })"
(node:32313) [DBUS_DEP0001] DeprecationWarning: The 'ReturnLongjs' option is
deprecated. 64-bit values (x/t) become native BigInt in 2.0, which represents
the full range without a dependency. See .../deprecations.md#dbus_dep0001
```

`docs/deprecations.md` had it right all along — it labels DBUS_DEP0001 **Runtime** — so this was only ever wrong in the roadmap.

Step 1 is struck through rather than deleted, since "already done, for five releases" is the useful thing to record. The practical consequence: there is no further notice to give before 2.0 removes the option.