### PR TITLE
fix: accept '-' in property names, which 0.11.0 wrongly rejected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,11 @@ already correct.
   element of [A-Za-z_][A-Za-z0-9_]* with no dots, at most 255 bytes
   ```
 
-  Rename the member, or open an issue if you have a case where the old
-  behaviour was correct. See [docs/api.md#names](https://github.com/sidorares/dbus-native/blob/master/docs/api.md#names).
+  **Superseded for properties in 0.11.1**, which was the case where the old
+  behaviour was correct: property names are not member names, and `-` in one
+  works everywhere. `properties: { 'my-prop': 's' }` exports again. Method and
+  signal names are unchanged. See
+  [docs/api.md#names](https://github.com/sidorares/dbus-native/blob/master/docs/api.md#names).
 
 * **`lib/portforward.js` has been removed**
   ([#342](https://github.com/sidorares/dbus-native/pull/342)) — it was

--- a/README.md
+++ b/README.md
@@ -557,8 +557,9 @@ Object paths, interface names, error names and member names each have their own
 rules, and a name that breaks them produces a message no peer can route. Those
 you **send** are now checked — `exportInterface` (the path, the interface name
 and every member name), `sendSignal`, `sendError`, and any `o` value, which
-covers the path header of every outgoing message. Each throws an `Error` naming
-the rule that was broken:
+covers the path header of every outgoing message. Property names get a looser
+rule of their own, since the specification gives them none: a member name that
+may also contain `-`. Each throws an `Error` naming the rule that was broken:
 
 ```
 Invalid interface name for the interface descriptor: "MyIface" -- must be two or

--- a/docs/api.md
+++ b/docs/api.md
@@ -683,16 +683,31 @@ and they are easy to confuse:
 | member name    | one `[A-Za-z_][A-Za-z0-9_]*` element               | no dots, ≤ 255 bytes                    |
 | bus name       | `:1.23`, or an interface name that may contain `-` | ≤ 255 bytes                             |
 
+Property names are the odd one out: the specification does not give them a rule
+at all. A method or signal name is a header field the bus itself parses, but a
+property name is only ever a string _argument_ to `Properties.Get`/`Set`, and
+the introspection DTD declares the attribute as `CDATA`. So a property may
+additionally contain `-`, which is the GObject convention and which GDBus,
+sd-bus and python-dbus all read and write without complaint:
+
+| kind          | shape                                 | notes                              |
+| ------------- | ------------------------------------- | ---------------------------------- |
+| property name | one `[A-Za-z_][A-Za-z0-9_-]*` element | member name, plus `-`; ≤ 255 bytes |
+
+The rest of the member charset is kept so the name needs no escaping in the
+introspection XML, and so typos — a space, a dot, a stray quote — are still
+caught.
+
 These are enforced on what you **send**, because an invalid name produces a
 message no peer can route — and for a signal, which gets no reply, that fails
 silently:
 
-| where                   | checks                                          |
-| ----------------------- | ----------------------------------------------- |
-| `bus.exportInterface()` | the path, `iface.name`, and every member name   |
-| `bus.sendSignal()`      | the interface and member name                   |
-| `bus.sendError()`       | the error name                                  |
-| marshalling an `o`      | the object path, including every message's path |
+| where                   | checks                                                                                                      |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `bus.exportInterface()` | the path, `iface.name`, every method and signal name, and every property name against the looser rule above |
+| `bus.sendSignal()`      | the interface and member name                                                                               |
+| `bus.sendError()`       | the error name                                                                                              |
+| marshalling an `o`      | the object path, including every message's path                                                             |
 
 All of them throw an `Error` naming the rule that was broken. Incoming names
 are not checked — be strict in what you send, lenient in what you accept.
