### PR TITLE
feat: parse and evaluate match rules

### DIFF
--- a/lib/match-rule.js
+++ b/lib/match-rule.js
@@ -1,0 +1,229 @@
+// Match rules: the language a client uses to say which messages it wants.
+//
+// https://dbus.freedesktop.org/doc/dbus-specification.html#message-bus-routing-match-rules
+//
+// A rule is comma-separated `key='value'` pairs, and every key that is present
+// must match for the message to be delivered. Absent keys match everything, so
+// the empty rule matches every message -- which is why AddMatch with an empty
+// string is a firehose rather than a no-op.
+//
+// This is the client's side of the story today (bus.addMatch just posts the
+// string to the daemon) and the routing table's side in lib/broker.js.
+
+const constants = require('./constants');
+
+const MESSAGE_TYPES = {
+  method_call: constants.messageType.methodCall,
+  method_return: constants.messageType.methodReturn,
+  error: constants.messageType.error,
+  signal: constants.messageType.signal
+};
+
+// argN and argNpath are limited to 0..63 by the specification; a rule naming
+// arg64 is an error rather than a filter that never matches, because silently
+// accepting it would hide a typo.
+const MAX_ARG = 63;
+
+const SCALAR_KEYS = new Set([
+  'type',
+  'sender',
+  'interface',
+  'member',
+  'path',
+  'path_namespace',
+  'destination',
+  'arg0namespace',
+  'eavesdrop'
+]);
+
+/**
+ * Split a rule into `[key, value]` pairs.
+ *
+ * Quoting follows libdbus: a single quote opens and closes a literal section,
+ * and outside one a backslash escapes the next character. A literal quote is
+ * therefore written by closing the section first -- `arg0='it'\''s'` is the
+ * seven characters `it's`. Commas and equals signs inside quotes are data.
+ */
+function tokenize(rule) {
+  const pairs = [];
+  let key = null;
+  let value = '';
+  let quoted = false;
+  let sawAny = false;
+
+  const flush = () => {
+    if (key === null) {
+      // A pair with no '=' at all. An empty trailing segment is the harmless
+      // result of a trailing comma; anything else is a malformed rule.
+      if (value.trim() !== '') {
+        throw new Error(`Match rule has a key with no value: "${value}"`);
+      }
+      return;
+    }
+    pairs.push([key.trim(), value]);
+    key = null;
+    value = '';
+  };
+
+  for (let i = 0; i < rule.length; i++) {
+    const c = rule[i];
+    if (quoted) {
+      if (c === "'") quoted = false;
+      else value += c;
+      continue;
+    }
+    switch (c) {
+      case "'":
+        quoted = true;
+        sawAny = true;
+        break;
+      case '\\': {
+        // A backslash at the very end escapes nothing. libdbus accepts the
+        // rule and drops it, and this has to agree: refusing a rule the daemon
+        // accepts would mean a client that works against dbus-daemon fails
+        // against lib/broker.js. Checked against dbus-daemon 1.14 -- see
+        // test/integration/match-rules.js.
+        const next = rule[++i];
+        if (next !== undefined) value += next;
+        break;
+      }
+      case '=':
+        if (key === null) {
+          key = value;
+          value = '';
+          sawAny = true;
+        } else {
+          value += c;
+        }
+        break;
+      case ',':
+        flush();
+        break;
+      default:
+        value += c;
+        if (c.trim() !== '') sawAny = true;
+    }
+  }
+  if (quoted) throw new Error('Match rule has an unterminated quote');
+  flush();
+  if (!sawAny && pairs.length === 0) return [];
+  return pairs;
+}
+
+/**
+ * Parse a match rule string.
+ *
+ * @throws if a key is unknown or a value is not usable -- the daemon answers
+ *   AddMatch with org.freedesktop.DBus.Error.MatchRuleInvalid for both, and a
+ *   rule that is quietly ignored is worse than one that is refused.
+ */
+function parse(rule) {
+  if (typeof rule !== 'string') {
+    throw new Error(`Match rule must be a string, got ${typeof rule}`);
+  }
+  const parsed = { args: new Map(), argPaths: new Map() };
+
+  for (const [key, value] of tokenize(rule)) {
+    const argMatch = /^arg(\d+)(path)?$/.exec(key);
+    if (argMatch) {
+      const index = Number(argMatch[1]);
+      if (index > MAX_ARG) {
+        throw new Error(
+          `Match rule argument index ${index} is above ${MAX_ARG}`
+        );
+      }
+      (argMatch[2] ? parsed.argPaths : parsed.args).set(index, value);
+      continue;
+    }
+    if (!SCALAR_KEYS.has(key)) {
+      throw new Error(`Match rule has an unknown key "${key}"`);
+    }
+    if (key === 'type' && !Object.hasOwn(MESSAGE_TYPES, value)) {
+      throw new Error(
+        `Match rule type "${value}" is not one of ${Object.keys(MESSAGE_TYPES).join(', ')}`
+      );
+    }
+    if (key === 'path_namespace' && parsed.path !== undefined) {
+      throw new Error('Match rule cannot use both path and path_namespace');
+    }
+    if (key === 'path' && parsed.path_namespace !== undefined) {
+      throw new Error('Match rule cannot use both path and path_namespace');
+    }
+    parsed[key] = value;
+  }
+  return parsed;
+}
+
+/**
+ * Is `path` at or below `namespace`?
+ *
+ * The prefix has to end on a path separator: `/foo/bar` is below `/foo` but
+ * `/foobar` is not, and a plain startsWith would say otherwise. The root
+ * namespace covers everything.
+ */
+function underNamespace(path, namespace) {
+  if (typeof path !== 'string') return false;
+  if (namespace === '/') return path.startsWith('/');
+  return path === namespace || path.startsWith(`${namespace}/`);
+}
+
+/** Is `name` the given bus name, or in its namespace? */
+function inNameNamespace(name, namespace) {
+  if (typeof name !== 'string') return false;
+  return name === namespace || name.startsWith(`${namespace}.`);
+}
+
+/**
+ * Does `msg` satisfy `rule`?
+ *
+ * `rule` may be a string or the result of parse(); routing parses once and
+ * matches many times, so both are accepted.
+ */
+function matches(rule, msg) {
+  const parsed = typeof rule === 'string' ? parse(rule) : rule;
+
+  if (parsed.type !== undefined && msg.type !== MESSAGE_TYPES[parsed.type]) {
+    return false;
+  }
+  // `sender` and `destination` are matched as written. The daemon resolves a
+  // well-known name to its owner before comparing, which it can do because it
+  // owns the name table; here there is nothing to resolve against, so a rule
+  // naming a well-known sender is compared against whatever the message says.
+  // lib/broker.js passes an already-resolved message.
+  for (const key of ['sender', 'destination', 'interface', 'member', 'path']) {
+    if (parsed[key] !== undefined && msg[key] !== parsed[key]) return false;
+  }
+  if (
+    parsed.path_namespace !== undefined &&
+    !underNamespace(msg.path, parsed.path_namespace)
+  ) {
+    return false;
+  }
+
+  const body = msg.body || [];
+  for (const [index, expected] of parsed.args) {
+    // Only string-like arguments can match; the spec restricts argN to
+    // STRING, OBJECT_PATH and SIGNATURE, and anything else simply does not.
+    if (typeof body[index] !== 'string' || body[index] !== expected) {
+      return false;
+    }
+  }
+  for (const [index, prefix] of parsed.argPaths) {
+    const value = body[index];
+    if (typeof value !== 'string') return false;
+    // argNpath matches in both directions: the argument may be the prefix of
+    // the rule or the rule the prefix of the argument, which is what makes it
+    // useful for watching a subtree from either end.
+    const ok =
+      value === prefix ||
+      (prefix.endsWith('/') && value.startsWith(prefix)) ||
+      (value.endsWith('/') && prefix.startsWith(value));
+    if (!ok) return false;
+  }
+  if (parsed.arg0namespace !== undefined) {
+    if (!inNameNamespace(body[0], parsed.arg0namespace)) return false;
+  }
+  return true;
+}
+
+module.exports = { parse, matches, tokenize, MESSAGE_TYPES, MAX_ARG };

