### PR TITLE
chore: drop node-static from the dbusproxy example

### DIFF
--- a/examples/dbusproxy/README.md
+++ b/examples/dbusproxy/README.md
@@ -1,6 +1,24 @@
-Dbus proxy / web client example
-========================
+# D-Bus proxy / web client example
 
-TODO: add docs
+A bridge between a browser and the session bus. `server.js` accepts
+[SockJS](https://github.com/sockjs/sockjs-node) connections, parses each
+incoming frame as a JSON D-Bus message and hands it straight to
+`connection.message()`; every message coming back off the bus is stringified
+and written to the socket. `index.html` is a page that opens one of those
+sockets, subscribes to all traffic with three `AddMatch` calls, and renders any
+`a(ssssbbusbbi)` reply it sees as an image — that signature is the old
+`indicator-sound` menu, hence the `<img>`.
 
-Code is based on sockjs/echo example
+Based on the sockjs `echo` example.
+
+```bash
+cd examples/dbusproxy && npm install && node server.js
+```
+
+Then open <http://127.0.0.1:9999/>.
+
+> **This is a demonstration, not something to deploy.** Anything that connects
+> to the port gets unauthenticated access to your session bus, which is to say
+> to your desktop: notifications, secrets prompts, systemd, whatever else is on
+> there. It listens on the loopback interface for that reason. Do not put it on
+> a routable address, and do not put it behind a reverse proxy.

--- a/examples/dbusproxy/index.html
+++ b/examples/dbusproxy/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
     <style>
       .box {

--- a/examples/dbusproxy/package.json
+++ b/examples/dbusproxy/package.json
@@ -1,8 +1,8 @@
 {
   "name": "dbus-proxy",
   "version": "0.0.0-unreleasable",
+  "private": true,
   "dependencies": {
-    "node-static": "0.5.9",
-    "sockjs": "*"
+    "sockjs": "^0.3.24"
   }
 }

--- a/examples/dbusproxy/server.js
+++ b/examples/dbusproxy/server.js
@@ -1,6 +1,7 @@
 const http = require('http');
+const fs = require('fs');
+const path = require('path');
 const sockjs = require('sockjs');
-const node_static = require('node-static');
 const dbus = require('../../index');
 
 // 1. Echo sockjs server
@@ -33,18 +34,41 @@ sockjs_echo.on('connection', conn => {
 });
 
 // 2. Static files server
-const static_directory = new node_static.Server(__dirname);
+//
+// One page, served from a fixed path. This used to be `node-static`, which is
+// unmaintained and carries an unfixed directory-traversal advisory
+// (CVE-2023-26111) -- for a single file that is a dependency, and an attack
+// surface, in exchange for nothing. Nothing here is built from the request, so
+// there is no path to traverse.
+const indexHtml = path.join(__dirname, 'index.html');
+const serveIndex = (req, res) => {
+  if (req.url !== '/' && req.url.split('?')[0] !== '/index.html') {
+    res.writeHead(404, { 'content-type': 'text/plain' });
+    return res.end('not found\n');
+  }
+  fs.readFile(indexHtml, (err, body) => {
+    if (err) {
+      res.writeHead(500, { 'content-type': 'text/plain' });
+      return res.end(`${err.message}\n`);
+    }
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    res.end(body);
+  });
+};
 
 // 3. Usual http stuff
 const server = http.createServer();
-server.addListener('request', (req, res) => {
-  static_directory.serve(req, res);
-});
+server.addListener('request', serveIndex);
 server.addListener('upgrade', (req, res) => {
   res.end();
 });
 
 sockjs_echo.installHandlers(server, { prefix: '/echo' });
 
-console.log(' [*] Listening on 0.0.0.0:9999');
-server.listen(9999, '0.0.0.0');
+// Bound to the loopback interface on purpose. Every message arriving on the
+// socket is forwarded to the session bus unauthenticated, so anyone who can
+// reach this port can do anything the user can: read their keyring prompts,
+// drive their desktop, call systemd. It used to listen on 0.0.0.0, which
+// offered all of that to the local network.
+console.log(' [*] Listening on 127.0.0.1:9999');
+server.listen(9999, '127.0.0.1');


### PR DESCRIPTION
Both open Dependabot alerts on `master` are the same package in the same place:

| severity | advisory | package | manifest |
| --- | --- | --- | --- |
| high | [GHSA-5g97-whc9-8g7j](https://github.com/advisories/GHSA-5g97-whc9-8g7j) (CVE-2023-26111, directory traversal) | `node-static` | `examples/dbusproxy/package.json` |
| medium | [GHSA-8r4g-cg4m-x23c](https://github.com/advisories/GHSA-8r4g-cg4m-x23c) | `node-static` | `examples/dbusproxy/package.json` |

Neither has a patched version — the package is unmaintained — so they cannot be resolved by bumping. They do not reach anyone installing `dbus-native` (`files` does not ship `examples/`), but they are real for anyone who runs the example, which hands `node-static` `__dirname` and lets it serve whatever it is asked for.

The example serves **one page**. That is twelve lines of `node:http`, and since nothing in the path is built from the request there is nothing to traverse.

## Two other things in the same file

Both make the example unsafe or unrunnable rather than merely dated, so they belong with this change:

- **It listened on `0.0.0.0`.** Every frame arriving on that socket is parsed as a D-Bus message and passed straight to `connection.message()` with no authentication, so this offered the user's entire session bus — secrets prompts, systemd, notifications — to anyone on the local network. Now `127.0.0.1`, with a comment saying why and a warning in the README.
- The jQuery `<script>` was `http://`, and `sockjs` was pinned to `"*"` (now `^0.3.24`).

The README has said "TODO: add docs" since 2012. It now says what the example does, how to run it, and what not to do with it.

## Verified

Against a real session bus:

```
 [*] Listening on 127.0.0.1:9999
GET /                      200 text/html; charset=utf-8  4162
GET /index.html?x=1        200
GET /../../package.json    404
GET /../../../etc/passwd   404
GET /server.js             404
GET /echo/info             200   <- sockjs still bound
```

`npm audit` in the example is left with one transitive moderate — `uuid`, via sockjs, for a bounds check in the v3/v5/v6 code paths that sockjs does not use. npm's proposed "fix" is downgrading sockjs to 0.3.16, which is worse; leaving it.

## Alternative

The other option is deleting the example: it is undocumented, sockjs is largely superseded by plain WebSocket, and a browser-to-session-bus bridge is an awkward thing to publish at all. I have kept it because the idea is a genuinely interesting demo and repairing it is smaller and more reversible than removing it — happy to delete instead if you would rather.