### PR TITLE
fix: escape the introspection XML, which a stray '&' made unparseable

### DIFF
--- a/lib/stdifaces.js
+++ b/lib/stdifaces.js
@@ -25,6 +25,26 @@ function getMachineId() {
 
 // TODO: use xmlbuilder
 
+// Escape a value going into an XML attribute.
+//
+// Not everything that lands in this document is validated. Interface, method,
+// signal and property names are checked at export, but *argument* names are
+// free-form -- the spec gives them no rule and the DTD declares them CDATA --
+// and a property's declared `type` string is passed through unparsed.
+//
+// The failure mode is worse than a mangled attribute: one stray '&' or '"'
+// makes the whole Introspect reply ill-formed, so a peer's parser rejects the
+// entire document and loses every interface on the object rather than the one
+// with the odd name. Escaping is also the right fix rather than more
+// validation, since there is nothing invalid about an arg named `a&b`.
+const XML_ESCAPES = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;'
+};
+const attr = value => String(value).replace(/[&<>"]/g, c => XML_ESCAPES[c]);
+
 const xmlHeader =
   '<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"\n' +
   '    "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">';
@@ -70,17 +90,17 @@ module.exports = function (msg, bus) {
         resultXml.push('</node>');
       } else {
         resultXml.push(
-          `<node>\n  <node name="${Object.keys(nodes)[0]}"/>\n  </node>`
+          `<node>\n  <node name="${attr(Object.keys(nodes)[0])}"/>\n  </node>`
         );
       }
     } else {
       resultXml.push('<node>');
       for (const name in nodes) {
         if (nodes[name] === null) {
-          resultXml.push(`  <node name="${name}" />`);
+          resultXml.push(`  <node name="${attr(name)}" />`);
         } else {
           const node = nodes[name];
-          resultXml.push(`  <node name="${name}" >`);
+          resultXml.push(`  <node name="${attr(name)}" >`);
           for (const ifaceName in node) {
             resultXml.push(interfaceToXML(node[ifaceName][0]));
           }
@@ -238,19 +258,20 @@ function interfaceToXML(iface) {
     const args = parseSignature(argsSignature);
     args.forEach((arg, num) => {
       const argName = argsNames ? argsNames[num] : direction + num;
-      const dirStr = direction === 'signal' ? '' : `" direction="${direction}`;
+      const dirStr =
+        direction === 'signal' ? '' : ` direction="${attr(direction)}"`;
       result.push(
-        `      <arg type="${dumpSignature([arg])}" name="${argName}${
-          dirStr
-        }" />`
+        `      <arg type="${attr(dumpSignature([arg]))}" name="${attr(
+          argName
+        )}"${dirStr} />`
       );
     });
   };
-  result.push(`  <interface name="${iface.name}">`);
+  result.push(`  <interface name="${attr(iface.name)}">`);
   if (iface.methods) {
     for (const methodName in iface.methods) {
       const method = iface.methods[methodName];
-      result.push(`    <method name="${methodName}">`);
+      result.push(`    <method name="${attr(methodName)}">`);
       dumpArgs(method[0], method[2], 'in');
       dumpArgs(method[1], method[3], 'out');
       result.push('    </method>');
@@ -259,7 +280,7 @@ function interfaceToXML(iface) {
   if (iface.signals) {
     for (const signalName in iface.signals) {
       const signal = iface.signals[signalName];
-      result.push(`    <signal name="${signalName}">`);
+      result.push(`    <signal name="${attr(signalName)}">`);
       dumpArgs(signal[0], signal.slice(1), 'signal');
       result.push('    </signal>');
     }
@@ -267,9 +288,9 @@ function interfaceToXML(iface) {
   for (const propertyName of properties.names(iface)) {
     const decl = properties.declaration(iface, propertyName);
     result.push(
-      `    <property name="${propertyName}" type="${decl.type}" access="${
-        decl.access
-      }"/>`
+      `    <property name="${attr(propertyName)}" type="${attr(
+        decl.type
+      )}" access="${attr(decl.access)}"/>`
     );
   }
   result.push('  </interface>');

--- a/test/introspect-xml.js
+++ b/test/introspect-xml.js
@@ -1,0 +1,153 @@
+// The Introspect reply has to be well-formed XML whatever the service put in
+// its interface descriptor.
+//
+// Names that go in the message header are validated at export (see names.js),
+// but argument names are not -- the spec gives them no rule and the DTD
+// declares the attribute CDATA -- and a property's declared `type` is passed
+// through unparsed. An unescaped '&' or '"' in either does not just spoil one
+// attribute: it makes the whole document ill-formed, so a peer's parser throws
+// and the caller loses every interface on the object.
+
+const { describe, it } = require('node:test');
+const assert = require('assert');
+const xml2js = require('xml2js');
+const stdifaces = require('../lib/stdifaces');
+const constants = require('../lib/constants');
+const { processXML } = require('../lib/introspect');
+
+// Drive the real Introspect handler and hand back the XML it would send.
+function introspect(path, iface) {
+  let reply;
+  const bus = {
+    serial: 1,
+    exportedObjects: { [path]: { [iface.name]: [iface, {}] } },
+    connection: {
+      message: msg => {
+        reply = msg;
+      }
+    }
+  };
+  const handled = stdifaces(
+    {
+      interface: 'org.freedesktop.DBus.Introspectable',
+      member: 'Introspect',
+      path,
+      serial: 7,
+      sender: ':1.2'
+    },
+    bus
+  );
+  assert.strictEqual(handled, 1, 'the handler claimed the message');
+  assert.strictEqual(reply.type, constants.messageType.methodReturn);
+  return reply.body[0];
+}
+
+const parse = xml =>
+  new Promise((resolve, reject) =>
+    new xml2js.Parser().parseString(xml, (err, result) =>
+      err ? reject(err) : resolve(result)
+    )
+  );
+
+const PATH = '/com/example/Obj';
+
+describe('introspection XML escaping', () => {
+  it('escapes an argument name that would otherwise break the document', async () => {
+    const xml = introspect(PATH, {
+      name: 'com.example.Iface',
+      methods: { Frob: ['s', 's', ['a&b'], ['out']] },
+      signals: {},
+      properties: {}
+    });
+
+    assert.match(xml, /name="a&amp;b"/);
+    assert.doesNotMatch(xml, /name="a&b"/);
+    // The real assertion: a peer can still read it.
+    const parsed = await parse(xml);
+    const [arg] = parsed.node.interface[0].method[0].arg;
+    assert.strictEqual(arg['$'].name, 'a&b', 'and gets the name back intact');
+  });
+
+  it('escapes a quote, which would otherwise inject an attribute', async () => {
+    const xml = introspect(PATH, {
+      name: 'com.example.Iface',
+      methods: { Frob: ['s', '', ['ok" /><evil name="pwned'], []] },
+      signals: {},
+      properties: {}
+    });
+
+    assert.doesNotMatch(xml, /<evil/);
+    const parsed = await parse(xml);
+    const [arg] = parsed.node.interface[0].method[0].arg;
+    assert.strictEqual(arg['$'].name, 'ok" /><evil name="pwned');
+  });
+
+  it('escapes a declared property type, which is never parsed', async () => {
+    const xml = introspect(PATH, {
+      name: 'com.example.Iface',
+      methods: {},
+      signals: {},
+      properties: { Broken: { type: 's" access="readwrite', access: 'read' } }
+    });
+
+    const parsed = await parse(xml);
+    const [prop] = parsed.node.interface[0].property;
+    assert.strictEqual(prop['$'].type, 's" access="readwrite');
+    assert.strictEqual(prop['$'].access, 'read', 'the real access survives');
+  });
+
+  it('escapes a signal argument name', async () => {
+    const xml = introspect(PATH, {
+      name: 'com.example.Iface',
+      methods: {},
+      signals: { Pinged: ['s', 'who <& why'] },
+      properties: {}
+    });
+
+    const parsed = await parse(xml);
+    const [arg] = parsed.node.interface[0].signal[0].arg;
+    assert.strictEqual(arg['$'].name, 'who <& why');
+    assert.strictEqual(arg['$'].direction, undefined, 'signals have none');
+  });
+
+  it('leaves ordinary names byte for byte as they were', async () => {
+    const xml = introspect(PATH, {
+      name: 'com.example.Iface',
+      methods: { Frob: ['s', 's', ['input'], ['output']] },
+      signals: { Pinged: ['s', 'who'] },
+      properties: { Greeting: 's', 'my-prop': { type: 'b', access: 'read' } }
+    });
+
+    assert.match(
+      xml,
+      /<arg type="s" name="input" direction="in" \/>\n {6}<arg type="s" name="output" direction="out" \/>/
+    );
+    assert.match(xml, /<arg type="s" name="who" \/>/);
+    assert.match(
+      xml,
+      /<property name="Greeting" type="s" access="readwrite"\/>/
+    );
+    assert.match(xml, /<property name="my-prop" type="b" access="read"\/>/);
+    await parse(xml); // and it is still well-formed
+  });
+
+  it('survives the round trip into a client proxy', async () => {
+    const xml = introspect(PATH, {
+      name: 'com.example.Iface',
+      methods: { Frob: ['s', 's', ['a&b'], ['c<d']] },
+      signals: {},
+      properties: {}
+    });
+
+    // processXML is what getInterface() feeds the reply to. Before the fix it
+    // called back with an xml2js parse error and no interface at all.
+    const obj = { name: PATH, service: { name: 'com.example', bus: {} } };
+    const proxy = await new Promise((resolve, reject) =>
+      processXML(null, xml, obj, (err, result) =>
+        err ? reject(err) : resolve(result)
+      )
+    );
+    assert.ok(proxy['com.example.Iface'], 'the interface came back');
+    assert.strictEqual(typeof proxy['com.example.Iface'].Frob, 'function');
+  });
+});


### PR DESCRIPTION
`interfaceToXML` builds attribute values by string interpolation, and not everything that reaches it is validated.

Interface, method, signal and property names are checked at export by #333. **Argument names are not** — the spec gives them no rule and the DTD declares the attribute `CDATA` — and a property's declared `type` is passed through without ever being parsed. Either can contain `&`, `<` or `"`.

## Why it matters beyond one attribute

A single unescaped character makes the **whole document** ill-formed, so a peer's parser rejects the entire `Introspect` reply. The caller does not lose the interface with the odd name; it loses every interface on the object. For this library's own client that means `getInterface()` fails with an xml2js parse error.

With a quote it is worse than malformed. On master, an argument named `ok" /><evil name="pwned` produces:

```xml
<arg type="s" name="ok" /><evil name="pwned" direction="in" />
```

That parses perfectly well — as an element the service never declared.

## The fix

An `attr()` helper escaping `&`, `<`, `>` and `"`, applied to every interpolated attribute value: node names, interface names, method and signal names, property names, property types, and argument names and types.

Escaping rather than more validation, deliberately: there is nothing invalid about an argument named `a&b`, and it is only a problem because we write XML by hand. Names that *are* validated get escaped anyway — it costs nothing and stops this coming back if a rule is ever relaxed (as #346 relaxes one).

## Tests

New `test/introspect-xml.js`, driving the real `Introspect` handler and parsing the reply with the same xml2js the client uses:

- an `&` in an arg name — escaped, and the name comes back intact
- a quote — no injected element, value preserved
- a property `type` that tries to inject an `access` attribute — the real `access` survives
- a signal arg name, which takes a different code path (no `direction`)
- **ordinary names come out byte for byte as before** — the no-regression test
- the whole thing round-trips through `processXML`, which is what `getInterface()` uses

5 of the 6 fail on master; the byte-for-byte one passes there, as it should.

579 unit tests pass; lint, prettier and `tsc --noEmit` clean.