--- a/test/integration/match-rules.js
+++ b/test/integration/match-rules.js
@@ -1,0 +1,170 @@
+// Does lib/match-rule.js agree with dbus-daemon about what a valid rule is?
+//
+// The grammar is described in prose rather than given as a formal syntax, so
+// the only way to be sure of the edge cases -- what a bare backslash does,
+// whether a comma inside quotes is data, whether whitespace around a value is
+// allowed -- is to ask the reference implementation. The rules below are the
+// corpus that established the current behaviour; a disagreement means either
+// our parser drifted or libdbus changed, and both are worth failing over.
+//
+// This matters for lib/broker.js, which has to accept whatever a client that
+// works against dbus-daemon sends it.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('assert');
+const dbus = require('../../index');
+const { parse } = require('../../lib/match-rule');
+
+const NO_BUS =
+  !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
+
+// Each entry is a rule the daemon is asked to accept or reject.
+const CORPUS = [
+  '',
+  "type='signal'",
+  'type=signal',
+  "type='shout'",
+  "sender='org.freedesktop.DBus'",
+  "interface='com.example.I',member='Pinged'",
+  "path='/com/example/Obj'",
+  "path_namespace='/com/example'",
+  "path='/a',path_namespace='/'",
+  "destination=':1.9'",
+  "arg0='alpha'",
+  "arg63='x'",
+  "arg64='x'",
+  "arg0path='/a/'",
+  "arg0namespace='com.example'",
+  "nonsense='x'",
+  "arg0='a,b'",
+  "arg0='a=b'",
+  'arg0=a=b',
+  "arg0='it'\\''s'",
+  'arg0=a\\,b',
+  "arg0='a''b'",
+  "arg0=''",
+  "type='signal',",
+  'justakey',
+  "arg0='unterminated",
+  'arg0=x\\',
+  "eavesdrop='true'",
+  "eavesdrop='false'",
+  "type='signal',eavesdrop='true',arg0namespace='org.freedesktop'",
+  "  type='signal'  ",
+  "type='signal' , member='X'"
+];
+
+describe(
+  'integration: match rules vs dbus-daemon',
+  { timeout: 30000, skip: NO_BUS },
+  () => {
+    let bus;
+
+    before(async () => {
+      bus = dbus.sessionBus();
+      await bus.getId();
+    });
+
+    after(() => {
+      if (bus) bus.connection.end();
+    });
+
+    const daemonAccepts = async rule => {
+      try {
+        await bus.invokeDbus({
+          member: 'AddMatch',
+          signature: 's',
+          body: [rule]
+        });
+      } catch {
+        return false;
+      }
+      // Take it back off, so a corpus of thirty rules does not leave the daemon
+      // matching everything for the rest of the suite.
+      await bus
+        .invokeDbus({ member: 'RemoveMatch', signature: 's', body: [rule] })
+        .catch(() => {});
+      return true;
+    };
+
+    const weAccept = rule => {
+      try {
+        parse(rule);
+        return true;
+      } catch {
+        return false;
+      }
+    };
+
+    it('agrees with the daemon on every rule in the corpus', async () => {
+      const disagreements = [];
+      for (const rule of CORPUS) {
+        const theirs = await daemonAccepts(rule);
+        const ours = weAccept(rule);
+        if (ours !== theirs) {
+          disagreements.push(
+            `${JSON.stringify(rule)}: we ${ours ? 'accept' : 'reject'}, ` +
+              `the daemon ${theirs ? 'accepts' : 'rejects'}`
+          );
+        }
+      }
+      assert.deepStrictEqual(disagreements, []);
+    });
+
+    it('rejects the things the daemon rejects, for the reasons we claim', async () => {
+      // Spot-check that our refusals are not accidental: the message should name
+      // what is wrong, since these become MatchRuleInvalid to a caller.
+      const cases = [
+        ["type='shout'", /type "shout" is not one of/],
+        ["nonsense='x'", /unknown key "nonsense"/],
+        ["arg64='x'", /above 63/],
+        ["arg0='unterminated", /unterminated quote/],
+        ["path='/a',path_namespace='/'", /both path and path_namespace/]
+      ];
+      for (const [rule, message] of cases) {
+        assert.throws(() => parse(rule), { message }, rule);
+        assert.strictEqual(await daemonAccepts(rule), false, rule);
+      }
+    });
+
+    it('delivers a signal the way a rule we parsed says it should', async () => {
+      // The other half: not just that the daemon accepts our rules, but that our
+      // matcher agrees with the daemon's routing for the same rule.
+      const { matches } = require('../../lib/match-rule');
+      const rule =
+        "type='signal',sender='org.freedesktop.DBus'," +
+        "interface='org.freedesktop.DBus',member='NameOwnerChanged'," +
+        "arg0='com.example.MatchRuleProbe'";
+      await bus.invokeDbus({
+        member: 'AddMatch',
+        signature: 's',
+        body: [rule]
+      });
+
+      const delivered = [];
+      bus.connection.on('message', msg => {
+        if (msg.member === 'NameOwnerChanged') delivered.push(msg);
+      });
+
+      const other = dbus.sessionBus();
+      await other.getId();
+      await new Promise((resolve, reject) =>
+        other.requestName('com.example.MatchRuleProbe', 0, err =>
+          err ? reject(err) : resolve()
+        )
+      );
+      await new Promise(resolve => setTimeout(resolve, 300));
+      other.connection.end();
+
+      assert.ok(delivered.length > 0, 'the daemon delivered it');
+      const parsed = parse(rule);
+      for (const msg of delivered) {
+        assert.strictEqual(
+          matches(parsed, msg),
+          true,
+          `we would not have delivered ${JSON.stringify(msg.body)}`
+        );
+      }
+    });
+  }
+);

