### PR TITLE
fix: return the object that was asked for, and all of its children

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -238,11 +238,28 @@ path.
 
 | member              |                                                              |
 | ------------------- | ------------------------------------------------------------ |
-| `obj.name`          | the object path                                              |
+| `obj.name`          | the object path — always the one you asked for               |
 | `obj.service`       | the owning `DBusService`                                     |
 | `obj.proxy`         | every introspected interface, by name                        |
-| `obj.nodes`         | child node paths from the introspection data                 |
+| `obj.nodes`         | the names of the child objects, relative to this path        |
 | `obj.as(ifaceName)` | one interface — **throws `UnknownInterfaceError`** if absent |
+
+A path that groups other objects and implements nothing itself — a container,
+like `/org/freedesktop/UPower/devices` — comes back with an empty `proxy` and
+its children in `nodes`. Walk down from there:
+
+```js
+const container = await service.getObject('/com/example/Devices');
+for (const child of container.nodes) {
+  const device = await service.getObject(`/com/example/Devices/${child}`);
+}
+```
+
+> Before 0.12 such a path was silently replaced by its **first child**: you got
+> a proxy for `/com/example/Devices/<first>` while believing you had the
+> container, calls went to an object you never named, and the other children
+> were dropped. Asking a container for an interface now throws
+> `UnknownInterfaceError`, and the message names the children.
 
 ### DBusInterface
 

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -543,7 +543,8 @@ module.exports = function bus(conn, opts) {
           ifaceName,
           this.name,
           this.service && this.service.name,
-          Object.keys(this.proxy)
+          Object.keys(this.proxy),
+          this.nodes
         );
       return iface;
     };

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -137,13 +137,23 @@ class ConnectionClosedError extends DBusError {
  * "cannot read property of undefined" somewhere unrelated. That is issue #208.
  */
 class UnknownInterfaceError extends DBusError {
-  constructor(interfaceName, path, service, available) {
+  constructor(interfaceName, path, service, available, children) {
     const known =
       available && available.length
         ? ` Available: ${available.join(', ')}.`
         : '';
+    // A path with no interfaces but with children is a container, and asking
+    // it for an interface is almost always a path that stopped one level
+    // short. Saying which children it has turns "no such interface" into the
+    // next thing to try. Until 0.12 the library guessed on the caller's
+    // behalf and introspected the first child instead, which meant calls went
+    // silently to an object nobody asked for.
+    const below =
+      !known && children && children.length
+        ? ` It has no interfaces of its own, but has child objects: ${children.join(', ')}. Did you mean one of those?`
+        : '';
     super(
-      `No such interface "${interfaceName}" at object path "${path}" on "${service}".${known}`,
+      `No such interface "${interfaceName}" at object path "${path}" on "${service}".${known}${below}`,
       'org.freedesktop.DBus.Error.UnknownInterface',
       undefined,
       undefined

--- a/lib/introspect.js
+++ b/lib/introspect.js
@@ -23,28 +23,53 @@ module.exports.processXML = function (err, xml, obj, callback) {
   const parser = new xml2js.Parser();
   parser.parseString(xml, (err, result) => {
     if (err) return callback(err);
-    if (!result.node) throw new Error('No root XML node');
-    result = result.node; // unwrap the root node
-    // If no interface, try first sub node?
-    if (!result.interface) {
-      if (result.node && result.node.length > 0 && result.node[0]['$']) {
-        const subObj = Object.assign(obj, {});
-        if (subObj.name.slice(-1) !== '/') subObj.name += '/';
-        subObj.name += result.node[0]['$'].name;
-        return module.exports.introspectBus(subObj, callback);
-      }
-      return callback(new Error('No such interface found'));
+    // A peer that answers Introspect with something other than a <node>
+    // document is misbehaving, but throwing here would go straight past the
+    // callback and out of the socket read handler as an uncaught exception.
+    //
+    // Tested for the key rather than a truthy value: xml2js renders an empty
+    // `<node/>` as `{ node: '' }`, and that is a well-formed answer meaning
+    // "nothing here" -- this library's own server sends exactly that for a
+    // path it has not exported. Checking truthiness reported it as a document
+    // with no root node, which is both wrong and unhelpful.
+    if (!Object.hasOwn(result, 'node')) {
+      return callback(new Error('No root XML node'));
     }
-    const proxy = {};
-    const nodes = [];
-    let ifaceName, method, property, iface, arg, signature, currentIface;
-    const ifaces = result['interface'];
-    const xmlnodes = result['node'] || [];
+    result = result.node || {}; // unwrap the root node
 
-    for (let n = 1; n < xmlnodes.length; ++n) {
-      // Start at 1 because we want to skip the root node
-      nodes.push(xmlnodes[n]['$']['name']);
-    }
+    // The child object paths.
+    //
+    // This loop used to start at 1, on the reasoning that the root node had to
+    // be skipped -- but `result` is *already* the unwrapped root, so
+    // `result.node` is the list of children and element 0 is one of them.
+    // `obj.nodes` therefore always dropped whichever child came first.
+    const xmlnodes = result['node'] || [];
+    const nodes = xmlnodes
+      .map(node => node['$'] && node['$'].name)
+      .filter(name => name !== undefined);
+
+    const ifaces = result['interface'];
+
+    // A path with no interfaces on it is a perfectly ordinary thing: it is how
+    // a service groups its objects, and /org/freedesktop/UPower/devices is
+    // nothing but a container.
+    //
+    // This used to re-introspect the *first* child and hand that back as
+    // though it were the object asked for -- so getObject('/com/example')
+    // silently returned a proxy for '/com/example/Alpha', calls went to the
+    // wrong object, every other child was discarded, and `obj.name` was
+    // rewritten in place (`Object.assign(obj, {})` assigns nothing onto obj
+    // and returns obj, so it mutated the caller's object rather than copying
+    // it). The child list was lost too, which is the one thing a caller
+    // introspecting a container actually wants.
+    //
+    // So: report the object that was asked for. No interfaces, and the
+    // children in `nodes`. `obj.as()` then throws UnknownInterfaceError, which
+    // names the children so the mistake is obvious.
+    if (!ifaces) return callback(null, {}, nodes);
+
+    const proxy = {};
+    let ifaceName, method, property, iface, arg, signature, currentIface;
 
     for (let i = 0; i < ifaces.length; ++i) {
       iface = ifaces[i];

--- a/test/integration/object-paths.js
+++ b/test/integration/object-paths.js
@@ -1,0 +1,106 @@
+// Walking a service's object tree, against a real bus.
+//
+// A container path -- one that groups child objects and implements nothing
+// itself -- used to come back as its own first child, so calls went to an
+// object the caller never named and the other children vanished.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const dbus = require('../../index');
+
+const NO_BUS =
+  !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
+
+const SERVICE = 'com.github.sidorares.dbusnative.Paths';
+const CONTAINER = '/com/github/sidorares/dbusnative/Paths';
+const ALPHA = `${CONTAINER}/Alpha`;
+const BETA = `${CONTAINER}/Beta`;
+
+const descriptor = name => ({
+  name,
+  methods: { WhoAmI: ['', 's'] },
+  signals: {},
+  properties: {}
+});
+
+const impl = which => {
+  const obj = Object.assign(Object.create(EventEmitter.prototype), {
+    WhoAmI: () => which
+  });
+  EventEmitter.call(obj);
+  return obj;
+};
+
+describe('integration: object paths', { timeout: 10000, skip: NO_BUS }, () => {
+  let serviceBus, clientBus, service;
+
+  before(async () => {
+    serviceBus = dbus.sessionBus();
+    clientBus = dbus.sessionBus();
+    await Promise.all([serviceBus.getId(), clientBus.getId()]);
+    await new Promise((resolve, reject) =>
+      serviceBus.requestName(SERVICE, 0, err => (err ? reject(err) : resolve()))
+    );
+    // Nothing is exported at CONTAINER itself; it exists only as the parent.
+    serviceBus.exportInterface(
+      impl('alpha'),
+      ALPHA,
+      descriptor('com.example.Alpha')
+    );
+    serviceBus.exportInterface(
+      impl('beta'),
+      BETA,
+      descriptor('com.example.Beta')
+    );
+    service = clientBus.getService(SERVICE);
+  });
+
+  after(() => {
+    for (const bus of [serviceBus, clientBus]) if (bus) bus.connection.end();
+  });
+
+  const getObject = path =>
+    new Promise((resolve, reject) =>
+      service.getObject(path, (err, obj) => (err ? reject(err) : resolve(obj)))
+    );
+
+  it('returns the container itself, not its first child', async () => {
+    const obj = await getObject(CONTAINER);
+    assert.strictEqual(obj.name, CONTAINER, 'the path that was asked for');
+    assert.deepStrictEqual(Object.keys(obj.proxy), []);
+  });
+
+  it('lists every child, including the first', async () => {
+    const obj = await getObject(CONTAINER);
+    assert.deepStrictEqual(obj.nodes.sort(), ['Alpha', 'Beta']);
+  });
+
+  it('says which children there are when asked for an interface', async () => {
+    const obj = await getObject(CONTAINER);
+    assert.throws(() => obj.as('com.example.Alpha'), {
+      name: 'UnknownInterfaceError',
+      message: /child objects: (Alpha, Beta|Beta, Alpha)/
+    });
+  });
+
+  it('still talks to a child that was named properly', async () => {
+    const obj = await getObject(ALPHA);
+    assert.strictEqual(obj.name, ALPHA);
+    const who = await new Promise((resolve, reject) =>
+      obj
+        .as('com.example.Alpha')
+        .WhoAmI((err, value) => (err ? reject(err) : resolve(value)))
+    );
+    assert.strictEqual(who, 'alpha');
+  });
+
+  it('reports an unexported path as an object with nothing on it', async () => {
+    // The server answers `<node/>` for a path it does not know, which is a
+    // well-formed "nothing here" -- it used to be reported as a document with
+    // no root node.
+    const obj = await getObject(`${CONTAINER}/Nope`);
+    assert.deepStrictEqual(Object.keys(obj.proxy), []);
+    assert.deepStrictEqual(obj.nodes, []);
+  });
+});

--- a/test/introspect-paths.js
+++ b/test/introspect-paths.js
@@ -1,0 +1,135 @@
+// Which object does an introspected proxy actually point at, and which
+// children does it report?
+//
+// Both used to be wrong in the same function. A path with no interfaces was
+// silently replaced by its first child, and the child list dropped whichever
+// child came first.
+
+const { describe, it } = require('node:test');
+const assert = require('assert');
+const introspect = require('../lib/introspect');
+const { UnknownInterfaceError } = require('../lib/errors');
+
+const PATH = '/com/example/Obj';
+
+const parse = (xml, obj) =>
+  new Promise((resolve, reject) =>
+    introspect.processXML(
+      null,
+      xml,
+      obj || { name: PATH, service: { name: 'com.example', bus: {} } },
+      (err, proxy, nodes) => (err ? reject(err) : resolve({ proxy, nodes }))
+    )
+  );
+
+const withIface = `
+  <node>
+    <interface name="com.example.Iface"><method name="Ping"/></interface>
+    <node name="Alpha"/>
+    <node name="Beta"/>
+    <node name="Gamma"/>
+  </node>`;
+
+describe('introspection: the child node list', () => {
+  it('includes the first child, which used to be dropped', async () => {
+    const { nodes } = await parse(withIface);
+    assert.deepStrictEqual(nodes, ['Alpha', 'Beta', 'Gamma']);
+  });
+
+  it('reports a lone child rather than nothing at all', async () => {
+    // The same answer lib/codegen.js has always given for this document.
+    const { nodes } = await parse(
+      '<node><interface name="com.example.I"/><node name="child"/></node>'
+    );
+    assert.deepStrictEqual(nodes, ['child']);
+  });
+
+  it('is empty for an object with no children', async () => {
+    const { nodes } = await parse(
+      '<node><interface name="com.example.I"/></node>'
+    );
+    assert.deepStrictEqual(nodes, []);
+  });
+
+  it('ignores a <node> with no name attribute', async () => {
+    const { nodes } = await parse(
+      '<node><interface name="com.example.I"/><node/><node name="real"/></node>'
+    );
+    assert.deepStrictEqual(nodes, ['real']);
+  });
+});
+
+describe('introspection: a path with no interfaces', () => {
+  const container = '<node><node name="Alpha"/><node name="Beta"/></node>';
+
+  it('describes the object asked for, not its first child', async () => {
+    const { proxy, nodes } = await parse(container);
+    assert.deepStrictEqual(Object.keys(proxy), []);
+    assert.deepStrictEqual(nodes, ['Alpha', 'Beta'], 'every child, in order');
+  });
+
+  it('leaves the caller object alone', async () => {
+    // `Object.assign(obj, {})` assigns nothing onto obj and returns obj, so
+    // the redirect rewrote the caller's own object path in place.
+    const obj = { name: PATH, service: { name: 'com.example', bus: {} } };
+    await parse(container, obj);
+    assert.strictEqual(obj.name, PATH);
+  });
+
+  it('succeeds even with no children at all', async () => {
+    const { proxy, nodes } = await parse('<node/>');
+    assert.deepStrictEqual(Object.keys(proxy), []);
+    assert.deepStrictEqual(nodes, []);
+  });
+
+  it('still builds a proxy when interfaces are present', async () => {
+    const { proxy } = await parse(withIface);
+    assert.ok(proxy['com.example.Iface']);
+    assert.strictEqual(typeof proxy['com.example.Iface'].Ping, 'function');
+  });
+});
+
+describe('introspection: a reply that is not a node document', () => {
+  it('reaches the callback instead of throwing past it', async () => {
+    // This used to `throw` from inside the xml2js callback, which runs under
+    // the socket read handler -- so it surfaced as an uncaught exception
+    // rather than as an error for the caller.
+    await assert.rejects(() => parse('<nope/>'), /No root XML node/);
+  });
+
+  it('reports malformed XML as an error too', async () => {
+    await assert.rejects(() => parse('<node><unclosed></node>'));
+  });
+});
+
+describe('UnknownInterfaceError names the children', () => {
+  it('points at the child objects when there are no interfaces', () => {
+    const err = new UnknownInterfaceError(
+      'com.example.Alpha',
+      PATH,
+      'com.example',
+      [],
+      ['Alpha', 'Beta']
+    );
+    assert.match(err.message, /no interfaces of its own/);
+    assert.match(err.message, /child objects: Alpha, Beta/);
+  });
+
+  it('prefers listing the interfaces that are there', () => {
+    const err = new UnknownInterfaceError(
+      'com.example.Nope',
+      PATH,
+      'com.example',
+      ['com.example.Real'],
+      ['Alpha']
+    );
+    assert.match(err.message, /Available: com\.example\.Real\./);
+    assert.doesNotMatch(err.message, /child objects/);
+  });
+
+  it('says neither when there is nothing to say', () => {
+    const err = new UnknownInterfaceError('a.b', PATH, 'com.example', [], []);
+    assert.match(err.message, /No such interface "a\.b"/);
+    assert.doesNotMatch(err.message, /child objects|Available/);
+  });
+});


### PR DESCRIPTION
Three faults in `processXML`, all answering the same question badly: **which object am I actually looking at?**

## 1. A path with no interfaces was silently replaced by its first child

`lib/introspect.js` did this:

```js
// If no interface, try first sub node?
if (!result.interface) {
  if (result.node && result.node.length > 0 && result.node[0]['$']) {
    const subObj = Object.assign(obj, {});
    subObj.name += result.node[0]['$'].name;
    return module.exports.introspectBus(subObj, callback);
```

Against a real bus, a container with children `Alpha` and `Beta`:

```
asked for      : /com/example/Redirect
obj.name is    : /com/example/Redirect/Alpha
interfaces     : [ 'com.example.Alpha', ... ]
WhoAmI() says  : alpha
```

So `getObject(container)` hands back a proxy for a **different object**, method calls go somewhere the caller never named, and `Beta` is gone. `obj.nodes` is populated from the *child's* introspection, so the child list — the one thing you introspect a container for — is destroyed.

`Object.assign(obj, {})` is also not the copy it was meant to be: it assigns nothing onto `obj` and returns `obj`, so the caller's own object is mutated. That is observable from outside the library.

Container paths are entirely ordinary; `/org/freedesktop/UPower/devices` is one.

**Now:** the object that was asked for, an empty `proxy`, and the children in `nodes`. `obj.as()` throws `UnknownInterfaceError`, and the message names the children so a path that stopped one level short says so rather than guessing:

```
No such interface "com.example.Alpha" at object path "/com/example/Redirect"
on "com.example.Redirect". It has no interfaces of its own, but has child
objects: Alpha, Beta. Did you mean one of those?
```

## 2. `nodes` always dropped the first child

```js
for (let n = 1; n < xmlnodes.length; ++n) {
  // Start at 1 because we want to skip the root node
```

`result` is *already* the unwrapped root, so `result.node` is the child list and element 0 is a child. Three children in, two out:

```
children in the XML : [ 'Alpha', 'Beta', 'Gamma' ]
nodes returned      : [ 'Beta', 'Gamma' ]
```

`lib/codegen.js` has always parsed the same document correctly (`test/codegen.js` asserts `['child']` for the single-child case), so there is an in-repo answer to compare against.

## 3. An empty `<node/>` was reported as "No root XML node"

xml2js renders `<node/>` as `{ node: '' }`, and a truthiness check cannot tell that from a document with no root element. It is a well-formed *"nothing here"* — **this library's own server sends exactly that** for a path it has not exported. Testing for the key instead fixes it.

Also, that branch used `throw` from inside the xml2js callback, which runs under the socket read handler — so a misbehaving peer produced an uncaught exception rather than an error for the caller.

## Behaviour change

Anyone relying on the redirect gets an error where they used to get a working (wrong) proxy. The error names the children, so the fix is to append one path element. This is the kind of thing that should be loud rather than quiet, and `obj.name` is documented as "the object path".

## Tests

- `test/introspect-paths.js` — the node list including the first child, the container case, that the caller's object is not mutated, `<node/>` vs `<nope/>`, and the enriched error
- `test/integration/object-paths.js` — end to end against a real daemon: container identity, both children listed, the error naming them, a properly-named child still working, and an unexported path

6 of 13 unit tests and 4 of 5 integration tests fail on master. 610 unit and 128 integration tests pass here; lint, prettier and `tsc --noEmit` clean.

## Related

[#140](https://github.com/sidorares/dbus-native/pull/140) (2017) is the mirror image of this, on the **server** side: `lib/stdifaces.js` looks up `bus.exportedObjects[msg.path]` inside the loop rather than `[path]`, so an exported path never advertises its children at all. That is a real bug — a service built with this library serves a tree that cannot be walked — but it is a separate direction and a separate file, so it is not in this PR.