### PR TITLE
fix: put the space back in the DBUS_COOKIE_SHA1 response

### DIFF
--- a/lib/handshake.js
+++ b/lib/handshake.js
@@ -142,7 +142,19 @@ function tryAuth(stream, methods, cb) {
           const response = sha1(
             [serverChallenge, clientChallenge, cookie].join(':')
           );
-          const reply = hexlify(clientChallenge + response);
+          // The two fields are separated by a space before hex-encoding:
+          //
+          // > the client ... concatenates ... the client's challenge string, a
+          // > space character, and the SHA-1 hex digest, hex-encodes the
+          // > result and sends it back to the server.
+          //
+          // Without the space the server sees one 72-character blob where it
+          // expects two fields, cannot recover the client challenge, and
+          // answers REJECTED. So this mechanism has never authenticated
+          // against a real bus. It went unnoticed because EXTERNAL is tried
+          // first and succeeds on a unix socket, which leaves
+          // DBUS_COOKIE_SHA1 mattering only over TCP.
+          const reply = hexlify(`${clientChallenge} ${response}`);
           if (!send(stream, `DATA ${reply}\r\n`)) return;
           beginOrNextAuth();
         });

--- a/test/handshake-cookie.js
+++ b/test/handshake-cookie.js
@@ -1,0 +1,158 @@
+// DBUS_COOKIE_SHA1, the mechanism that matters when EXTERNAL cannot work.
+//
+// EXTERNAL is tried first and succeeds on a unix socket, so this one only
+// comes up over TCP -- which is why a malformed response went unnoticed for
+// years. The response carries two fields, and the space between them is not
+// optional: without it the server sees one blob, cannot recover the client
+// challenge, and answers REJECTED.
+//
+// https://dbus.freedesktop.org/doc/dbus-specification.html#auth-mechanisms-sha
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('assert');
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { Duplex } = require('stream');
+const auth = require('../lib/handshake');
+
+const CONTEXT = 'org_freedesktop_general';
+const COOKIE_ID = '162004020';
+const COOKIE = 'e17968c5c097bff2fd50a93cfdf8a97c9acb39ba13d95bc5';
+const SERVER_CHALLENGE = '6bb9ec9396d6bb47940780a6b60da269';
+
+const hex = s => Buffer.from(String(s), 'ascii').toString('hex');
+const unhex = s => Buffer.from(s, 'hex').toString('ascii');
+
+// Captures what the client writes, and lets the test feed it server lines.
+class FakeSocket extends Duplex {
+  constructor() {
+    super();
+    this.written = [];
+  }
+  _write(chunk, enc, cb) {
+    this.written.push(chunk.toString());
+    cb();
+  }
+  _read() {}
+  // Every complete line the client has written so far.
+  lines() {
+    return this.written.join('').split('\r\n').filter(Boolean);
+  }
+  reply(line) {
+    this.push(`${line}\r\n`);
+  }
+}
+
+// Wait until the client has written `n` lines (the '\0' rides on the first).
+const until = (socket, n) =>
+  new Promise((resolve, reject) => {
+    const started = Date.now();
+    const poll = () => {
+      if (socket.lines().length >= n) return resolve();
+      if (Date.now() - started > 2000)
+        return reject(new Error(`only ${socket.lines().length} lines written`));
+      setImmediate(poll);
+    };
+    poll();
+  });
+
+describe('DBUS_COOKIE_SHA1', () => {
+  let home, previousHome;
+
+  before(() => {
+    // getCookie() refuses a keyring directory that others can write or that
+    // belongs to someone else, so 0700 and our own uid are both required.
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'dbus-keyring-'));
+    fs.mkdirSync(path.join(home, '.dbus-keyrings'), { mode: 0o700 });
+    fs.writeFileSync(
+      path.join(home, '.dbus-keyrings', CONTEXT),
+      `${COOKIE_ID} 1700000000 ${COOKIE}\n`
+    );
+    previousHome = process.env.HOME;
+    process.env.HOME = home;
+  });
+
+  after(() => {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  // Runs the handshake to completion and hands back what was said.
+  async function handshake() {
+    const socket = new FakeSocket();
+    const done = new Promise((resolve, reject) =>
+      auth(socket, { authMethods: ['DBUS_COOKIE_SHA1'] }, (err, guid) =>
+        err ? reject(err) : resolve(guid)
+      )
+    );
+
+    await until(socket, 1);
+    socket.reply(`DATA ${hex(`${CONTEXT} ${COOKIE_ID} ${SERVER_CHALLENGE}`)}`);
+
+    await until(socket, 2);
+    socket.reply('OK 326475c33141ef4255ca5ed96a69c063');
+
+    return { socket, guid: await done };
+  }
+
+  it('sends AUTH with the hex-encoded uid', async () => {
+    const { socket } = await handshake();
+    const uid = typeof process.getuid === 'function' ? process.getuid() : 0;
+    assert.strictEqual(
+      socket.lines()[0],
+      `\0AUTH DBUS_COOKIE_SHA1 ${hex(uid)}`
+    );
+  });
+
+  it('separates the challenge and the digest with a space', async () => {
+    const { socket } = await handshake();
+    const payload = unhex(socket.lines()[1].slice('DATA '.length));
+    const fields = payload.split(' ');
+    assert.strictEqual(
+      fields.length,
+      2,
+      `expected "<challenge> <digest>", got ${JSON.stringify(payload)}`
+    );
+  });
+
+  it('digests server challenge, client challenge and cookie, in that order', async () => {
+    const { socket } = await handshake();
+    const [clientChallenge, digest] = unhex(
+      socket.lines()[1].slice('DATA '.length)
+    ).split(' ');
+
+    const expected = crypto
+      .createHash('sha1')
+      .update([SERVER_CHALLENGE, clientChallenge, COOKIE].join(':'))
+      .digest('hex');
+    assert.strictEqual(digest, expected);
+    assert.strictEqual(digest.length, 40, 'a hex sha1');
+  });
+
+  it('uses a fresh client challenge each time', async () => {
+    const first = await handshake();
+    const second = await handshake();
+    const challenge = s =>
+      unhex(s.lines()[1].slice('DATA '.length)).split(' ')[0];
+    assert.notStrictEqual(challenge(first.socket), challenge(second.socket));
+  });
+
+  it('begins, and reports the server GUID', async () => {
+    const { socket, guid } = await handshake();
+    assert.strictEqual(socket.lines()[2], 'BEGIN');
+    assert.strictEqual(guid, '326475c33141ef4255ca5ed96a69c063');
+  });
+
+  it('fails when the keyring has no cookie with that id', async () => {
+    const socket = new FakeSocket();
+    const done = new Promise(resolve =>
+      auth(socket, { authMethods: ['DBUS_COOKIE_SHA1'] }, err => resolve(err))
+    );
+    await until(socket, 1);
+    socket.reply(`DATA ${hex(`${CONTEXT} 999 ${SERVER_CHALLENGE}`)}`);
+    assert.match((await done).message, /cookie not found/);
+  });
+});