--- a/test/match-rule.js
+++ b/test/match-rule.js
@@ -1,0 +1,289 @@
+// Match rules.
+//
+// https://dbus.freedesktop.org/doc/dbus-specification.html#message-bus-routing-match-rules
+
+const { describe, it } = require('node:test');
+const assert = require('assert');
+const { parse, matches, tokenize } = require('../lib/match-rule');
+const constants = require('../lib/constants');
+
+const signal = (overrides = {}) => ({
+  type: constants.messageType.signal,
+  sender: ':1.7',
+  path: '/com/example/Obj',
+  interface: 'com.example.Iface',
+  member: 'Pinged',
+  body: [],
+  ...overrides
+});
+
+describe('match rules: parsing', () => {
+  it('reads the keys the specification defines', () => {
+    const rule = parse(
+      "type='signal',sender='org.freedesktop.DBus',interface='com.example.I'," +
+        "member='Pinged',path='/com/example/Obj',destination=':1.9'"
+    );
+    assert.strictEqual(rule.type, 'signal');
+    assert.strictEqual(rule.sender, 'org.freedesktop.DBus');
+    assert.strictEqual(rule['interface'], 'com.example.I');
+    assert.strictEqual(rule.member, 'Pinged');
+    assert.strictEqual(rule.path, '/com/example/Obj');
+    assert.strictEqual(rule.destination, ':1.9');
+  });
+
+  it('reads argN, argNpath and arg0namespace', () => {
+    const rule = parse(
+      "arg0='first',arg3='fourth',arg1path='/a/b/',arg0namespace='com.example'"
+    );
+    assert.strictEqual(rule.args.get(0), 'first');
+    assert.strictEqual(rule.args.get(3), 'fourth');
+    assert.strictEqual(rule.argPaths.get(1), '/a/b/');
+    assert.strictEqual(rule.arg0namespace, 'com.example');
+  });
+
+  it('treats an empty rule as matching everything', () => {
+    const rule = parse('');
+    assert.deepStrictEqual(rule.args.size, 0);
+    assert.strictEqual(matches(rule, signal()), true);
+    assert.strictEqual(
+      matches(rule, signal({ type: constants.messageType.methodCall })),
+      true
+    );
+  });
+
+  it('accepts values with no quotes at all', () => {
+    // The daemon is lenient here, and plenty of code in the wild writes
+    // type=signal without them.
+    const rule = parse('type=signal,member=Pinged');
+    assert.strictEqual(rule.type, 'signal');
+    assert.strictEqual(rule.member, 'Pinged');
+  });
+
+  describe('quoting', () => {
+    it('keeps a comma inside quotes as data', () => {
+      const rule = parse("arg0='a,b',member='X'");
+      assert.strictEqual(rule.args.get(0), 'a,b');
+      assert.strictEqual(rule.member, 'X');
+    });
+
+    it('keeps an equals sign inside quotes as data', () => {
+      assert.strictEqual(parse("arg0='a=b'").args.get(0), 'a=b');
+    });
+
+    it('takes only the first equals sign as the separator', () => {
+      assert.strictEqual(parse('arg0=a=b').args.get(0), 'a=b');
+    });
+
+    it("embeds a literal quote by closing the section: it'\\''s", () => {
+      assert.strictEqual(parse("arg0='it'\\''s'").args.get(0), "it's");
+    });
+
+    it('lets a backslash outside quotes escape the next character', () => {
+      assert.strictEqual(parse('arg0=a\\,b').args.get(0), 'a,b');
+      assert.strictEqual(parse("arg0=a\\'b").args.get(0), "a'b");
+    });
+
+    it('joins adjacent quoted sections', () => {
+      assert.strictEqual(parse("arg0='a''b'").args.get(0), 'ab');
+    });
+
+    it('allows an empty value', () => {
+      assert.strictEqual(parse("arg0=''").args.get(0), '');
+    });
+
+    it('drops a backslash at the very end, as libdbus does', () => {
+      // Not an error: dbus-daemon accepts this rule, and refusing it would
+      // mean a client that works against the daemon fails against our broker.
+      assert.strictEqual(parse('arg0=x\\').args.get(0), 'x');
+    });
+
+    it('tolerates a trailing comma', () => {
+      assert.strictEqual(parse("type='signal',").type, 'signal');
+    });
+
+    it('exposes the tokenizer, because the quoting is the fiddly part', () => {
+      assert.deepStrictEqual(tokenize("a='1',b='2'"), [
+        ['a', '1'],
+        ['b', '2']
+      ]);
+    });
+  });
+
+  describe('what it refuses', () => {
+    const bad = [
+      ["type='shout'", /type "shout" is not one of/],
+      ["nonsense='x'", /unknown key "nonsense"/],
+      ["arg64='x'", /argument index 64 is above 63/],
+      ["arg0='unterminated", /unterminated quote/],
+      ["path='/a',path_namespace='/'", /both path and path_namespace/],
+      ["path_namespace='/',path='/a'", /both path and path_namespace/],
+      ['justakey', /key with no value/]
+    ];
+    for (const [rule, message] of bad) {
+      it(`refuses ${JSON.stringify(rule)}`, () =>
+        assert.throws(() => parse(rule), { message }));
+    }
+
+    it('refuses a rule that is not a string', () => {
+      assert.throws(() => parse(42), /must be a string/);
+    });
+  });
+});
+
+describe('match rules: matching', () => {
+  it('matches on type', () => {
+    assert.strictEqual(matches("type='signal'", signal()), true);
+    assert.strictEqual(matches("type='method_call'", signal()), false);
+  });
+
+  it('matches on sender, interface, member, path and destination', () => {
+    const msg = signal({ destination: ':1.9' });
+    assert.strictEqual(matches("sender=':1.7'", msg), true);
+    assert.strictEqual(matches("sender=':1.8'", msg), false);
+    assert.strictEqual(matches("interface='com.example.Iface'", msg), true);
+    assert.strictEqual(matches("member='Pinged'", msg), true);
+    assert.strictEqual(matches("member='Ponged'", msg), false);
+    assert.strictEqual(matches("path='/com/example/Obj'", msg), true);
+    assert.strictEqual(matches("destination=':1.9'", msg), true);
+    assert.strictEqual(matches("destination=':1.1'", msg), false);
+  });
+
+  it('requires every key present in the rule to match', () => {
+    const rule = "type='signal',member='Pinged',path='/com/example/Obj'";
+    assert.strictEqual(matches(rule, signal()), true);
+    assert.strictEqual(matches(rule, signal({ member: 'Other' })), false);
+  });
+
+  describe('path_namespace', () => {
+    it('matches the namespace itself and anything under it', () => {
+      const rule = "path_namespace='/com/example'";
+      assert.strictEqual(matches(rule, signal({ path: '/com/example' })), true);
+      assert.strictEqual(
+        matches(rule, signal({ path: '/com/example/Obj' })),
+        true
+      );
+      assert.strictEqual(
+        matches(rule, signal({ path: '/com/example/a/b/c' })),
+        true
+      );
+    });
+
+    it('stops at a path separator, not at a character', () => {
+      // The trap a plain startsWith falls into.
+      assert.strictEqual(
+        matches(
+          "path_namespace='/com/example'",
+          signal({ path: '/com/exampleX' })
+        ),
+        false
+      );
+    });
+
+    it("treats '/' as everything", () => {
+      assert.strictEqual(matches("path_namespace='/'", signal()), true);
+    });
+  });
+
+  describe('argN', () => {
+    it('matches a string argument exactly', () => {
+      const msg = signal({ body: ['alpha', 'beta'] });
+      assert.strictEqual(matches("arg0='alpha'", msg), true);
+      assert.strictEqual(matches("arg1='beta'", msg), true);
+      assert.strictEqual(matches("arg1='alpha'", msg), false);
+      assert.strictEqual(matches("arg0='alpha',arg1='beta'", msg), true);
+    });
+
+    it('does not match a missing argument', () => {
+      assert.strictEqual(matches("arg2='x'", signal({ body: ['a'] })), false);
+    });
+
+    it('does not match a non-string argument', () => {
+      // The spec restricts argN to STRING, OBJECT_PATH and SIGNATURE.
+      assert.strictEqual(matches("arg0='7'", signal({ body: [7] })), false);
+      assert.strictEqual(
+        matches("arg0='true'", signal({ body: [true] })),
+        false
+      );
+    });
+  });
+
+  describe('argNpath', () => {
+    it('matches an exact path', () => {
+      const msg = signal({ body: ['/a/b'] });
+      assert.strictEqual(matches("arg0path='/a/b'", msg), true);
+    });
+
+    it('matches when the rule is a prefix of the argument', () => {
+      assert.strictEqual(
+        matches("arg0path='/a/'", signal({ body: ['/a/b/c'] })),
+        true
+      );
+    });
+
+    it('matches when the argument is a prefix of the rule', () => {
+      // Both directions, which is what lets a watcher and a sender agree on a
+      // subtree without knowing which is more specific.
+      assert.strictEqual(
+        matches("arg0path='/a/b/c'", signal({ body: ['/a/'] })),
+        true
+      );
+    });
+
+    it('does not match an unrelated path', () => {
+      assert.strictEqual(
+        matches("arg0path='/a/'", signal({ body: ['/z/b'] })),
+        false
+      );
+    });
+  });
+
+  describe('arg0namespace', () => {
+    it('matches the name itself and anything below it', () => {
+      const rule = "arg0namespace='com.example'";
+      assert.strictEqual(
+        matches(rule, signal({ body: ['com.example'] })),
+        true
+      );
+      assert.strictEqual(
+        matches(rule, signal({ body: ['com.example.Service'] })),
+        true
+      );
+    });
+
+    it('stops at a dot, not at a character', () => {
+      assert.strictEqual(
+        matches(
+          "arg0namespace='com.example'",
+          signal({ body: ['com.exampleX'] })
+        ),
+        false
+      );
+    });
+  });
+
+  it('accepts a pre-parsed rule, so routing parses once', () => {
+    const rule = parse("type='signal',member='Pinged'");
+    assert.strictEqual(matches(rule, signal()), true);
+    assert.strictEqual(matches(rule, signal({ member: 'Nope' })), false);
+  });
+
+  it('matches a NameOwnerChanged rule of the shape everyone writes', () => {
+    const rule = parse(
+      "type='signal',sender='org.freedesktop.DBus'," +
+        "interface='org.freedesktop.DBus',member='NameOwnerChanged'," +
+        "arg0='com.example.Watched'"
+    );
+    const msg = signal({
+      sender: 'org.freedesktop.DBus',
+      path: '/org/freedesktop/DBus',
+      interface: 'org.freedesktop.DBus',
+      member: 'NameOwnerChanged',
+      body: ['com.example.Watched', '', ':1.42']
+    });
+    assert.strictEqual(matches(rule, msg), true);
+    assert.strictEqual(
+      matches(rule, { ...msg, body: ['com.example.Other', '', ':1.42'] }),
+      false
+    );
+  });
+});


