### PR TITLE
feat: a real server-side SASL handshake

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -5,8 +5,10 @@
 // the connection switches to binary framing and this is no longer involved.
 module.exports = function readOneLine(stream, cb) {
   const parts = [];
+  let finished = false;
 
   function readable() {
+    if (finished) return;
     let chunk;
     while ((chunk = stream.read()) !== null) {
       const newline = chunk.indexOf(0x0a);
@@ -21,6 +23,7 @@ module.exports = function readOneLine(stream, cb) {
 
       // Detach before handing anything back: the callback normally starts the
       // next readOneLine, and unshift() re-emits 'readable'.
+      finished = true;
       stream.removeListener('readable', readable);
       if (rest.length > 0) stream.unshift(rest);
 
@@ -34,4 +37,19 @@ module.exports = function readOneLine(stream, cb) {
   }
 
   stream.on('readable', readable);
+
+  // Kick it, because attaching the listener is not always enough.
+  //
+  // read() hands back one buffered chunk at a time, so a peer that wrote three
+  // lines in three writes leaves two chunks queued once the first line comes
+  // out. Attaching a 'readable' listener while data is already buffered would
+  // normally schedule an emit -- but not while an emission is already in
+  // progress, and that is exactly the case here: a line-oriented conversation
+  // starts its next read from inside the callback of the previous one, which
+  // runs inside that emit. The new listener then waits forever for bytes that
+  // arrived before it existed, and the exchange stops dead.
+  //
+  // Harmless when nothing is waiting: read() returns null and the loop does
+  // not run. `finished` keeps this from racing a real 'readable'.
+  process.nextTick(readable);
 };

--- a/lib/server-handshake.js
+++ b/lib/server-handshake.js
@@ -1,36 +1,375 @@
+// The server half of the SASL handshake.
+//
+// https://dbus.freedesktop.org/doc/dbus-specification.html#auth-protocol
+//
+// What was here before was a transcript of someone's 2014 session replayed
+// verbatim: a hardcoded cookie, a hardcoded GUID, an unconditional REJECTED
+// followed by an OK that ignored whatever the client had said, and a
+// console.log per connection. It authenticated nobody -- it only resembled a
+// handshake if the client happened to ask its questions in that order.
+//
+// This is the state machine from the specification, three mechanisms, and a
+// GUID generated per server.
+
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
 const readLine = require('./readline');
 
-module.exports = function serverHandshake(stream, opts, cb) {
-  stream.name = 'SERVER SERVER';
-  readLine(stream, hello => {
-    console.log(['hello string: ', hello.toString(), hello]);
-    stream.write('REJECTED EXTERNAL DBUS_COOKIE_SHA1 ANONYMOUS\r\n');
-    readLine(stream, () => {
-      stream.write(
-        `DATA ${Buffer.from(
-          'org_freedesktop_general 642038150 b9ce247a275f427c8586e4c9de9bb951'
-        ).toString('hex')}\r\n`
+// A connection that opens and then says nothing still costs a socket.
+// dbus-daemon's own limit is 30 seconds.
+const DEFAULT_AUTH_TIMEOUT = 30000;
+
+// The spec has the server answer REJECTED and wait for another AUTH, which on
+// its own is an unbounded loop for a client that keeps guessing.
+const MAX_REJECTIONS = 8;
+
+// Offered unless the caller says otherwise. ANONYMOUS is deliberately not
+// among them: it authenticates nobody, and it should be turned on knowingly.
+// dbus-daemon takes the same line with <allow_anonymous/>.
+const DEFAULT_MECHANISMS = ['EXTERNAL', 'DBUS_COOKIE_SHA1'];
+
+const DEFAULT_COOKIE_CONTEXT = 'org_freedesktop_general';
+
+// How long a cookie stays usable, and how long it stays in the file. A cookie
+// is only needed for the length of a handshake, and one left lying around is a
+// credential, so both are short.
+const COOKIE_LIFETIME_MS = 5 * 60 * 1000;
+const COOKIE_RETENTION_MS = 10 * 60 * 1000;
+
+const KNOWN_COMMANDS = [
+  'AUTH',
+  'DATA',
+  'BEGIN',
+  'CANCEL',
+  'ERROR',
+  'NEGOTIATE_UNIX_FD'
+];
+
+const hex = value => Buffer.from(String(value), 'ascii').toString('hex');
+const unhex = value => Buffer.from(value, 'hex').toString('ascii');
+const sha1 = input => crypto.createHash('sha1').update(input).digest('hex');
+
+/** A D-Bus GUID: 16 random bytes as lower-case hex. */
+function generateGuid() {
+  return crypto.randomBytes(16).toString('hex');
+}
+
+// As in lib/handshake.js: writing to a stream the peer has already dropped is
+// not an error worth reporting.
+function writable(stream) {
+  return (
+    !stream.writableEnded && !stream.destroyed && stream.writable !== false
+  );
+}
+
+/**
+ * A cookie the client can be expected to find in its own keyring, creating one
+ * if there is nothing usable.
+ *
+ * The file holds a line per cookie: id, creation time in seconds, and the
+ * cookie in hex. Entries past their retention are dropped on the way through,
+ * so the file does not grow without bound and an old credential does not sit
+ * on disk indefinitely.
+ */
+function ensureCookie(context, cb) {
+  const file = path.join(os.homedir(), '.dbus-keyrings', context);
+  const dir = path.dirname(file);
+  let entries = [];
+  try {
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    // A keyring anyone can write is a keyring anyone can authenticate with.
+    // The client checks this before trusting the directory; so do we.
+    if (fs.statSync(dir).mode & 0o022) {
+      return cb(
+        new Error(`${dir} is writable by other users; refusing to use it`)
       );
-      readLine(stream, () => {
-        stream.write(
-          'OK 6f72675f667265656465736b746f705f67656e6572616c20353631303331333937206239636532343761323735663432376338353836653463396465396262393531\r\n'
-        );
-        readLine(stream, begin => {
-          console.log(['AFTER begin: ', begin.toString()]);
-          cb(null);
-        });
-      });
+    }
+    if (fs.existsSync(file)) {
+      entries = fs
+        .readFileSync(file, 'ascii')
+        .split('\n')
+        .map(line => line.split(' '))
+        .filter(fields => fields.length === 3);
+    }
+  } catch (err) {
+    return cb(err);
+  }
+
+  const now = Date.now();
+  const age = fields => now - Number(fields[1]) * 1000;
+  const kept = entries.filter(fields => age(fields) < COOKIE_RETENTION_MS);
+  const usable = kept.find(fields => age(fields) < COOKIE_LIFETIME_MS);
+
+  if (usable && kept.length === entries.length) {
+    return cb(null, { id: usable[0], cookie: usable[2] });
+  }
+
+  const entry = usable || [
+    String(crypto.randomInt(1, 2 ** 31)),
+    String(Math.floor(now / 1000)),
+    crypto.randomBytes(24).toString('hex')
+  ];
+  const lines = usable ? kept : [...kept, entry];
+  try {
+    fs.writeFileSync(file, `${lines.map(f => f.join(' ')).join('\n')}\n`, {
+      mode: 0o600
     });
-  });
+  } catch (err) {
+    return cb(err);
+  }
+  return cb(null, { id: entry[0], cookie: entry[2] });
+}
+
+/**
+ * Run the server side of the handshake on `stream`.
+ *
+ * `opts`:
+ *   guid           this server's GUID; generated when absent
+ *   authMethods    mechanisms to offer, in the order they are advertised
+ *   anonymous      also offer ANONYMOUS
+ *   authorize      ({mechanism, uid}) => boolean, the last word on accepting
+ *   cookieContext  keyring context used by DBUS_COOKIE_SHA1
+ *   authTimeout    ms before an unauthenticated connection is dropped; 0 waits
+ *
+ * Calls back with `(null, guid, identity)` once the client has sent BEGIN.
+ */
+module.exports = function serverHandshake(stream, opts, cb) {
+  opts = opts || {};
+  const guid = opts.guid || generateGuid();
+  const mechanisms = (opts.authMethods || DEFAULT_MECHANISMS).slice();
+  if (opts.anonymous && !mechanisms.includes('ANONYMOUS')) {
+    mechanisms.push('ANONYMOUS');
+  }
+  const cookieContext = opts.cookieContext || DEFAULT_COOKIE_CONTEXT;
+  const authorize = opts.authorize;
+
+  let state = 'WaitingForAuth';
+  let rejections = 0;
+  let firstLine = true;
+  let settled = false;
+  // Set while a mechanism is mid-exchange, so a DATA line knows who wants it.
+  let pending = null;
+  // What we learnt about the peer; passed to `authorize` and to the caller.
+  const identity = { mechanism: null, uid: null };
+
+  const timeout =
+    opts.authTimeout === undefined ? DEFAULT_AUTH_TIMEOUT : opts.authTimeout;
+  const timer =
+    timeout > 0
+      ? setTimeout(
+          () =>
+            fail(new Error('Timed out waiting for the client to authenticate')),
+          timeout
+        )
+      : null;
+
+  function send(line) {
+    if (!writable(stream)) return false;
+    stream.write(`${line}\r\n`);
+    return true;
+  }
+
+  function fail(error) {
+    if (settled) return;
+    settled = true;
+    if (timer) clearTimeout(timer);
+    stream.end();
+    cb(error);
+  }
+
+  function succeed() {
+    if (settled) return;
+    settled = true;
+    if (timer) clearTimeout(timer);
+    cb(null, guid, identity);
+  }
+
+  // Refuse this attempt and let the client try again with another mechanism,
+  // which is what REJECTED means.
+  function reject() {
+    pending = null;
+    state = 'WaitingForAuth';
+    if (++rejections > MAX_REJECTIONS) {
+      return fail(
+        new Error(
+          `Client failed to authenticate after ${MAX_REJECTIONS} attempts`
+        )
+      );
+    }
+    if (send(`REJECTED ${mechanisms.join(' ')}`)) next();
+  }
+
+  function next() {
+    if (settled) return;
+    readLine(stream, line => {
+      if (settled) return;
+      let text = line.toString('ascii');
+      if (firstLine) {
+        firstLine = false;
+        // "Immediately after connecting to the server, the client must send a
+        // single nul byte." It arrives in front of the first command rather
+        // than on a line of its own.
+        if (text[0] !== '\0') {
+          return fail(new Error('Client did not send the initial nul byte'));
+        }
+        text = text.slice(1);
+      }
+      handle(text.replace(/\r$/, ''));
+    });
+  }
+
+  function handle(line) {
+    const space = line.indexOf(' ');
+    const command = space === -1 ? line : line.slice(0, space);
+    const argument = space === -1 ? '' : line.slice(space + 1).trim();
+
+    // BEGIN before authentication cannot be answered: the client has stopped
+    // speaking SASL, so there is nothing left to say to it.
+    if (command === 'BEGIN' && state !== 'WaitingForBegin') {
+      return fail(new Error(`Client sent BEGIN while ${state}`));
+    }
+    // "If a client or server receives an unknown command it shall respond with
+    // ERROR and not consider this fatal."
+    if (!KNOWN_COMMANDS.includes(command)) {
+      send(`ERROR Unknown command "${command}"`);
+      return next();
+    }
+    // From any state, both of these mean "start over".
+    if (command === 'CANCEL' || command === 'ERROR') return reject();
+
+    switch (state) {
+      case 'WaitingForAuth':
+        return onAuth(command, argument);
+      case 'WaitingForData':
+        return onData(command, argument);
+      default:
+        return onBegin(command);
+    }
+  }
+
+  function onAuth(command, argument) {
+    if (command !== 'AUTH') {
+      send(`ERROR Expected AUTH, got ${command}`);
+      return next();
+    }
+    // A bare AUTH asks what is on offer, and REJECTED is how that is answered.
+    if (argument === '') return reject();
+
+    const space = argument.indexOf(' ');
+    const mechanism = space === -1 ? argument : argument.slice(0, space);
+    const initial = space === -1 ? null : argument.slice(space + 1).trim();
+
+    if (!mechanisms.includes(mechanism)) return reject();
+    identity.mechanism = mechanism;
+
+    switch (mechanism) {
+      case 'EXTERNAL':
+        return external(initial);
+      case 'ANONYMOUS':
+        // The argument is a free-text trace string, of interest to nobody.
+        return accept();
+      case 'DBUS_COOKIE_SHA1':
+        return cookieChallenge();
+      default:
+        return reject();
+    }
+  }
+
+  function onData(command, argument) {
+    if (command !== 'DATA') {
+      send(`ERROR Expected DATA, got ${command}`);
+      return next();
+    }
+    const handler = pending;
+    pending = null;
+    if (!handler) return reject();
+    return handler(argument);
+  }
+
+  function onBegin(command) {
+    if (command === 'BEGIN') return succeed();
+    if (command === 'NEGOTIATE_UNIX_FD') {
+      // Refused rather than agreed. A file descriptor travels as ancillary
+      // data, which Node cannot send or receive -- see
+      // constants.unsupportedType and ROADMAP section 2.8. ERROR is what the
+      // spec expects here, and the client carries on without fd passing.
+      send('ERROR UNIX_FD passing is not supported');
+      return next();
+    }
+    send(`ERROR Expected BEGIN, got ${command}`);
+    return next();
+  }
+
+  // EXTERNAL. The client offers its uid, and the spec has the server check it
+  // against credentials the transport supplies out of band. Node exposes no
+  // such thing -- there is no SO_PEERCRED -- so the claim cannot be verified
+  // here. The default is therefore the narrowest useful rule: the peer must
+  // claim to be the user this process runs as, which is what a private
+  // per-user bus wants. `authorize` replaces that judgement outright.
+  function external(initial) {
+    if (!initial) {
+      // An empty response means "use the out-of-band credentials", which we do
+      // not have. Asking for the uid is the only way we can answer at all.
+      pending = data => external(data);
+      state = 'WaitingForData';
+      if (send('DATA')) next();
+      return;
+    }
+    const uid = unhex(initial);
+    if (!/^\d+$/.test(uid)) return reject();
+    identity.uid = Number(uid);
+    if (!authorize && typeof process.getuid === 'function') {
+      if (identity.uid !== process.getuid()) return reject();
+    }
+    return accept();
+  }
+
+  // DBUS_COOKIE_SHA1. We name a cookie the client should be able to read from
+  // its own keyring, plus a challenge; it proves it read the cookie.
+  function cookieChallenge() {
+    ensureCookie(cookieContext, (err, entry) => {
+      if (err) return fail(err);
+      const challenge = crypto.randomBytes(16).toString('hex');
+      pending = data => verifyCookie(entry, challenge, data);
+      state = 'WaitingForData';
+      if (send(`DATA ${hex(`${cookieContext} ${entry.id} ${challenge}`)}`)) {
+        next();
+      }
+    });
+  }
+
+  function verifyCookie(entry, challenge, data) {
+    const [clientChallenge, digest] = unhex(data).split(' ');
+    if (!clientChallenge || !digest) return reject();
+    const expected = sha1([challenge, clientChallenge, entry.cookie].join(':'));
+    // Compared without a short circuit: the digest is derived from a secret,
+    // and how long the comparison takes is a hint about it.
+    const offered = Buffer.from(digest, 'ascii');
+    const wanted = Buffer.from(expected, 'ascii');
+    if (
+      offered.length !== wanted.length ||
+      !crypto.timingSafeEqual(offered, wanted)
+    ) {
+      return reject();
+    }
+    return accept();
+  }
+
+  function accept() {
+    if (authorize && !authorize({ ...identity })) return reject();
+    state = 'WaitingForBegin';
+    if (send(`OK ${guid}`)) next();
+  }
+
+  // The client can go away at any point in the conversation.
+  stream.once('end', () =>
+    fail(new Error('Client closed the connection during authentication'))
+  );
+
+  next();
 };
 
-// cookie: 561031397 1410749774 3a83c8200f930e7af4de135e8abd299b681a1f44dbb85399
-
-// 1539856202
-
-// server: org_freedesktop_general 561031397 b9ce247a275f427c8586e4c9de9bb951
-// client: bwFSDjS0TJerqb0l 82986a987194788803d7da2a4b00e801cff9bdfd
-//                          82986a987194788803d7da2a4b00e801cff9bdfd = sha1(b9ce247a275f427c8586e4c9de9bb951:bwFSDjS0TJerqb0l:3a83c8200f930e7af4de135e8abd299b681a1f44dbb85399)
-// server: OK e12a29dd7ffe3effac5eb95054123f80
-
-//dbus.write('DATA 6f72675f667265656465736b746f705f67656e6572616c203636383430 31303032 203733653733313762383630356537323937623438303233376336353234343533\r\n');
+module.exports.generateGuid = generateGuid;

--- a/test/readline.js
+++ b/test/readline.js
@@ -60,6 +60,56 @@ describe('readOneLine', () => {
     assert.strictEqual(await p, 'AUTH EXTERNAL');
   });
 
+  // Everything above either puts its lines in one write -- which the unshift
+  // path covers -- or starts the next read from a promise continuation, by
+  // which time the stream is no longer mid-emit.
+  //
+  // A SASL conversation does neither. It starts the next read *synchronously*
+  // from the callback of the last one, which runs inside the 'readable'
+  // emission. Attaching a listener there cannot schedule another emit, and
+  // read() only ever hands back one buffered chunk, so a peer that wrote its
+  // lines separately leaves the rest queued and the exchange stops dead.
+  //
+  // Chained with a helper rather than `await` on purpose: awaiting is what
+  // hides it.
+  const chain = (stream, count) =>
+    new Promise(resolve => {
+      const got = [];
+      const step = () =>
+        readOneLine(stream, buf => {
+          got.push(buf.toString());
+          if (got.length === count) return resolve(got);
+          step();
+        });
+      step();
+    });
+
+  it('reads on when each line came in its own write', async () => {
+    const s = new PassThrough();
+    const all = chain(s, 3);
+    s.write('one\n');
+    s.write('two\n');
+    s.write('three\n');
+    assert.deepStrictEqual(await all, ['one', 'two', 'three']);
+  });
+
+  it('reads on when the lines were written before anyone was reading', async () => {
+    const s = new PassThrough();
+    s.write('early\n');
+    s.write('bird\n');
+    await new Promise(setImmediate);
+    assert.deepStrictEqual(await chain(s, 2), ['early', 'bird']);
+  });
+
+  it('reads on when a line is split across writes after the first', async () => {
+    const s = new PassThrough();
+    const all = chain(s, 2);
+    s.write('AUTH\n');
+    s.write('EXTER');
+    s.write('NAL\n');
+    assert.deepStrictEqual(await all, ['AUTH', 'EXTERNAL']);
+  });
+
   it('reports a throwing callback on the stream', (t, done) => {
     const s = new PassThrough();
     s.on('error', err => {

--- a/test/server-handshake.js
+++ b/test/server-handshake.js
@@ -1,0 +1,382 @@
+// The server half of the SASL handshake.
+//
+// https://dbus.freedesktop.org/doc/dbus-specification.html#auth-protocol
+//
+// Two kinds of test here: the happy paths run our own client against our own
+// server, so both halves have to agree; the protocol cases script a raw client
+// by hand, because a well-behaved client will not send BEGIN out of turn.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('assert');
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { PassThrough, Duplex } = require('stream');
+
+const clientAuth = require('../lib/handshake');
+const serverAuth = require('../lib/server-handshake');
+
+const hex = value => Buffer.from(String(value), 'ascii').toString('hex');
+const unhex = value => Buffer.from(value, 'hex').toString('ascii');
+const UID = typeof process.getuid === 'function' ? process.getuid() : 0;
+
+// Two ends of one conversation, without going near a socket.
+function pair() {
+  const up = new PassThrough();
+  const down = new PassThrough();
+  return {
+    client: Duplex.from({ readable: down, writable: up }),
+    server: Duplex.from({ readable: up, writable: down })
+  };
+}
+
+// A client we drive by hand: writes bytes, collects the server's lines.
+function rawClient(stream) {
+  const lines = [];
+  let buffer = '';
+  stream.on('data', chunk => {
+    buffer += chunk.toString('ascii');
+    let at;
+    while ((at = buffer.indexOf('\r\n')) !== -1) {
+      lines.push(buffer.slice(0, at));
+      buffer = buffer.slice(at + 2);
+    }
+  });
+  return {
+    lines,
+    write: text => stream.write(text),
+    send: line => stream.write(`${line}\r\n`),
+    // Resolves with the next line the server sends after the ones already seen.
+    async expect(n = lines.length + 1) {
+      const started = Date.now();
+      while (lines.length < n) {
+        if (Date.now() - started > 2000) {
+          throw new Error(`server said only: ${JSON.stringify(lines)}`);
+        }
+        await new Promise(resolve => setImmediate(resolve));
+      }
+      return lines[n - 1];
+    }
+  };
+}
+
+// Runs a server handshake and resolves with how it ended.
+function runServer(stream, opts) {
+  return new Promise(resolve =>
+    serverAuth(stream, { authTimeout: 0, ...opts }, (err, guid, identity) =>
+      resolve({ err, guid, identity })
+    )
+  );
+}
+
+describe('server handshake: with our own client', { timeout: 10000 }, () => {
+  const both = async (serverOpts, clientOpts) => {
+    const { client, server } = pair();
+    const serverDone = runServer(server, serverOpts);
+    const c = await new Promise(resolve =>
+      clientAuth(client, clientOpts, (err, guid) => resolve({ err, guid }))
+    );
+    // A client that has run out of mechanisms stops talking without saying so.
+    // A real socket would close; here we have to do it, or the server sits in
+    // WaitingForAuth for as long as its timeout allows.
+    if (c.err) client.end();
+    return [await serverDone, c];
+  };
+
+  it('authenticates EXTERNAL, and both ends agree on the GUID', async () => {
+    const [s, c] = await both(
+      { authMethods: ['EXTERNAL'] },
+      { authMethods: ['EXTERNAL'] }
+    );
+    assert.ifError(s.err);
+    assert.ifError(c.err);
+    assert.strictEqual(c.guid, s.guid);
+    assert.match(s.guid, /^[0-9a-f]{32}$/, 'a D-Bus GUID');
+    assert.deepStrictEqual(s.identity, { mechanism: 'EXTERNAL', uid: UID });
+  });
+
+  it('generates a different GUID per server, and honours a given one', async () => {
+    const [a] = await both({ authMethods: ['EXTERNAL'] }, {});
+    const [b] = await both({ authMethods: ['EXTERNAL'] }, {});
+    assert.notStrictEqual(a.guid, b.guid);
+
+    const fixed = 'ffeeddccbbaa99887766554433221100';
+    const [c] = await both({ authMethods: ['EXTERNAL'], guid: fixed }, {});
+    assert.strictEqual(c.guid, fixed);
+  });
+
+  it('lets the client fall through to a mechanism the server offers', async () => {
+    // The client tries EXTERNAL first; the server only speaks ANONYMOUS.
+    const [s, c] = await both(
+      { authMethods: ['ANONYMOUS'] },
+      { authMethods: ['EXTERNAL', 'ANONYMOUS'] }
+    );
+    assert.ifError(s.err);
+    assert.ifError(c.err);
+    assert.strictEqual(s.identity.mechanism, 'ANONYMOUS');
+  });
+
+  it('does not offer ANONYMOUS unless asked to', async () => {
+    const [s, c] = await both({}, { authMethods: ['ANONYMOUS'] });
+    assert.match(c.err.message, /No authentication methods left to try/);
+    assert.ok(s.err, 'and the server never authenticated anyone');
+  });
+
+  it('offers ANONYMOUS when anonymous is set', async () => {
+    const [s] = await both({ anonymous: true }, { authMethods: ['ANONYMOUS'] });
+    assert.ifError(s.err);
+    assert.strictEqual(s.identity.mechanism, 'ANONYMOUS');
+  });
+});
+
+describe('server handshake: DBUS_COOKIE_SHA1', { timeout: 10000 }, () => {
+  let home, previousHome;
+
+  before(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'dbus-server-keyring-'));
+    previousHome = process.env.HOME;
+    process.env.HOME = home;
+  });
+
+  after(() => {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it('challenges, and accepts a client that knows the cookie', async () => {
+    const { client, server } = pair();
+    const [s, c] = await Promise.all([
+      runServer(server, { authMethods: ['DBUS_COOKIE_SHA1'] }),
+      new Promise(resolve =>
+        clientAuth(client, { authMethods: ['DBUS_COOKIE_SHA1'] }, (err, guid) =>
+          resolve({ err, guid })
+        )
+      )
+    ]);
+    assert.ifError(s.err);
+    assert.ifError(c.err);
+    assert.strictEqual(c.guid, s.guid);
+    assert.strictEqual(s.identity.mechanism, 'DBUS_COOKIE_SHA1');
+  });
+
+  it('creates the keyring it needs, readable only by its owner', async () => {
+    const file = path.join(home, '.dbus-keyrings', 'org_freedesktop_general');
+    assert.ok(fs.existsSync(file), 'the keyring was written');
+    assert.strictEqual(fs.statSync(file).mode & 0o777, 0o600);
+    const [id, created, cookie] = fs
+      .readFileSync(file, 'ascii')
+      .trim()
+      .split('\n')[0]
+      .split(' ');
+    assert.match(id, /^\d+$/);
+    assert.ok(Number(created) > 1600000000, 'seconds since the epoch');
+    assert.match(cookie, /^[0-9a-f]{48}$/);
+  });
+
+  it('rejects a digest that does not match the challenge', async () => {
+    const { client, server } = pair();
+    const raw = rawClient(client);
+    const done = runServer(server, {
+      authMethods: ['DBUS_COOKIE_SHA1'],
+      authTimeout: 0
+    });
+
+    raw.write('\0');
+    raw.send(`AUTH DBUS_COOKIE_SHA1 ${hex(UID)}`);
+    const challenge = await raw.expect(1);
+    assert.match(challenge, /^DATA /);
+
+    raw.send(`DATA ${hex(`deadbeef ${'0'.repeat(40)}`)}`);
+    assert.match(await raw.expect(2), /^REJECTED /);
+
+    client.end();
+    assert.ok((await done).err, 'and the handshake does not complete');
+  });
+
+  it('uses the cookie the client can actually read', async () => {
+    // The server names an id from the shared keyring; a client that reads the
+    // same file must find it. This is the round trip that a missing space in
+    // the client's response used to break.
+    const { client, server } = pair();
+    const raw = rawClient(client);
+    runServer(server, { authMethods: ['DBUS_COOKIE_SHA1'], authTimeout: 0 });
+
+    raw.write('\0');
+    raw.send(`AUTH DBUS_COOKIE_SHA1 ${hex(UID)}`);
+    const payload = unhex((await raw.expect(1)).slice('DATA '.length));
+    const [context, id, challenge] = payload.split(' ');
+    assert.strictEqual(context, 'org_freedesktop_general');
+
+    const keyring = fs
+      .readFileSync(path.join(home, '.dbus-keyrings', context), 'ascii')
+      .split('\n')
+      .map(line => line.split(' '))
+      .find(fields => fields[0] === id);
+    assert.ok(keyring, 'the id names a cookie in the file');
+
+    const clientChallenge = crypto.randomBytes(16).toString('hex');
+    const digest = crypto
+      .createHash('sha1')
+      .update([challenge, clientChallenge, keyring[2]].join(':'))
+      .digest('hex');
+    raw.send(`DATA ${hex(`${clientChallenge} ${digest}`)}`);
+    assert.match(await raw.expect(2), /^OK [0-9a-f]{32}$/);
+  });
+});
+
+describe('server handshake: the protocol', { timeout: 10000 }, () => {
+  // Starts a server and a hand-driven client that has sent its nul byte.
+  const scripted = opts => {
+    const { client, server } = pair();
+    const raw = rawClient(client);
+    const done = runServer(server, { authTimeout: 0, ...opts });
+    raw.write('\0');
+    return { raw, done, client, server };
+  };
+
+  it('answers a bare AUTH with the mechanisms it offers', async () => {
+    const { raw } = scripted({ authMethods: ['EXTERNAL', 'DBUS_COOKIE_SHA1'] });
+    raw.send('AUTH');
+    assert.strictEqual(
+      await raw.expect(1),
+      'REJECTED EXTERNAL DBUS_COOKIE_SHA1'
+    );
+  });
+
+  it('rejects a mechanism it does not offer, and keeps listening', async () => {
+    const { raw } = scripted({ authMethods: ['EXTERNAL'] });
+    raw.send('AUTH KERBEROS_V4 abc');
+    assert.strictEqual(await raw.expect(1), 'REJECTED EXTERNAL');
+    raw.send(`AUTH EXTERNAL ${hex(UID)}`);
+    assert.match(await raw.expect(2), /^OK /);
+  });
+
+  it('answers an unknown command with ERROR and carries on', async () => {
+    // "If a client or server receives an unknown command it shall respond
+    // with ERROR and not consider this fatal."
+    const { raw } = scripted({ authMethods: ['EXTERNAL'] });
+    raw.send('WHAT IS THIS');
+    assert.match(await raw.expect(1), /^ERROR Unknown command "WHAT"/);
+    raw.send(`AUTH EXTERNAL ${hex(UID)}`);
+    assert.match(await raw.expect(2), /^OK /);
+  });
+
+  it('refuses UNIX_FD passing but stays in the handshake', async () => {
+    const { raw, done } = scripted({ authMethods: ['EXTERNAL'] });
+    raw.send(`AUTH EXTERNAL ${hex(UID)}`);
+    await raw.expect(1);
+    raw.send('NEGOTIATE_UNIX_FD');
+    assert.match(await raw.expect(2), /^ERROR .*UNIX_FD/);
+    raw.send('BEGIN');
+    assert.ifError((await done).err);
+  });
+
+  it('starts over on CANCEL', async () => {
+    const { raw } = scripted({ authMethods: ['EXTERNAL'] });
+    raw.send('AUTH EXTERNAL');
+    assert.strictEqual(await raw.expect(1), 'DATA', 'asked for the uid');
+    raw.send('CANCEL');
+    assert.strictEqual(await raw.expect(2), 'REJECTED EXTERNAL');
+    raw.send(`AUTH EXTERNAL ${hex(UID)}`);
+    assert.match(await raw.expect(3), /^OK /);
+  });
+
+  it('gives up on a client that only ever guesses', async () => {
+    const { raw, done } = scripted({ authMethods: ['EXTERNAL'] });
+    for (let i = 0; i < 12; i++) raw.send('AUTH NOPE');
+    assert.match((await done).err.message, /failed to authenticate after/);
+  });
+
+  it('treats BEGIN before authentication as fatal', async () => {
+    const { raw, done } = scripted({ authMethods: ['EXTERNAL'] });
+    raw.send('BEGIN');
+    assert.match((await done).err.message, /BEGIN while WaitingForAuth/);
+  });
+
+  it('requires the initial nul byte', async () => {
+    const { client, server } = pair();
+    const done = runServer(server, { authTimeout: 0 });
+    client.write(`AUTH EXTERNAL ${hex(UID)}\r\n`);
+    assert.match((await done).err.message, /initial nul byte/);
+  });
+
+  it('drops a connection that never authenticates', async () => {
+    const { server } = pair();
+    const { err } = await runServer(server, { authTimeout: 40 });
+    assert.match(err.message, /Timed out waiting/);
+  });
+
+  it('reports a client that hangs up mid-handshake', async () => {
+    const { raw, done, client } = scripted({ authMethods: ['EXTERNAL'] });
+    raw.send('AUTH EXTERNAL');
+    await raw.expect(1);
+    client.end();
+    assert.match((await done).err.message, /closed the connection/);
+  });
+
+  it('leaves the bytes after BEGIN on the stream', async () => {
+    // The first message can share a packet with BEGIN. Swallowing it would
+    // desynchronise the connection before it had carried anything.
+    const { raw, done, server } = scripted({ authMethods: ['EXTERNAL'] });
+    raw.send(`AUTH EXTERNAL ${hex(UID)}`);
+    await raw.expect(1);
+    raw.write('BEGIN\r\nMESSAGEBYTES');
+    assert.ifError((await done).err);
+    await new Promise(resolve => setImmediate(resolve));
+    assert.strictEqual(server.read().toString(), 'MESSAGEBYTES');
+  });
+});
+
+describe('server handshake: who is allowed in', { timeout: 10000 }, () => {
+  const external = (opts, uid) => {
+    const { client, server } = pair();
+    const raw = rawClient(client);
+    const done = runServer(server, {
+      authMethods: ['EXTERNAL'],
+      authTimeout: 0,
+      ...opts
+    });
+    raw.write('\0');
+    raw.send(`AUTH EXTERNAL ${hex(uid)}`);
+    return { raw, done };
+  };
+
+  it('accepts a peer claiming to be the user we are running as', async () => {
+    const { raw } = external({}, UID);
+    assert.match(await raw.expect(1), /^OK /);
+  });
+
+  it('rejects a peer claiming to be somebody else', async () => {
+    // Node cannot read the peer's real credentials, so the claim is all there
+    // is; the narrowest useful default is to require it to be our own uid.
+    const { raw } = external({}, UID + 1);
+    assert.match(await raw.expect(1), /^REJECTED/);
+  });
+
+  it('rejects a uid that is not a number', async () => {
+    const { raw } = external({}, 'root');
+    assert.match(await raw.expect(1), /^REJECTED/);
+  });
+
+  it('hands the decision to authorize when one is given', async () => {
+    const seen = [];
+    const { raw } = external(
+      {
+        authorize: info => {
+          seen.push(info);
+          return info.uid === 4242;
+        }
+      },
+      4242
+    );
+    assert.match(await raw.expect(1), /^OK /);
+    assert.deepStrictEqual(seen, [{ mechanism: 'EXTERNAL', uid: 4242 }]);
+  });
+
+  it('lets authorize refuse someone the default would allow', async () => {
+    const { raw } = external({ authorize: () => false }, UID);
+    assert.match(await raw.expect(1), /^REJECTED/);
+  });
+});


### PR DESCRIPTION
`lib/server-handshake.js` was a transcript of someone's 2014 session played back verbatim:

```js
readLine(stream, hello => {
  console.log(['hello string: ', hello.toString(), hello]);
  stream.write('REJECTED EXTERNAL DBUS_COOKIE_SHA1 ANONYMOUS\r\n');
  readLine(stream, () => {
    stream.write(`DATA ${Buffer.from('org_freedesktop_general 642038150 b9ce247a...').toString('hex')}\r\n`);
```

A hardcoded cookie, a hardcoded GUID, an unconditional `REJECTED` followed by an `OK` that ignored whatever the client had said, and a `console.log` per connection. It authenticated nobody — it only resembled a handshake if the client happened to ask its questions in that order. ROADMAP §4.5 has said "either finish it or mark it experimental" for a while; this is the first half of finishing it.

## What replaces it

The state machine from [the specification](https://dbus.freedesktop.org/doc/dbus-specification.html#auth-protocol):

- `WaitingForAuth` / `WaitingForData` / `WaitingForBegin`, with `REJECTED`, `OK`, `DATA` and `ERROR` where the spec puts them
- **EXTERNAL**, **DBUS_COOKIE_SHA1** and **ANONYMOUS**
- a GUID generated per server, or supplied via `opts.guid`
- the initial nul byte required; unknown commands answered with `ERROR` and *not* treated as fatal, as the spec requires; `CANCEL` and `ERROR` starting over
- `NEGOTIATE_UNIX_FD` refused, since fd passing needs ancillary data Node cannot send (§2.8)
- an auth timeout, and a cap on rejected attempts — the spec's REJECTED-and-retry loop is otherwise unbounded for a client that keeps guessing

### EXTERNAL, honestly

The spec wants the client's uid checked against credentials the transport supplies out of band. Node has no `SO_PEERCRED`, so **the claim cannot be verified here**. The default is the narrowest useful rule — the peer must claim to be the user this process runs as, which is what a private per-user bus wants — and `opts.authorize({mechanism, uid})` replaces that judgement outright.

### DBUS_COOKIE_SHA1

Manages `~/.dbus-keyrings` itself: reuses a cookie that is still fresh, writes one when there is not, drops entries past their retention, refuses a keyring directory others can write (as the client already does), and compares the digest with `timingSafeEqual`.

## A readline bug this made reachable

`read()` hands back **one buffered chunk at a time**, and attaching a `'readable'` listener while an emission is in progress cannot schedule another one. That is exactly what a line-oriented conversation does — it starts the next read from inside the callback of the last, which runs inside that emit. So a peer that wrote its lines in separate writes stopped being read after the first:

```
readLine chained synchronously, three lines in three writes:
  before: ["one"]
  after:  ["one", "two", "three"]
```

It never bit the client, because a daemon answers one line per round trip and nothing is ever waiting when the next reader attaches. A server, whose client can pipeline, hits it immediately — the first symptom here was a client sending 12 `AUTH` lines and getting exactly one `REJECTED` back.

Fixed with a `process.nextTick` kick and a `finished` guard against racing a real `'readable'`.

## Tests

- `test/server-handshake.js` (25) — the happy paths run **our own client against our own server**, so both halves have to agree; the protocol cases script a raw client by hand, because a well-behaved client will not send `BEGIN` out of turn. Covers all three mechanisms, mechanism fall-through, the GUID, the nul byte, unknown commands, `CANCEL`, `NEGOTIATE_UNIX_FD`, the rejection cap, the auth timeout, a mid-handshake hangup, that **the bytes after `BEGIN` stay on the stream** (the first message can share a packet with it), and the EXTERNAL/`authorize` policy.
- `test/readline.js` (+3) — the three chained-read cases, which **hang** on the old code.

653 unit tests and 128 integration tests pass; lint, prettier and `tsc --noEmit` clean.

## Not in this PR

The broker. `createServer` still hands you a `DBusConnection` per socket with nothing routing between them — no `Hello`, no name ownership, no message routing. That is the other half of §4.5 and is next; this one is a prerequisite, since there was nothing to authenticate against before.