@@ -709,8 +724,8 @@ if (!isValidObjectPath(`/com/example/${deviceId}`)) {
 ```
 
 `isValidObjectPath`, `isValidInterfaceName`, `isValidErrorName`,
-`isValidMemberName` and `isValidBusName` all take any value and return a
-boolean.
+`isValidMemberName`, `isValidPropertyName` and `isValidBusName` all take any
+value and return a boolean.
 
 ---
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -105,6 +105,15 @@ export function isValidErrorName(name: unknown): boolean;
 /** A single `[A-Za-z_][A-Za-z0-9_]*` element with no dots, ≤ 255 bytes. */
 export function isValidMemberName(name: unknown): boolean;
 
+/**
+ * A member name that may also contain `-`.
+ *
+ * Property names are not one of the spec's name kinds -- a property name is a
+ * string argument to `Properties.Get`/`Set`, never a header field -- and `-` is
+ * the GObject convention, so the rule is deliberately looser than a member's.
+ */
+export function isValidPropertyName(name: unknown): boolean;
+
 /** A unique name like `:1.23`, or a well-known name (which may contain `-`). */
 export function isValidBusName(name: unknown): boolean;
 

--- a/index.js
+++ b/index.js
@@ -314,6 +314,7 @@ module.exports.isValidObjectPath = names.isValidObjectPath;
 module.exports.isValidInterfaceName = names.isValidInterfaceName;
 module.exports.isValidErrorName = names.isValidErrorName;
 module.exports.isValidMemberName = names.isValidMemberName;
+module.exports.isValidPropertyName = names.isValidPropertyName;
 module.exports.isValidBusName = names.isValidBusName;
 
 module.exports.createConnection = createConnection;

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -463,10 +463,17 @@ module.exports = function bus(conn, opts) {
     // to say so is where the mistake was made.
     assertValidName('object path', path);
     assertValidName('interface name', iface.name, 'the interface descriptor');
-    for (const kind of ['methods', 'signals', 'properties']) {
+    for (const kind of ['methods', 'signals']) {
       for (const member of Object.keys(iface[kind] || {})) {
         assertValidName('member name', member, `${kind}.${member}`);
       }
+    }
+    // Properties get their own, looser rule. A method or signal name is a
+    // header field the daemon parses, so an invalid one is unreachable; a
+    // property name is only ever a string argument to Properties.Get/Set, and
+    // '-' in one works everywhere. See isValidPropertyName.
+    for (const name of Object.keys(iface.properties || {})) {
+      assertValidName('property name', name, `properties.${name}`);
     }
 
     let entry;

--- a/lib/names.js
+++ b/lib/names.js
@@ -7,6 +7,9 @@
 // `.` and do not, member names allow neither, and bus names are interface names
 // that additionally allow `-` (and, when unique, a leading `:` and digits).
 //
+// Property names are a fifth kind, and are *not* in the spec at all -- see
+// isValidPropertyName.
+//
 // These are applied to what we *send*. Incoming names are left alone -- be
 // strict in what you emit and lenient in what you accept, which is also what
 // the spec allows a receiver to do.
@@ -18,6 +21,7 @@ const MAX_NAME_LENGTH = 255;
 // and cannot be made to backtrack.
 const INTERFACE_NAME = /^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+$/;
 const MEMBER_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const PROPERTY_NAME = /^[A-Za-z_][A-Za-z0-9_-]*$/;
 const WELL_KNOWN_BUS_NAME =
   /^[A-Za-z_-][A-Za-z0-9_-]*(?:\.[A-Za-z_-][A-Za-z0-9_-]*)+$/;
 // Unique names are ':' followed by elements that may start with a digit.
@@ -78,6 +82,36 @@ function isValidMemberName(name) {
   );
 }
 
+/**
+ * A property name: a member name that may also contain '-'.
+ *
+ * The spec's "Valid Names" section covers object paths, interface names, bus
+ * names, member names and error names. Property names are not among them, and
+ * nothing on the bus parses one: a property name travels as an ordinary string
+ * *argument* to Properties.Get/Set/GetAll, never in a message header, so the
+ * daemon never inspects it. The introspection DTD declares the attribute as
+ * `<!ATTLIST property name CDATA #REQUIRED>` -- any character data at all.
+ *
+ * GDBus, sd-bus and python-dbus all introspect, read and write a hyphenated
+ * property without complaint (busctl even lists it as `.my-prop`), and '-' is
+ * the GObject property convention, so services written against GObject reach
+ * for it naturally. 0.11.0 applied the member-name rules here and broke them;
+ * this is the narrowest rule that takes them back.
+ *
+ * The rest of the member charset is kept rather than allowing anything: a
+ * property name goes straight into the introspection XML, and restricting it
+ * to characters that need no escaping keeps that reply well-formed. It also
+ * still catches the typos worth catching -- a space, a dot, a quote.
+ */
+function isValidPropertyName(name) {
+  return (
+    typeof name === 'string' &&
+    name.length > 0 &&
+    name.length <= MAX_NAME_LENGTH &&
+    PROPERTY_NAME.test(name)
+  );
+}
+
 /** A bus name: well-known like an interface name, or a unique ':1.23'. */
 function isValidBusName(name) {
   if (typeof name !== 'string') return false;
@@ -97,6 +131,8 @@ const RULES = {
     'must be two or more dot-separated elements of [A-Za-z_][A-Za-z0-9_]*, at most 255 bytes',
   'member name':
     'must be a single element of [A-Za-z_][A-Za-z0-9_]* with no dots, at most 255 bytes',
+  'property name':
+    'must be a single element of [A-Za-z_][A-Za-z0-9_-]* with no dots, at most 255 bytes',
   'bus name':
     'must be a unique name like ":1.23", or two or more dot-separated elements, at most 255 bytes'
 };
@@ -106,6 +142,7 @@ const VALIDATORS = {
   'interface name': isValidInterfaceName,
   'error name': isValidErrorName,
   'member name': isValidMemberName,
+  'property name': isValidPropertyName,
   'bus name': isValidBusName
 };
 
@@ -129,6 +166,7 @@ module.exports = {
   isValidInterfaceName,
   isValidErrorName,
   isValidMemberName,
+  isValidPropertyName,
   isValidBusName,
   assertValidName
 };

--- a/test/integration/properties.js
+++ b/test/integration/properties.js
@@ -22,7 +22,11 @@ const ifaceDesc = {
     // the classic form: a bare signature, still meaning readwrite
     Greeting: 's',
     Locked: { type: 'b', access: 'read' },
-    Secret: { type: 's', access: 'write' }
+    Secret: { type: 's', access: 'write' },
+    // Property names are not member names -- '-' is the GObject convention and
+    // every other implementation reads one happily. 0.11.0 refused to export
+    // this at all.
+    'my-prop': 's'
   }
 };
 
@@ -50,7 +54,8 @@ describe('integration: properties', { timeout: 10000, skip: NO_BUS }, () => {
     impl = Object.assign(Object.create(EventEmitter.prototype), {
       Greeting: 'hello',
       Locked: true,
-      Secret: 'shh'
+      Secret: 'shh',
+      'my-prop': 'hyphen works'
     });
     EventEmitter.call(impl);
 
@@ -101,6 +106,44 @@ describe('integration: properties', { timeout: 10000, skip: NO_BUS }, () => {
     });
   });
 
+  // A property name is a string *argument* to Get/Set, never a header field,
+  // so the daemon never parses it and neither should we. Exercised end to end
+  // because that is the only way to show the whole path works: the export, the
+  // XML, the lookup by name, and the change signal.
+  describe("a property name containing '-'", () => {
+    it('appears in the introspection XML', async () => {
+      const xml = await clientBus.invoke({
+        destination: SERVICE,
+        path: OBJECT_PATH,
+        interface: 'org.freedesktop.DBus.Introspectable',
+        member: 'Introspect'
+      });
+      assert.match(
+        xml,
+        /<property name="my-prop" type="s" access="readwrite"\/>/
+      );
+    });
+
+    it('reads and writes', async () => {
+      const before = await call('Get', 'ss', [IFACE, 'my-prop']);
+      assert.strictEqual(before[1][0], 'hyphen works');
+      await call('Set', 'ssv', [IFACE, 'my-prop', ['s', 'and writes']]);
+      assert.strictEqual(impl['my-prop'], 'and writes');
+      const after = await call('Get', 'ss', [IFACE, 'my-prop']);
+      assert.strictEqual(after[1][0], 'and writes');
+    });
+
+    it('is carried by PropertiesChanged', async () => {
+      const change = nextChange();
+      await call('Set', 'ssv', [IFACE, 'my-prop', ['s', 'signalled']]);
+      assert.deepStrictEqual(await change, {
+        interfaceName: IFACE,
+        changed: { 'my-prop': 'signalled' },
+        invalidated: []
+      });
+    });
+  });
+
   describe('access control', () => {
     it('rejects writing a read-only property', async () => {
       await assert.rejects(
@@ -125,7 +168,7 @@ describe('integration: properties', { timeout: 10000, skip: NO_BUS }, () => {
     it('omits write-only properties from GetAll', async () => {
       const all = await call('GetAll', 's', [IFACE]);
       const names = all.map(([k]) => k);
-      assert.deepStrictEqual(names, ['Greeting', 'Locked']);
+      assert.deepStrictEqual(names, ['Greeting', 'Locked', 'my-prop']);
     });
 
     it('still reads and writes a readwrite property', async () => {

--- a/test/names.js
+++ b/test/names.js
@@ -12,6 +12,7 @@ const {
   isValidInterfaceName,
   isValidErrorName,
   isValidMemberName,
+  isValidPropertyName,
   isValidBusName,
   assertValidName
 } = require('../lib/names');
@@ -106,6 +107,41 @@ describe('names', () => {
     for (const [name, why] of invalid)
       it(`rejects ${JSON.stringify(name).slice(0, 20)} (${why})`, () =>
         assert.strictEqual(isValidMemberName(name), false));
+  });
+
+  describe('property names', () => {
+    // Looser than member names by exactly one character. The spec does not
+    // cover property names at all, and GObject-derived services use '-'.
+    for (const name of [
+      'a',
+      'Greeting',
+      '_private',
+      'Get2',
+      'my-prop',
+      'a-b-c'
+    ])
+      it(`accepts ${name}`, () =>
+        assert.strictEqual(isValidPropertyName(name), true));
+
+    const invalid = [
+      ['', 'empty'],
+      ['a.b', 'dots are not allowed'],
+      ['1a', 'starting with a digit'],
+      ['-a', 'starting with a hyphen'],
+      ['a b', 'space'],
+      ['a"b', 'a quote would break the introspection XML'],
+      ['a<b', 'a bracket would break the introspection XML'],
+      [42, 'not a string'],
+      ['b'.repeat(256), 'over 255 bytes']
+    ];
+    for (const [name, why] of invalid)
+      it(`rejects ${JSON.stringify(name).slice(0, 20)} (${why})`, () =>
+        assert.strictEqual(isValidPropertyName(name), false));
+
+    it('is exported from the package entry point', () => {
+      assert.strictEqual(dbus.isValidPropertyName('my-prop'), true);
+      assert.strictEqual(dbus.isValidMemberName('my-prop'), false);
+    });
   });
 
   describe('bus names', () => {
@@ -249,10 +285,16 @@ describe('exportInterface validates what it is given', () => {
       /Invalid member name for signals\.1Pinged/
     ],
     [
-      'a property name with a hyphen',
+      'a property name containing a dot',
       '/com/example/Obj',
-      withDesc({ properties: { 'my-prop': 's' } }),
-      /Invalid member name for properties\.my-prop/
+      withDesc({ properties: { 'a.b': 's' } }),
+      /Invalid property name for properties\.a\.b/
+    ],
+    [
+      'a property name containing a space',
+      '/com/example/Obj',
+      withDesc({ properties: { 'my prop': 's' } }),
+      /Invalid property name for properties\.my prop/
     ]
   ];
 
@@ -263,6 +305,30 @@ describe('exportInterface validates what it is given', () => {
       bus.connection.end();
     });
   }
+
+  // 0.11.0 applied the member-name rules to property names and broke this.
+  // GDBus, sd-bus and python-dbus all read and write a hyphenated property
+  // without complaint, and '-' is the GObject convention.
+  it("accepts a property name containing '-', unlike a member name", async () => {
+    const bus = await connectBus();
+    assert.doesNotThrow(() =>
+      bus.exportInterface(
+        {},
+        '/com/example/Obj',
+        withDesc({ properties: { 'my-prop': 's', 'a-b-c': { type: 'b' } } })
+      )
+    );
+    assert.throws(
+      () =>
+        bus.exportInterface(
+          {},
+          '/com/example/Obj',
+          withDesc({ methods: { 'my-method': ['', ''] } })
+        ),
+      /Invalid member name for methods\.my-method/
+    );
+    bus.connection.end();
+  });
 
   it('does not half-export an object it then rejects', async () => {
     const bus = await connectBus();


### PR DESCRIPTION
0.11.0's changelog said, of the new `exportInterface()` name validation:

> Rename the member, or open an issue if you have a case where the old behaviour was correct.

Here is that case. #333 applied the **member-name** rules to **property** names, and it should not have.

## Why this is wrong

A method or signal name is a header field the daemon itself parses, so an invalid one is genuinely unroutable. A property name is nothing of the sort — it is an ordinary string *argument* to `Properties.Get`/`Set`/`GetAll`, and no one on the bus ever inspects it. The spec's [Valid Names](https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names) section covers object paths, interface names, bus names, member names and error names. Property names are not in it. The introspection DTD is equally unconstrained:

```
<!ELEMENT property (annotation)*>
<!ATTLIST property name CDATA #REQUIRED>
```

## Checked rather than assumed

A `dbus-native` service exporting `my-prop`, probed from Debian bookworm (GLib 2.74, systemd 252, python-dbus 1.3.2):

| peer | result |
| --- | --- |
| `gdbus introspect` | `readwrite s my-prop = 'hyphen works'` |
| `busctl introspect` | `.my-prop  property  s  "hyphen works"  emits-change writable` |
| `gdbus … Properties.GetAll` | `{'my-prop': <'hyphen works'>, 'GoodProp': <'plain works'>}` |
| `busctl set-property` | `s "set by sd-bus"` |
| python-dbus `Get`/`Set` | `set by python` |

Every implementation reads and writes it happily; sd-bus even renders it as `.my-prop`. And `-` is the GObject property convention, so anyone bridging GObject properties reaches for it naturally — which is exactly who 0.11.0 breaks.

## The rule

Property names get their own validator: **a member name that may also contain `-`**.

Not "no validation at all", for two reasons:

- the name goes straight into the introspection XML, and keeping it to characters that need no escaping keeps that reply well-formed;
- the typos worth catching — a space, a dot, a stray quote — are still caught.

Method and signal names are untouched. A hyphenated one was unroutable long before #333 rejected it.

## Changes

- `lib/names.js` — `isValidPropertyName`, and a `'property name'` kind for `assertValidName`
- `lib/bus.js` — `exportInterface` validates properties against the looser rule
- `index.js` / `index.d.ts` — `isValidPropertyName` exported alongside the other five
- docs, and a forward-pointing note on the 0.11.0 changelog entry, which currently tells people to rename

## Tests

- `test/names.js` — the predicate, including that `-` is accepted for a property and still rejected for a member; the export-time case flipped from rejection to acceptance
- `test/integration/properties.js` — end to end against a real daemon: the introspection XML, `Get`/`Set`, `GetAll`, and `PropertiesChanged` carrying a hyphenated name

591 unit tests and the properties integration suite pass; lint, prettier and `tsc --noEmit` clean.