### PR DESCRIPTION
The routing table `lib/broker.js` needs, and the first piece of the bus side of ROADMAP §4.5 that stands on its own. Nothing in the library evaluates match rules today — `bus.addMatch()` posts the string to the daemon and lets it decide.

## The grammar had to be established, not read

A rule is comma-separated `key='value'` pairs, and every key present must match. The *keys* are documented. The *grammar* is described in prose, which leaves the cases that actually bite unstated: what a bare backslash does, whether a comma inside quotes is data, whether whitespace around a value is allowed.

So I asked the reference implementation. A corpus of 32 rules goes to `dbus-daemon` 1.14 via `AddMatch`, and its verdict is compared with this parser's:

```
  ok  "arg0='a,b'"                    ours=accept  daemon=accept
  ok  "arg0='it'\\''s'"               ours=accept  daemon=accept
  ok  "arg0='a''b'"                   ours=accept  daemon=accept
  ok  "type='signal' , member='X'"    ours=reject  daemon=reject
  ok  "arg64='x'"                     ours=reject  daemon=reject
 DIFF "arg0=x\\"                      ours=reject  daemon=accept

agree on 31/32
```

The one disagreement: **libdbus accepts a rule ending in a backslash** and drops it, where refusing looked more correct to me. Refusing is the wrong call — it would mean a client that works against `dbus-daemon` fails against our broker — so this follows libdbus. `test/integration/match-rules.js` keeps the whole corpus agreeing, so the grammar cannot drift from the reference in either direction.