### PR DESCRIPTION
The client's `DATA` response carries two fields, and the space between them is not optional:

> the client ... concatenates ... the client's challenge string, a space character, and the SHA-1 hex digest, hex-encodes the result and sends it back to the server.

We concatenated them directly:

```js
const reply = hexlify(clientChallenge + response);
```

So the server received one 72-character blob where it expected two fields, could not recover the client challenge, and answered `REJECTED`. **`DBUS_COOKIE_SHA1` has never authenticated against a real bus.**

It went unnoticed because `EXTERNAL` is first in `defaultAuthMethods` and succeeds on a unix socket. That leaves `DBUS_COOKIE_SHA1` mattering only over TCP — where it is precisely the mechanism that is supposed to work, since `EXTERNAL` has no credentials to check there.

## Measured

`dbus-daemon` 1.14.10 on a TCP listener with `<auth>DBUS_COOKIE_SHA1</auth>` as its only offered mechanism, connecting with `authMethods: ['DBUS_COOKIE_SHA1']`:

```
as shipped (no space):
  -> FAILED: No authentication methods left to try.
     Last server response: REJECTED DBUS_COOKIE_SHA1
with the space:
  -> connected, bus id 274442add7ad079d3da47dfe6a69c063
```

A hand-written handshake against the same daemon confirms the shape the server wants:

```
C> "AUTH DBUS_COOKIE_SHA1 353031\r\n"
S> "DATA 6f72675f...31306630"
   decoded: "org_freedesktop_general 162004020 b625ee43482d8e62f1e0f34855360810"
C> "DATA <hex of "<client challenge> <sha1>">"
S> "OK 105ade7855c3b4119c05871b6a69bfbf"
```

## Tests

`test/handshake-cookie.js` drives the real `auth()` against a scripted server with a temporary `$HOME` holding a keyring: the `AUTH` line, that the response splits into exactly two fields, that the digest is `sha1(server:client:cookie)`, that the client challenge is fresh each time, `BEGIN` plus the GUID, and the missing-cookie failure.

2 of the 6 fail on master. 625 unit tests pass; lint and prettier clean.

## Context

First piece of the §4.5 server/broker work: a server implementation has to verify exactly this response, so it needed to be right — and correct on both sides — before there was anything to verify it against.