### PR TITLE
fix: advertise child objects on a path that is itself exported

### DIFF
--- a/lib/stdifaces.js
+++ b/lib/stdifaces.js
@@ -57,56 +57,48 @@ module.exports = function (msg, bus) {
     if (msg.path === '/') msg.path = '';
 
     const resultXml = [xmlHeader];
-    const nodes = {};
+
+    // The reply describes one object: the interfaces exported at the requested
+    // path, and a <node name="..."/> for each immediate child of it. Those are
+    // two separate things, and the object may well be absent -- a path that
+    // only groups other objects is how a service organises its tree.
+    //
+    // They used to be conflated in one `nodes` map, and the lookup inside the
+    // loop read `bus.exportedObjects[msg.path]` rather than `[path]`. That
+    // value does not vary with the loop, so as soon as the requested path was
+    // itself exported every iteration took the same branch and no child was
+    // ever collected: a service built with this library served a tree that
+    // could not be walked. This is #140.
+    const exported = bus.exportedObjects[msg.path];
+
+    // `msg.path` has had a lone '/' turned into '' above, so this is '/' at the
+    // root and '/com/example/' below it. Matching on a prefix that ends in the
+    // separator is also what keeps '/com/example/Treeish' from counting as a
+    // child of '/com/example/Tree'.
+    const prefix = `${msg.path}/`;
+    const children = new Set();
     // TODO: this is not very efficient for large number of exported objects
     // need to build objects tree as they are exported and walk this tree on introspect request
     for (const path in bus.exportedObjects) {
-      if (path.indexOf(msg.path) === 0) {
-        // objects path starts with requested
-        const introspectableObj = bus.exportedObjects[msg.path];
-        if (introspectableObj) {
-          nodes[msg.path] = introspectableObj;
-        } else {
-          if (path[msg.path.length] !== '/') continue;
-          const localPath = path.substr(msg.path.length);
-          const pathParts = localPath.split('/');
-          const localName = pathParts[1];
-          nodes[localName] = null;
-        }
-      }
+      if (!path.startsWith(prefix)) continue;
+      // Only the next element: a grandchild contributes its parent's name, and
+      // contributes it once.
+      const name = path.slice(prefix.length).split('/')[0];
+      if (name) children.add(name);
     }
 
-    const length = Object.keys(nodes).length;
-    if (length === 0) {
+    if (!exported && children.size === 0) {
       resultXml.push('<node/>');
-    } else if (length === 1) {
-      const obj = nodes[Object.keys(nodes)[0]];
-      if (obj) {
-        resultXml.push('<node>');
-        for (const ifaceNode in obj) {
-          resultXml.push(interfaceToXML(obj[ifaceNode][0]));
-        }
-        resultXml.push(stdIfaces);
-        resultXml.push('</node>');
-      } else {
-        resultXml.push(
-          `<node>\n  <node name="${attr(Object.keys(nodes)[0])}"/>\n  </node>`
-        );
-      }
     } else {
       resultXml.push('<node>');
-      for (const name in nodes) {
-        if (nodes[name] === null) {
-          resultXml.push(`  <node name="${attr(name)}" />`);
-        } else {
-          const node = nodes[name];
-          resultXml.push(`  <node name="${attr(name)}" >`);
-          for (const ifaceName in node) {
-            resultXml.push(interfaceToXML(node[ifaceName][0]));
-          }
-          resultXml.push(stdIfaces);
-          resultXml.push('  </node>');
+      if (exported) {
+        for (const ifaceName in exported) {
+          resultXml.push(interfaceToXML(exported[ifaceName][0]));
         }
+        resultXml.push(stdIfaces);
+      }
+      for (const name of children) {
+        resultXml.push(`  <node name="${attr(name)}"/>`);
       }
       resultXml.push('</node>');
     }

--- a/test/introspect-nodes.js
+++ b/test/introspect-nodes.js
@@ -1,0 +1,130 @@
+// What the Introspect reply says about child objects.
+//
+// The reply for a path describes one object: the interfaces exported there,
+// and a <node name="..."/> per immediate child. A path that is itself exported
+// used to advertise no children at all, so a tree built with this library
+// could not be walked -- see #140.
+
+const { describe, it } = require('node:test');
+const assert = require('assert');
+const stdifaces = require('../lib/stdifaces');
+
+const iface = name => ({
+  name,
+  methods: { Ping: ['', ''] },
+  signals: {},
+  properties: {}
+});
+
+// Build a bus exporting an interface at each of `paths`, and introspect `at`.
+function introspect(paths, at) {
+  const exportedObjects = {};
+  for (const path of paths) {
+    exportedObjects[path] = {
+      [`com.example${path.replace(/\//g, '.')}`]: [
+        iface(`com.example${path.replace(/\//g, '.')}`),
+        {}
+      ]
+    };
+  }
+  let reply;
+  stdifaces(
+    {
+      interface: 'org.freedesktop.DBus.Introspectable',
+      member: 'Introspect',
+      path: at,
+      serial: 1,
+      sender: ':1.2'
+    },
+    {
+      serial: 1,
+      exportedObjects,
+      connection: {
+        message: msg => {
+          reply = msg;
+        }
+      }
+    }
+  );
+  const xml = reply.body[0];
+  return {
+    xml,
+    nodes: [...xml.matchAll(/<node name="([^"]+)"/g)].map(m => m[1]),
+    ifaces: [...xml.matchAll(/<interface name="(com\.[^"]+)"/g)].map(m => m[1])
+  };
+}
+
+const TREE = [
+  '/com/example/Tree',
+  '/com/example/Tree/Alpha',
+  '/com/example/Tree/Beta',
+  '/com/example/Tree/Beta/Deep',
+  '/com/example/Treeish',
+  '/com/example/Bare/Child'
+];
+
+describe('Introspect: child nodes', () => {
+  it('lists the children of a path that is itself exported', () => {
+    const { nodes, ifaces } = introspect(TREE, '/com/example/Tree');
+    assert.deepStrictEqual(nodes, ['Alpha', 'Beta']);
+    assert.deepStrictEqual(
+      ifaces,
+      ['com.example.com.example.Tree'],
+      'and its own interface'
+    );
+  });
+
+  it('lists a grandchild by its parent, once', () => {
+    // /com/example/Tree/Beta/Deep contributes 'Beta', which is already there.
+    const { nodes } = introspect(TREE, '/com/example/Tree');
+    assert.strictEqual(nodes.filter(n => n === 'Beta').length, 1);
+
+    const beta = introspect(TREE, '/com/example/Tree/Beta');
+    assert.deepStrictEqual(beta.nodes, ['Deep']);
+  });
+
+  it('lists the children of a path that exports nothing', () => {
+    const { nodes, ifaces } = introspect(TREE, '/com/example/Bare');
+    assert.deepStrictEqual(nodes, ['Child']);
+    assert.deepStrictEqual(ifaces, []);
+  });
+
+  it('does not treat a path with a common prefix as a child', () => {
+    // '/com/example/Treeish' is not below '/com/example/Tree'.
+    const { nodes } = introspect(TREE, '/com/example/Tree');
+    assert.ok(!nodes.includes('Treeish'));
+    assert.ok(!nodes.includes('ish'));
+  });
+
+  it('reports nothing for a path that is neither exported nor a parent', () => {
+    const { xml } = introspect(TREE, '/com/example/Tre');
+    assert.match(xml, /<node\/>/);
+  });
+
+  it('lists every branch below an intermediate path', () => {
+    const { nodes } = introspect(TREE, '/com/example');
+    assert.deepStrictEqual(nodes.sort(), ['Bare', 'Tree', 'Treeish']);
+  });
+
+  it('descends from the root', () => {
+    const { nodes } = introspect(TREE, '/');
+    assert.deepStrictEqual(nodes, ['com']);
+  });
+
+  it('serves an object with no children as it always did', () => {
+    const { nodes, ifaces } = introspect(TREE, '/com/example/Tree/Alpha');
+    assert.deepStrictEqual(nodes, []);
+    assert.deepStrictEqual(ifaces, ['com.example.com.example.Tree.Alpha']);
+    // The standard interfaces still come with it.
+    const { xml } = introspect(TREE, '/com/example/Tree/Alpha');
+    assert.match(xml, /org\.freedesktop\.DBus\.Properties/);
+    assert.match(xml, /org\.freedesktop\.DBus\.Introspectable/);
+    assert.match(xml, /org\.freedesktop\.DBus\.Peer/);
+  });
+
+  it('does not offer the standard interfaces on a bare container', () => {
+    // Nothing is exported there, so there is nothing to answer Properties.Get.
+    const { xml } = introspect(TREE, '/com/example/Bare');
+    assert.doesNotMatch(xml, /org\.freedesktop\.DBus\.Properties/);
+  });
+});


### PR DESCRIPTION
`Introspect` never listed the children of an exported path, so **a service built with this library serves an object tree that cannot be walked**. This is [#140](https://github.com/sidorares/dbus-native/pull/140), open since 2017.

## The cause

```js
for (const path in bus.exportedObjects) {
  if (path.indexOf(msg.path) === 0) {
    const introspectableObj = bus.exportedObjects[msg.path];  // <- msg.path, not path
```

That lookup does not vary with the loop. As soon as the requested path was itself exported it was truthy on every iteration, so every iteration took the first branch and the `else` that collects children was unreachable.

## Measured

Exporting an interface at `/Tree`, `/Tree/Alpha`, `/Tree/Beta`, `/Tree/Beta/Deep`, `/Treeish` and `/Bare/Child`, then asking a real daemon for each path:

| introspected path | before | after |
| --- | --- | --- |
| `/com/example/Tree` | `[]` | `["Alpha","Beta"]` |
| `/com/example/Tree/Beta` | `[]` | `["Deep"]` |
| `/com/example/Bare` | `["Child"]` | `["Child"]` |
| `/com/example/Tre` | `[]` | `[]` |
| `/com/example` | `["Tree","Treeish","Bare"]` | `["Tree","Treeish","Bare"]` |
| `/` | `["com"]` | `["com"]` |

Only the two broken rows move. The interfaces at the path are unchanged throughout.

## The shape of the fix

The interfaces exported *at* the path and the children *below* it are now built separately, because they are separate things and either may be absent — a path that only groups other objects exports nothing itself. Conflating them in one `nodes` map is what allowed the branches to exclude each other.

The child scan matches a prefix ending in `/`, which also gets the boundary right by construction: `/com/example/Treeish` is not a child of `/com/example/Tree`. The old code needed a separate `path[msg.path.length] !== '/'` check for that — in the branch that was unreachable whenever the path was exported.

A container still does not advertise `org.freedesktop.DBus.Properties` and friends, since nothing is exported there to answer them. That is unchanged, and pinned by a test.

## Tests

`test/introspect-nodes.js`, driving the real handler over the tree above: the exported-path case, grandchildren counted once via their parent, the bare-container case, the `Treeish` prefix trap, an unrelated path, an intermediate path, the root, and that a childless object is served exactly as before.

2 of the 9 fail on master — the two rows in the table that change. The other 7 pin behaviour this PR preserves.

606 unit tests and 123 integration tests pass; lint and prettier clean.

## Relationship to the open PRs

- **[#140](https://github.com/sidorares/dbus-native/pull/140)** diagnosed this correctly in 2017 and is worth crediting. It predates the modernisation of the file, so it no longer applies, and it also rewrote the `<node name>` values to be relative in a way that would double up with the scan here. I have left it open for you to close.
- **[#350](https://github.com/sidorares/dbus-native/pull/350)** is the other half, on the client: `obj.nodes` dropped the first child and a container path was silently replaced by its first child. Independent of this one — this fixes what we *emit*, that fixes what we *read* — but a tree only becomes walkable end to end with both.