## Two places the obvious implementation is wrong

- **`path_namespace` and `arg0namespace` must stop on a separator.** A plain `startsWith` says `/com/exampleX` is under `/com/example`, and that `com.exampleEvil` is in the `com.example` namespace. Both are tested.
- **`argNpath` matches in both directions** — the argument may be a prefix of the rule, or the rule a prefix of the argument. That is what lets a watcher and a sender agree on a subtree without either knowing which is more specific.

Also: `argN` only matches string-like arguments, since the spec restricts it to `STRING`, `OBJECT_PATH` and `SIGNATURE`. A rule of `arg0='7'` does not match a body of `[7]`.

## API

```js
const { parse, matches } = require('dbus-native/lib/match-rule'); // internal for now
const rule = parse("type='signal',member='Pinged',arg0namespace='com.example'");
matches(rule, msg); // -> boolean
```

`matches` takes a string or a pre-parsed rule, because routing parses once and matches many times per message.

Not exported from `index.js`: it exists for the broker, and there is no reason to freeze the shape as public API before the broker has used it.

## Tests

39 unit tests, plus 3 integration tests — the last checks the other direction, that a `NameOwnerChanged` the daemon actually delivered would also have been delivered by our matcher.

664 unit tests and 131 integration tests pass; lint, prettier and `tsc --noEmit` clean.

## Next

`lib/broker.js`: unique names, `RequestName`/`ReleaseName` with the queue, `NameOwnerChanged`, and routing — unicast by destination, signals by these rules. Stacked on #353, since a client has to get through the handshake before there is anything to route.