### PR TITLE
feat: an in-process message bus

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -834,15 +834,45 @@ had simply gone stale.
 
 ### 4.5 Finish the server/broker
 
-`lib/server.js` plus `lib/server-handshake.js` are a stub: the handshake replies
-with a hardcoded cookie and GUID copied from someone's 2014 session, and logs to
-stdout unconditionally. Either finish it into a usable in-process broker — which
-would give the test suite a dependency-free bus and let contributors run tests
-without installing `dbus-daemon` — or mark it clearly experimental.
+**Done**, in three parts.
 
-Note the `test/integration/` suite added in this pass already gives us real
-coverage against `dbus-daemon`, so this is now an ergonomics win rather than a
-blocker.
+`lib/server-handshake.js` was a transcript of someone's 2014 session played
+back verbatim — a hardcoded cookie and GUID, an unconditional `REJECTED`, and a
+`console.log` per connection. It is now the state machine from the
+specification, with `EXTERNAL`, `DBUS_COOKIE_SHA1` and `ANONYMOUS`, a GUID per
+server, an auth timeout, and an `authorize` hook. `EXTERNAL` cannot be verified
+the way the spec intends, because Node has no `SO_PEERCRED`; the default is that
+the peer must claim to be the user this process runs as.
+
+`lib/match-rule.js` parses and evaluates match rules. The grammar is described
+in prose rather than given formally, so the edge cases were established against
+`dbus-daemon` and `test/integration/match-rules.js` keeps the two agreeing.
+
+`lib/broker.js` is the bus: unique names, `RequestName`/`ReleaseName` with the
+flags and the queue, the rest of `org.freedesktop.DBus`, and routing — unicast
+by destination, signals by match rule. `npm run test:integration:broker` runs
+the whole integration suite against it, and all of it passes, which was the
+point: contributors no longer need `dbus-daemon` installed.
+
+Three things it deliberately is not:
+
+- **No security policy.** Any client may own any name and call anyone. The
+  system bus refuses arbitrary names for good reason; this does not.
+- **No service activation.** `StartServiceByName` always answers
+  `ServiceUnknown`.
+- **No eavesdropping.** `BecomeMonitor` is unimplemented, so nothing sees
+  unicast traffic addressed elsewhere and `dbus-monitor` is of limited use
+  against it.
+
+One piece of internal debt worth naming: **the broker re-encodes what it
+forwards.** It unmarshals a message and marshals it again, so every value has to
+survive the round trip — and by default a 64-bit integer does not, which is why
+the broker's own connections read them as BigInt. A router should keep the body
+bytes and rewrite only the header fields it must; that needs the message layer
+to hand back the raw frame alongside the parsed one, which it does not do today.
+Until then the round trip is faithful but the cost is real, and a value shape
+the reader and writer disagree about would show up as a routing bug rather than
+a parsing one.
 
 ### 4.6 Signals on the client side
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -32,16 +32,60 @@ const dbus = require('dbus-native');
 | `dbus.systemBus()`             | `MessageBus`     | connects to `$DBUS_SYSTEM_BUS_ADDRESS`, or the standard system socket |
 | `dbus.createClient(opts?)`     | `MessageBus`     | connects to whatever `opts` describes                                 |
 | `dbus.createConnection(opts?)` | `DBusConnection` | the transport alone, with no `MessageBus` on top                      |
-| `dbus.createServer(handler?)`  | `DBusServer`     | **not production infrastructure** — see below                         |
+| `dbus.createServer(handler?)`  | `DBusServer`     | accepts peer-to-peer connections — see below                          |
+| `dbus.createBroker(opts?)`     | `DBusBroker`     | a message bus, not a replacement for `dbus-daemon` — see below        |
 
 `sessionBus` and `systemBus` are `createClient` with a `busAddress` filled in;
 all three take the same options.
 
-> `createServer` exists but `lib/server-handshake.js` is a stub: it replies
-> with a hardcoded GUID and cookie and logs to stdout. Do not treat it as
-> working infrastructure. `handler` is called with a `DBusConnection` per
-> accepted socket, and the returned object has a `listen(...)` delegating to
-> `net.Server#listen`.
+### createServer
+
+`handler` is called with a `DBusConnection` per accepted socket, and the
+returned object has a `listen(...)` delegating to `net.Server#listen`. The
+server side of the SASL handshake is real as of 0.12 — it offers `EXTERNAL` and
+`DBUS_COOKIE_SHA1`, generates a GUID per server, and takes `authorize`,
+`anonymous`, `authMethods` and `authTimeout` options. This is peer-to-peer:
+nothing routes between two connections and no names are assigned, so a client
+must connect with `direct: true` and address the peer directly.
+
+### createBroker
+
+A message bus, in process:
+
+```js
+const broker = dbus.createBroker();
+broker.listen((err, address) => {
+  const bus = dbus.createClient({ busAddress: address });
+});
+```
+
+| member                       |                                                        |
+| ---------------------------- | ------------------------------------------------------ |
+| `broker.listen(where?, cb?)` | `{socket}`, `{port, host}`, or a temporary unix socket |
+| `broker.address()`           | the address to connect to, once listening              |
+| `broker.names()`             | the names on the bus, as `ListNames` would report them |
+| `broker.close(cb?)`          | drop every client and stop listening                   |
+| `broker.guid`, `broker.id`   | the server GUID and the bus id                         |
+
+Events: `listening`, `connection`, `hello`, `disconnect`, `error`,
+`clientError`.
+
+It implements `org.freedesktop.DBus` — `Hello`, `RequestName`/`ReleaseName`
+with the full flag and queue behaviour, `ListNames`,
+`ListActivatableNames`, `NameHasOwner`, `GetNameOwner`, `ListQueuedOwners`,
+`AddMatch`/`RemoveMatch`, `GetId`, `GetConnectionUnixUser`,
+`GetConnectionUnixProcessID`, `StartServiceByName`,
+`UpdateActivationEnvironment`, plus `Peer`, `Introspectable` and
+`Properties` — and it routes: unicast by destination, signals by match rule,
+`NameOwnerChanged`/`NameAcquired`/`NameLost` as names change hands.
+
+**What it is for** is a bus the test suite can start without `dbus-daemon`
+installed; `npm run test:integration:broker` runs the whole integration suite
+against it. **It is not a replacement for `dbus-daemon`**: there is no security
+policy, so any client may own any name and call anyone; no service activation,
+so `StartServiceByName` always fails; no fd passing; and no eavesdropping, so
+`dbus-monitor` cannot see traffic addressed elsewhere. Do not put it on a
+socket other processes can reach.
 
 ### Connection options
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -292,6 +292,58 @@ export function createServer(
   handler?: (conn: DBusConnection) => void
 ): DBusServer;
 
+/** What the server side of the handshake learnt about a peer. */
+export interface PeerIdentity {
+  mechanism: string | null;
+  /** the uid the peer claimed; Node cannot verify it */
+  uid: number | null;
+}
+
+export interface BrokerOptions {
+  /** the server GUID; generated when absent */
+  guid?: string;
+  /** mechanisms to offer; default ['EXTERNAL', 'DBUS_COOKIE_SHA1'] */
+  authMethods?: string[];
+  /** also offer ANONYMOUS, which authenticates nobody */
+  anonymous?: boolean;
+  /** the last word on whether to accept a peer */
+  authorize?: (identity: PeerIdentity) => boolean;
+  /** keyring context for DBUS_COOKIE_SHA1 */
+  cookieContext?: string;
+  /** ms before an unauthenticated connection is dropped; 0 waits forever */
+  authTimeout?: number;
+}
+
+export interface BrokerListenOptions {
+  socket?: string;
+  port?: number;
+  host?: string;
+}
+
+/**
+ * An in-process message bus.
+ *
+ * Enough of one to route between clients, which `createServer` alone never
+ * did. **Not** a replacement for `dbus-daemon`: no security policy, no service
+ * activation, no fd passing, no eavesdropping. See docs/api.md#createbroker.
+ */
+export interface DBusBroker extends EventEmitter {
+  listen(
+    where?: BrokerListenOptions,
+    cb?: (err: Error | null, address: string) => void
+  ): DBusBroker;
+  listen(cb: (err: Error | null, address: string) => void): DBusBroker;
+  /** the address to connect to, once listening */
+  address(): string | null;
+  /** the names on the bus, as ListNames would report them */
+  names(): string[];
+  close(cb?: () => void): DBusBroker;
+  readonly guid: string;
+  readonly id: string;
+}
+
+export function createBroker(opts?: BrokerOptions): DBusBroker;
+
 // ---------------------------------------------------------------------------
 // Calls
 // ---------------------------------------------------------------------------

--- a/index.js
+++ b/index.js
@@ -209,11 +209,16 @@ function createConnection(opts) {
   };
 
   const handshake = opts.server ? serverHandshake : clientHandshake;
-  handshake(stream, opts, (error, guid) => {
+  handshake(stream, opts, (error, guid, identity) => {
     if (error) {
       return self.emit('error', error);
     }
     self.guid = guid;
+    // What the server side learnt about the peer while authenticating: the
+    // mechanism, and the uid it claimed. Undefined on a client connection,
+    // where there is nothing to learn. lib/broker.js answers
+    // GetConnectionUnixUser from it.
+    if (identity) self.identity = identity;
     self.emit('connect');
     message.unmarshalMessages(
       stream,
@@ -320,3 +325,8 @@ module.exports.isValidBusName = names.isValidBusName;
 module.exports.createConnection = createConnection;
 
 module.exports.createServer = server.createServer;
+
+// An in-process message bus. Not a replacement for dbus-daemon -- no security
+// policy, no service activation -- but enough of one to route between clients,
+// which is what `createServer` on its own never did. See lib/broker.js.
+module.exports.createBroker = require('./lib/broker').createBroker;

--- a/lib/broker.js
+++ b/lib/broker.js
@@ -1,0 +1,829 @@
+// An in-process message bus.
+//
+// `createServer` has always handed you one `DBusConnection` per accepted socket
+// with nothing between them: two clients could connect and neither could
+// address the other, because nothing assigned names or routed anything. This is
+// the missing part -- name ownership, org.freedesktop.DBus, and routing.
+//
+// What it is for: a bus the test suite can start in-process, so running the
+// integration tests does not require dbus-daemon to be installed. It is not a
+// replacement for dbus-daemon. There is no security policy, no service
+// activation, no fd passing, and no eavesdropping; see the notes at the bottom.
+//
+// https://dbus.freedesktop.org/doc/dbus-specification.html#message-bus
+
+const { EventEmitter } = require('events');
+const net = require('net');
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Required lazily-ish, as lib/server.js does: index.js requires this module
+// while it is still assembling its own exports, so createConnection is only
+// reachable by the time a socket is accepted.
+const dbus = require('../index');
+const constants = require('./constants');
+const { parse: parseRule, matches } = require('./match-rule');
+const { isValidBusName } = require('./names');
+const { generateGuid } = require('./server-handshake');
+
+const BUS_NAME = 'org.freedesktop.DBus';
+const BUS_PATH = '/org/freedesktop/DBus';
+const BUS_INTERFACE = 'org.freedesktop.DBus';
+
+/** RequestName flags. */
+const NAME_FLAG = {
+  ALLOW_REPLACEMENT: 1,
+  REPLACE_EXISTING: 2,
+  DO_NOT_QUEUE: 4
+};
+
+/** RequestName results. */
+const REQUEST_NAME = {
+  PRIMARY_OWNER: 1,
+  IN_QUEUE: 2,
+  EXISTS: 3,
+  ALREADY_OWNER: 4
+};
+
+/** ReleaseName results. */
+const RELEASE_NAME = {
+  RELEASED: 1,
+  NON_EXISTENT: 2,
+  NOT_OWNER: 3
+};
+
+const ERR = name => `org.freedesktop.DBus.Error.${name}`;
+
+// The bus's own introspection data, so `busctl introspect org.freedesktop.DBus
+// /org/freedesktop/DBus` and gdbus both work against it.
+const BUS_INTROSPECTION = `<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+    "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="org.freedesktop.DBus">
+    <method name="Hello">
+      <arg direction="out" type="s"/>
+    </method>
+    <method name="RequestName">
+      <arg direction="in" type="s"/>
+      <arg direction="in" type="u"/>
+      <arg direction="out" type="u"/>
+    </method>
+    <method name="ReleaseName">
+      <arg direction="in" type="s"/>
+      <arg direction="out" type="u"/>
+    </method>
+    <method name="ListNames">
+      <arg direction="out" type="as"/>
+    </method>
+    <method name="ListActivatableNames">
+      <arg direction="out" type="as"/>
+    </method>
+    <method name="NameHasOwner">
+      <arg direction="in" type="s"/>
+      <arg direction="out" type="b"/>
+    </method>
+    <method name="GetNameOwner">
+      <arg direction="in" type="s"/>
+      <arg direction="out" type="s"/>
+    </method>
+    <method name="ListQueuedOwners">
+      <arg direction="in" type="s"/>
+      <arg direction="out" type="as"/>
+    </method>
+    <method name="AddMatch">
+      <arg direction="in" type="s"/>
+    </method>
+    <method name="RemoveMatch">
+      <arg direction="in" type="s"/>
+    </method>
+    <method name="GetId">
+      <arg direction="out" type="s"/>
+    </method>
+    <method name="GetConnectionUnixUser">
+      <arg direction="in" type="s"/>
+      <arg direction="out" type="u"/>
+    </method>
+    <method name="GetConnectionUnixProcessID">
+      <arg direction="in" type="s"/>
+      <arg direction="out" type="u"/>
+    </method>
+    <method name="StartServiceByName">
+      <arg direction="in" type="s"/>
+      <arg direction="in" type="u"/>
+      <arg direction="out" type="u"/>
+    </method>
+    <method name="UpdateActivationEnvironment">
+      <arg direction="in" type="a{ss}"/>
+    </method>
+    <signal name="NameOwnerChanged">
+      <arg type="s"/>
+      <arg type="s"/>
+      <arg type="s"/>
+    </signal>
+    <signal name="NameAcquired">
+      <arg type="s"/>
+    </signal>
+    <signal name="NameLost">
+      <arg type="s"/>
+    </signal>
+    <property name="Features" type="as" access="read"/>
+    <property name="Interfaces" type="as" access="read"/>
+  </interface>
+  <interface name="org.freedesktop.DBus.Introspectable">
+    <method name="Introspect">
+      <arg direction="out" type="s"/>
+    </method>
+  </interface>
+  <interface name="org.freedesktop.DBus.Peer">
+    <method name="Ping"/>
+    <method name="GetMachineId">
+      <arg direction="out" type="s"/>
+    </method>
+  </interface>
+  <interface name="org.freedesktop.DBus.Properties">
+    <method name="Get">
+      <arg direction="in" type="s"/>
+      <arg direction="in" type="s"/>
+      <arg direction="out" type="v"/>
+    </method>
+    <method name="GetAll">
+      <arg direction="in" type="s"/>
+      <arg direction="out" type="a{sv}"/>
+    </method>
+  </interface>
+</node>`;
+
+/**
+ * A machine id, for Peer.GetMachineId.
+ *
+ * The real file is what other implementations compare against, so it is
+ * preferred; a made-up one is only so the method has something to answer with
+ * on a machine that has none.
+ */
+function machineId() {
+  for (const file of ['/var/lib/dbus/machine-id', '/etc/machine-id']) {
+    try {
+      const id = fs.readFileSync(file, 'ascii').trim();
+      if (/^[0-9a-f]{32}$/.test(id)) return id;
+    } catch {
+      /* try the next one */
+    }
+  }
+  return crypto.createHash('md5').update(os.hostname()).digest('hex');
+}
+
+/**
+ * Start a message bus.
+ *
+ * `opts`:
+ *   guid, authMethods, anonymous, authorize, cookieContext, authTimeout
+ *     -- passed to the server handshake, see lib/server-handshake.js
+ *
+ * Emits 'connection' (a client joined, before Hello), 'disconnect', and
+ * 'error'.
+ */
+function createBroker(opts = {}) {
+  const broker = new EventEmitter();
+  const guid = opts.guid || generateGuid();
+  const id = generateGuid();
+  const machine = machineId();
+
+  /** Every connected client, whether or not it has said Hello. */
+  const clients = new Set();
+  /** ':1.N' -> client */
+  const unique = new Map();
+  /** well-known name -> [{client, allowReplacement}], index 0 is the owner */
+  const names = new Map();
+  let nextUnique = 1;
+  let server = null;
+  let listenAddress = null;
+
+  // ---------------------------------------------------------------- sending
+
+  function send(client, msg) {
+    if (!client || client.gone) return false;
+    try {
+      client.conn.message({
+        serial: client.serial++,
+        sender: BUS_NAME,
+        ...msg
+      });
+      return true;
+    } catch (err) {
+      // A client that went away mid-write is not worth reporting. Anything
+      // else is a bug in here, and it is thrown rather than swallowed: a
+      // reply the bus failed to marshal leaves the caller waiting forever,
+      // which is the worst way for a bug here to present itself.
+      if (client.gone) return false;
+      throw err;
+    }
+  }
+
+  const reply = (client, call, signature, body) =>
+    send(client, {
+      type: constants.messageType.methodReturn,
+      replySerial: call.serial,
+      destination: call.sender,
+      ...(signature ? { signature, body } : {})
+    });
+
+  const replyError = (client, call, name, text) =>
+    send(client, {
+      type: constants.messageType.error,
+      replySerial: call.serial,
+      destination: call.sender,
+      errorName: name,
+      signature: 's',
+      body: [text]
+    });
+
+  /** Deliver a signal to every client whose rules ask for it. */
+  function broadcast(signal) {
+    const msg = {
+      type: constants.messageType.signal,
+      sender: BUS_NAME,
+      ...signal
+    };
+    for (const client of clients) {
+      if (!client.name) continue;
+      // A client sees its own broadcast if it asked for it -- checked against
+      // dbus-daemon, which delivers to the sender too.
+      if (client.rules.some(rule => matches(rule.parsed, msg))) {
+        send(client, msg);
+      }
+    }
+  }
+
+  const nameOwnerChanged = (name, from, to) =>
+    broadcast({
+      path: BUS_PATH,
+      interface: BUS_INTERFACE,
+      member: 'NameOwnerChanged',
+      signature: 'sss',
+      body: [name, from, to]
+    });
+
+  // NameAcquired and NameLost go to the connection concerned whether or not it
+  // has a matching rule; libdbus's own RequestName depends on that.
+  const nameSignal = (client, member, name) =>
+    send(client, {
+      type: constants.messageType.signal,
+      path: BUS_PATH,
+      interface: BUS_INTERFACE,
+      member,
+      destination: client.name,
+      signature: 's',
+      body: [name]
+    });
+
+  // ------------------------------------------------------------------ names
+
+  const ownerOf = name => {
+    const queue = names.get(name);
+    return queue && queue.length ? queue[0].client : undefined;
+  };
+
+  /** Resolve a destination to a client: a unique name, or a well-known one. */
+  const resolve = destination =>
+    destination.startsWith(':')
+      ? unique.get(destination)
+      : ownerOf(destination);
+
+  function requestName(client, name, flags) {
+    const queue = names.get(name);
+    if (!queue) {
+      names.set(name, [
+        { client, allowReplacement: !!(flags & NAME_FLAG.ALLOW_REPLACEMENT) }
+      ]);
+      client.owned.add(name);
+      nameOwnerChanged(name, '', client.name);
+      nameSignal(client, 'NameAcquired', name);
+      return REQUEST_NAME.PRIMARY_OWNER;
+    }
+
+    const existing = queue.findIndex(entry => entry.client === client);
+    if (existing === 0) {
+      queue[0].allowReplacement = !!(flags & NAME_FLAG.ALLOW_REPLACEMENT);
+      return REQUEST_NAME.ALREADY_OWNER;
+    }
+    if (existing > 0) {
+      queue[existing].allowReplacement = !!(
+        flags & NAME_FLAG.ALLOW_REPLACEMENT
+      );
+      return REQUEST_NAME.IN_QUEUE;
+    }
+
+    if (flags & NAME_FLAG.REPLACE_EXISTING && queue[0].allowReplacement) {
+      const previous = queue[0].client;
+      previous.owned.delete(name);
+      queue.shift();
+      queue.unshift({
+        client,
+        allowReplacement: !!(flags & NAME_FLAG.ALLOW_REPLACEMENT)
+      });
+      // The one that lost it goes back in the queue, so releasing the new
+      // owner's claim hands it back rather than dropping the name entirely.
+      queue.splice(1, 0, { client: previous, allowReplacement: true });
+      client.owned.add(name);
+      nameSignal(previous, 'NameLost', name);
+      nameSignal(client, 'NameAcquired', name);
+      nameOwnerChanged(name, previous.name, client.name);
+      return REQUEST_NAME.PRIMARY_OWNER;
+    }
+
+    if (flags & NAME_FLAG.DO_NOT_QUEUE) return REQUEST_NAME.EXISTS;
+    queue.push({
+      client,
+      allowReplacement: !!(flags & NAME_FLAG.ALLOW_REPLACEMENT)
+    });
+    return REQUEST_NAME.IN_QUEUE;
+  }
+
+  function releaseName(client, name) {
+    const queue = names.get(name);
+    if (!queue) return RELEASE_NAME.NON_EXISTENT;
+    const at = queue.findIndex(entry => entry.client === client);
+    if (at === -1) return RELEASE_NAME.NOT_OWNER;
+
+    queue.splice(at, 1);
+    client.owned.delete(name);
+    if (at !== 0) return RELEASE_NAME.RELEASED;
+
+    nameSignal(client, 'NameLost', name);
+    if (queue.length === 0) {
+      names.delete(name);
+      nameOwnerChanged(name, client.name, '');
+    } else {
+      const heir = queue[0].client;
+      heir.owned.add(name);
+      nameSignal(heir, 'NameAcquired', name);
+      nameOwnerChanged(name, client.name, heir.name);
+    }
+    return RELEASE_NAME.RELEASED;
+  }
+
+  // --------------------------------------------------- the bus's own object
+
+  function busMethod(client, msg) {
+    const member = msg.member;
+    const arg = (msg.body || [])[0];
+
+    if (msg['interface'] === 'org.freedesktop.DBus.Peer') {
+      if (member === 'Ping') return reply(client, msg);
+      if (member === 'GetMachineId') return reply(client, msg, 's', [machine]);
+    }
+    if (msg['interface'] === 'org.freedesktop.DBus.Introspectable') {
+      if (member === 'Introspect') {
+        return reply(client, msg, 's', [BUS_INTROSPECTION]);
+      }
+    }
+    if (msg['interface'] === 'org.freedesktop.DBus.Properties') {
+      // A variant is written as [signature, value]. `Features` names optional
+      // behaviour this bus does not have (no header filtering, no systemd
+      // activation) and `Interfaces` the extra interfaces on the bus object,
+      // of which there are none, so both are empty rather than absent.
+      const properties = {
+        Features: ['as', []],
+        Interfaces: ['as', []]
+      };
+      if (member === 'Get') {
+        const value = properties[(msg.body || [])[1]];
+        if (!value) {
+          return replyError(
+            client,
+            msg,
+            ERR('UnknownProperty'),
+            `No such property "${(msg.body || [])[1]}"`
+          );
+        }
+        return reply(client, msg, 'v', [value]);
+      }
+      if (member === 'GetAll') {
+        return reply(client, msg, 'a{sv}', [
+          Object.entries(properties).map(([key, value]) => [key, value])
+        ]);
+      }
+    }
+
+    if (msg['interface'] !== BUS_INTERFACE) {
+      return replyError(
+        client,
+        msg,
+        ERR('UnknownInterface'),
+        `${BUS_NAME} does not implement ${msg['interface']}`
+      );
+    }
+
+    switch (member) {
+      case 'Hello':
+        // "Before an application is able to send messages ... it must send the
+        // org.freedesktop.DBus.Hello message", and it may only do so once.
+        if (client.name) {
+          return replyError(
+            client,
+            msg,
+            ERR('Failed'),
+            'Already handled an Hello message'
+          );
+        }
+        return hello(client, msg);
+
+      case 'RequestName': {
+        if (typeof arg !== 'string' || !isValidBusName(arg)) {
+          return replyError(
+            client,
+            msg,
+            ERR('InvalidArgs'),
+            `"${arg}" is not a valid bus name`
+          );
+        }
+        if (arg.startsWith(':') || arg === BUS_NAME) {
+          return replyError(
+            client,
+            msg,
+            ERR('InvalidArgs'),
+            `Cannot request the name "${arg}"`
+          );
+        }
+        const flags = (msg.body || [])[1] || 0;
+        return reply(client, msg, 'u', [requestName(client, arg, flags)]);
+      }
+
+      case 'ReleaseName': {
+        if (typeof arg !== 'string' || !isValidBusName(arg)) {
+          return replyError(
+            client,
+            msg,
+            ERR('InvalidArgs'),
+            `"${arg}" is not a valid bus name`
+          );
+        }
+        return reply(client, msg, 'u', [releaseName(client, arg)]);
+      }
+
+      case 'ListNames':
+        return reply(client, msg, 'as', [
+          [BUS_NAME, ...unique.keys(), ...names.keys()]
+        ]);
+
+      case 'ListActivatableNames':
+        // Nothing here is activatable, but the bus itself always is.
+        return reply(client, msg, 'as', [[BUS_NAME]]);
+
+      case 'NameHasOwner':
+        return reply(client, msg, 'b', [
+          arg === BUS_NAME || resolve(String(arg)) !== undefined
+        ]);
+
+      case 'GetNameOwner': {
+        if (arg === BUS_NAME) return reply(client, msg, 's', [BUS_NAME]);
+        const owner = resolve(String(arg));
+        if (!owner) {
+          return replyError(
+            client,
+            msg,
+            ERR('NameHasNoOwner'),
+            `Could not get owner of name "${arg}": no such name`
+          );
+        }
+        return reply(client, msg, 's', [owner.name]);
+      }
+
+      case 'ListQueuedOwners': {
+        const queue = names.get(String(arg));
+        if (!queue) {
+          return replyError(
+            client,
+            msg,
+            ERR('NameHasNoOwner'),
+            `Could not get owners of name "${arg}": no such name`
+          );
+        }
+        return reply(client, msg, 'as', [
+          queue.map(entry => entry.client.name)
+        ]);
+      }
+
+      case 'AddMatch': {
+        let parsed;
+        try {
+          parsed = parseRule(String(arg));
+        } catch (err) {
+          return replyError(client, msg, ERR('MatchRuleInvalid'), err.message);
+        }
+        client.rules.push({ text: String(arg), parsed });
+        return reply(client, msg);
+      }
+
+      case 'RemoveMatch': {
+        const at = client.rules.findIndex(rule => rule.text === String(arg));
+        if (at === -1) {
+          return replyError(
+            client,
+            msg,
+            ERR('MatchRuleNotFound'),
+            'The given match rule was not found'
+          );
+        }
+        client.rules.splice(at, 1);
+        return reply(client, msg);
+      }
+
+      case 'GetId':
+        return reply(client, msg, 's', [id]);
+
+      case 'GetConnectionUnixUser':
+      case 'GetConnectionUnixProcessID': {
+        const target = resolve(String(arg));
+        if (!target) {
+          return replyError(
+            client,
+            msg,
+            ERR('NameHasNoOwner'),
+            `Could not get owner of name "${arg}": no such name`
+          );
+        }
+        // Node cannot read the peer's credentials from a socket, so the only
+        // honest answers are the ones the handshake was told and our own pid --
+        // which is right for an in-process bus and wrong for anything else.
+        const value =
+          member === 'GetConnectionUnixUser'
+            ? target.identity && target.identity.uid
+            : process.pid;
+        if (value === null || value === undefined) {
+          return replyError(
+            client,
+            msg,
+            ERR('Failed'),
+            'Could not determine the credentials of that connection'
+          );
+        }
+        return reply(client, msg, 'u', [value]);
+      }
+
+      case 'StartServiceByName':
+        return replyError(
+          client,
+          msg,
+          ERR('ServiceUnknown'),
+          `The name ${arg} was not provided by any .service files -- this bus does not activate services`
+        );
+
+      case 'UpdateActivationEnvironment':
+        return reply(client, msg);
+
+      default:
+        return replyError(
+          client,
+          msg,
+          ERR('UnknownMethod'),
+          `${BUS_NAME} has no method ${member}`
+        );
+    }
+  }
+
+  function hello(client, msg) {
+    client.name = `:1.${nextUnique++}`;
+    unique.set(client.name, client);
+    reply(client, msg, 's', [client.name]);
+    // The order matters: the reply carries the name, and only then can the
+    // client make sense of a signal addressed to it.
+    nameOwnerChanged(client.name, '', client.name);
+    nameSignal(client, 'NameAcquired', client.name);
+    broker.emit('hello', client.name);
+  }
+
+  // -------------------------------------------------------------- routing
+
+  function route(client, msg) {
+    // Until Hello there is no name to put in `sender`, so nothing else can be
+    // delivered or replied to.
+    if (!client.name) {
+      const isHello =
+        msg.destination === BUS_NAME &&
+        msg['interface'] === BUS_INTERFACE &&
+        msg.member === 'Hello';
+      if (!isHello) {
+        replyError(
+          client,
+          msg,
+          ERR('AccessDenied'),
+          'Client tried to send a message other than Hello without being registered'
+        );
+        return;
+      }
+    }
+
+    // The daemon stamps the sender itself; a client cannot claim to be someone
+    // else, and anything it put there is overwritten.
+    msg.sender = client.name;
+
+    if (msg.destination === BUS_NAME) {
+      if (msg.type !== constants.messageType.methodCall) return;
+      if (msg.path !== undefined && msg.path !== BUS_PATH) {
+        return replyError(
+          client,
+          msg,
+          ERR('UnknownObject'),
+          `${BUS_NAME} has no object at ${msg.path}`
+        );
+      }
+      return busMethod(client, msg);
+    }
+
+    if (msg.destination) {
+      const target = resolve(msg.destination);
+      if (!target) {
+        // A signal to a name nobody owns is dropped; a call gets told.
+        if (msg.type === constants.messageType.methodCall) {
+          replyError(
+            client,
+            msg,
+            ERR('NameHasNoOwner'),
+            `The name ${msg.destination} was not provided by any .service files`
+          );
+        }
+        return;
+      }
+      send(target, msg);
+      // A unicast message still reaches anyone whose rule asks for it -- that
+      // is how dbus-monitor sees traffic addressed elsewhere. Not implemented:
+      // eavesdropping needs BecomeMonitor, and delivering unicast traffic to
+      // third parties without it would be a surprise.
+      return;
+    }
+
+    if (msg.type === constants.messageType.signal) return broadcast(msg);
+
+    replyError(
+      client,
+      msg,
+      ERR('Failed'),
+      'A method call must name a destination'
+    );
+  }
+
+  // ---------------------------------------------------------- connections
+
+  function accept(stream) {
+    const conn = dbus.createConnection({
+      stream,
+      server: true,
+      guid,
+      authMethods: opts.authMethods,
+      anonymous: opts.anonymous,
+      authorize: opts.authorize,
+      cookieContext: opts.cookieContext,
+      authTimeout: opts.authTimeout,
+      // Forwarding here means unmarshalling a message and marshalling it
+      // again, so every value has to survive the round trip -- and by default
+      // a 64-bit integer does not. It is read as a Number, which is lossy
+      // above 2^53, and then refused on the way out with "Number outside
+      // range". A bus that quietly rounds someone's payload would be worse.
+      //
+      // The proper fix is not to re-encode at all: a router should keep the
+      // body bytes and rewrite only the header fields it must. That needs the
+      // message layer to hand back the raw frame, which it does not do today
+      // -- see ROADMAP 4.5. Until then, reading 64-bit values exactly is what
+      // makes the round trip faithful.
+      returnBigInt: true
+    });
+
+    const client = {
+      conn,
+      stream,
+      name: null,
+      serial: 1,
+      owned: new Set(),
+      rules: [],
+      identity: null,
+      gone: false
+    };
+    clients.add(client);
+
+    conn.on('connect', () => {
+      client.identity = conn.identity || null;
+      broker.emit('connection', client);
+    });
+    conn.on('message', msg => {
+      try {
+        route(client, msg);
+      } catch (err) {
+        // One client's bad message must not take the bus down with it -- and a
+        // caller waiting on a reply is owed one, even when the reason it did
+        // not arrive is a fault in here.
+        broker.emit('clientError', err, client);
+        if (msg.type === constants.messageType.methodCall && client.name) {
+          try {
+            replyError(client, msg, ERR('Failed'), err.message);
+          } catch {
+            /* nothing left to say it with */
+          }
+        }
+      }
+    });
+    conn.on('error', err => broker.emit('clientError', err, client));
+    const drop = () => {
+      if (client.gone) return;
+      client.gone = true;
+      clients.delete(client);
+      for (const name of [...client.owned]) releaseName(client, name);
+      if (client.name) {
+        unique.delete(client.name);
+        nameOwnerChanged(client.name, client.name, '');
+      }
+      broker.emit('disconnect', client);
+    };
+    conn.on('end', drop);
+    conn.on('close', drop);
+  }
+
+  // --------------------------------------------------------------- public
+
+  /**
+   * Start listening.
+   *
+   * `{socket}` for a unix socket, `{port, host}` for TCP, or nothing for a
+   * unix socket in a temporary directory. Calls back with the address.
+   */
+  broker.listen = function listen(where, cb) {
+    if (typeof where === 'function') {
+      cb = where;
+      where = undefined;
+    }
+    const target = where || {
+      socket: path.join(
+        fs.mkdtempSync(path.join(os.tmpdir(), 'dbus-broker-')),
+        'socket'
+      )
+    };
+
+    server = net.createServer(accept);
+    server.on('error', err => broker.emit('error', err));
+
+    const done = () => {
+      if (target.socket) {
+        listenAddress = `unix:path=${target.socket},guid=${guid}`;
+      } else {
+        const { port, address } = server.address();
+        listenAddress = `tcp:host=${address},port=${port},guid=${guid}`;
+      }
+      broker.emit('listening', listenAddress);
+      if (cb) cb(null, listenAddress);
+    };
+
+    if (target.socket) server.listen(target.socket, done);
+    else server.listen(target.port || 0, target.host || '127.0.0.1', done);
+    return broker;
+  };
+
+  /** The address a client should connect to, once listening. */
+  broker.address = () => listenAddress;
+  broker.guid = guid;
+  broker.id = id;
+
+  /** Names currently on the bus, as ListNames would report them. */
+  broker.names = () => [BUS_NAME, ...unique.keys(), ...names.keys()];
+
+  broker.close = function close(cb) {
+    for (const client of [...clients]) {
+      try {
+        client.stream.destroy();
+      } catch {
+        /* already gone */
+      }
+    }
+    clients.clear();
+    if (!server) {
+      if (cb) cb();
+      return broker;
+    }
+    const socket = listenAddress && /^unix:path=([^,]+)/.exec(listenAddress);
+    server.close(() => {
+      // A unix socket outlives the server that bound it.
+      if (socket) {
+        try {
+          fs.rmSync(socket[1], { force: true });
+          fs.rmdirSync(path.dirname(socket[1]));
+        } catch {
+          /* someone else's to clean up */
+        }
+      }
+      if (cb) cb();
+    });
+    return broker;
+  };
+
+  return broker;
+}
+
+module.exports = {
+  createBroker,
+  NAME_FLAG,
+  REQUEST_NAME,
+  RELEASE_NAME,
+  BUS_NAME,
+  BUS_PATH
+};

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "test:raw": "node --test --test-reporter=spec test/*.js",
     "test:integration": "node scripts/with-dbus.js -- npm run test:integration:raw",
     "test:integration:raw": "node --test --test-reporter=spec test/integration/*.js",
+    "test:integration:broker": "node scripts/with-broker.js -- npm run test:integration:raw",
     "dbus:session": "node scripts/dbus-session.js",
     "test:types": "tsc --noEmit"
   },

--- a/scripts/with-broker.js
+++ b/scripts/with-broker.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+//
+// Run a command against this library's own message bus.
+//
+//   node scripts/with-broker.js -- node --test test/integration/*.js
+//
+// The same contract as scripts/with-dbus.js -- exports
+// DBUS_SESSION_BUS_ADDRESS for the child and tears the bus down afterwards --
+// except that the bus is lib/broker.js rather than dbus-daemon, so this needs
+// nothing installed.
+//
+// Running the integration suite both ways is the point: the tests do not know
+// which bus they are talking to, so anywhere the two disagree shows up as a
+// test that passes against one and fails against the other.
+
+const { spawn } = require('child_process');
+const dbus = require('../index');
+
+const argv = process.argv.slice(2);
+const args = argv[0] === '--' ? argv.slice(1) : argv;
+
+if (args.length === 0) {
+  console.error('usage: node scripts/with-broker.js -- <command> [args...]');
+  process.exit(1);
+}
+
+const broker = dbus.createBroker();
+
+broker.on('error', err => {
+  console.error(`broker: ${err.message}`);
+});
+// A fault while serving one client is worth seeing on stderr -- it is the
+// difference between "the test failed" and "the bus is broken".
+broker.on('clientError', err => {
+  if (!/ECONNRESET|EPIPE|closed/i.test(err.message)) {
+    console.error(`broker: ${err.message}`);
+  }
+});
+
+broker.listen((err, address) => {
+  if (err) {
+    console.error(`broker: ${err.message}`);
+    process.exit(1);
+  }
+
+  const child = spawn(args[0], args.slice(1), {
+    stdio: 'inherit',
+    env: { ...process.env, DBUS_SESSION_BUS_ADDRESS: address }
+  });
+
+  const forward = signal => () => child.kill(signal);
+  process.on('SIGINT', forward('SIGINT'));
+  process.on('SIGTERM', forward('SIGTERM'));
+
+  child.on('error', spawnError => {
+    console.error(`failed to run ${args[0]}: ${spawnError.message}`);
+    broker.close(() => process.exit(1));
+  });
+
+  child.on('exit', (code, signal) => {
+    broker.close(() => {
+      if (signal) process.kill(process.pid, signal);
+      else process.exit(code ?? 1);
+    });
+  });
+});

--- a/test/broker.js
+++ b/test/broker.js
@@ -1,0 +1,950 @@
+// The in-process message bus.
+//
+// Everything here goes over a real socket through the real handshake and the
+// real marshaller -- the only thing that is not a normal client is that the bus
+// happens to live in this process.
+
+const {
+  describe,
+  it,
+  before,
+  after,
+  beforeEach,
+  afterEach
+} = require('node:test');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const dbus = require('../index');
+const constants = require('../lib/constants');
+const { REQUEST_NAME, RELEASE_NAME, NAME_FLAG } = require('../lib/broker');
+
+const DBUS = {
+  destination: 'org.freedesktop.DBus',
+  path: '/org/freedesktop/DBus',
+  interface: 'org.freedesktop.DBus'
+};
+
+describe('broker', { timeout: 20000 }, () => {
+  let broker;
+  let address;
+  let opened;
+  let faults;
+
+  before(
+    () =>
+      new Promise((resolve, reject) => {
+        broker = dbus.createBroker();
+        faults = [];
+        // A fault inside the bus shows up as a call that never answers, which
+        // reads as a hung test rather than a broken one. Collect them so the
+        // failure names itself.
+        broker.on('error', err => faults.push(err));
+        broker.on('clientError', err => faults.push(err));
+        broker.listen((err, at) => {
+          if (err) return reject(err);
+          address = at;
+          resolve();
+        });
+      })
+  );
+
+  after(() => new Promise(resolve => broker.close(resolve)));
+
+  beforeEach(() => {
+    opened = [];
+    faults.length = 0;
+  });
+
+  afterEach(() => {
+    for (const bus of opened) {
+      try {
+        bus.connection.stream.destroy();
+      } catch {
+        /* already gone */
+      }
+    }
+    // Dropping a client mid-conversation is how several tests end, and the
+    // read loop notices; only complain about faults from the bus itself.
+    const real = faults.filter(
+      err => !/ECONNRESET|EPIPE|closed/i.test(err.message)
+    );
+    assert.deepStrictEqual(
+      real.map(err => err.message),
+      [],
+      'the bus reported no faults'
+    );
+  });
+
+  /** A connected client, torn down after the test. */
+  async function client(opts = {}) {
+    const bus = dbus.createClient({ busAddress: address, ...opts });
+    opened.push(bus);
+    bus.connection.on('error', () => {});
+    await bus.getId();
+    return bus;
+  }
+
+  const request = (bus, name, flags = 0) =>
+    bus.invokeDbus({
+      member: 'RequestName',
+      signature: 'su',
+      body: [name, flags]
+    });
+
+  const release = (bus, name) =>
+    bus.invokeDbus({ member: 'ReleaseName', signature: 's', body: [name] });
+
+  /** Collect messages matching a predicate, after installing a match rule. */
+  async function watch(bus, rule, predicate) {
+    await bus.invokeDbus({ member: 'AddMatch', signature: 's', body: [rule] });
+    const seen = [];
+    bus.connection.on('message', msg => {
+      if (!predicate || predicate(msg)) seen.push(msg);
+    });
+    return seen;
+  }
+
+  const settle = (ms = 120) => new Promise(resolve => setTimeout(resolve, ms));
+
+  describe('Hello and unique names', () => {
+    it('hands out :1.N names, one per connection', async () => {
+      const a = await client();
+      const b = await client();
+      assert.match(a.name, /^:1\.\d+$/);
+      assert.match(b.name, /^:1\.\d+$/);
+      assert.notStrictEqual(a.name, b.name);
+    });
+
+    it('refuses a second Hello', async () => {
+      const bus = await client();
+      await assert.rejects(() => bus.invokeDbus({ member: 'Hello' }), {
+        dbusName: 'org.freedesktop.DBus.Error.Failed'
+      });
+    });
+
+    it('refuses anything else before Hello', async () => {
+      // `direct` skips the automatic Hello, so this connection has no name.
+      const bus = dbus.createClient({ busAddress: address, direct: true });
+      opened.push(bus);
+      bus.connection.on('error', () => {});
+      await new Promise(resolve => bus.connection.once('connect', resolve));
+      await assert.rejects(() => bus.invokeDbus({ member: 'ListNames' }), {
+        dbusName: 'org.freedesktop.DBus.Error.AccessDenied'
+      });
+    });
+
+    it('stamps the sender itself, ignoring what the client claims', async () => {
+      const a = await client();
+      const b = await client();
+      const seen = await watch(
+        b,
+        "type='signal',interface='com.example.Spoof'"
+      );
+      a.connection.message({
+        type: constants.messageType.signal,
+        serial: 9999,
+        path: '/com/example/Obj',
+        interface: 'com.example.Spoof',
+        member: 'Fired',
+        sender: ':1.999'
+      });
+      await settle();
+      assert.strictEqual(seen.length, 1);
+      assert.strictEqual(seen[0].sender, a.name, 'not the claimed :1.999');
+    });
+  });
+
+  describe('RequestName', () => {
+    it('makes the first caller the primary owner', async () => {
+      const bus = await client();
+      assert.strictEqual(
+        await request(bus, 'com.example.First'),
+        REQUEST_NAME.PRIMARY_OWNER
+      );
+    });
+
+    it('tells an owner it already owns it', async () => {
+      const bus = await client();
+      await request(bus, 'com.example.Again');
+      assert.strictEqual(
+        await request(bus, 'com.example.Again'),
+        REQUEST_NAME.ALREADY_OWNER
+      );
+    });
+
+    it('queues a second claimant', async () => {
+      const a = await client();
+      const b = await client();
+      await request(a, 'com.example.Queued');
+      assert.strictEqual(
+        await request(b, 'com.example.Queued'),
+        REQUEST_NAME.IN_QUEUE
+      );
+    });
+
+    it('reports EXISTS rather than queueing when asked not to queue', async () => {
+      const a = await client();
+      const b = await client();
+      await request(a, 'com.example.NoQueue');
+      assert.strictEqual(
+        await request(b, 'com.example.NoQueue', NAME_FLAG.DO_NOT_QUEUE),
+        REQUEST_NAME.EXISTS
+      );
+    });
+
+    it('replaces an owner that allowed replacement', async () => {
+      const a = await client();
+      const b = await client();
+      await request(a, 'com.example.Replace', NAME_FLAG.ALLOW_REPLACEMENT);
+      assert.strictEqual(
+        await request(b, 'com.example.Replace', NAME_FLAG.REPLACE_EXISTING),
+        REQUEST_NAME.PRIMARY_OWNER
+      );
+      const owner = await b.invokeDbus({
+        member: 'GetNameOwner',
+        signature: 's',
+        body: ['com.example.Replace']
+      });
+      assert.strictEqual(owner, b.name);
+    });
+
+    it('will not replace an owner that did not allow it', async () => {
+      const a = await client();
+      const b = await client();
+      await request(a, 'com.example.Firm');
+      assert.strictEqual(
+        await request(b, 'com.example.Firm', NAME_FLAG.REPLACE_EXISTING),
+        REQUEST_NAME.IN_QUEUE
+      );
+    });
+
+    it('hands the name back when a replacing owner releases it', async () => {
+      const a = await client();
+      const b = await client();
+      await request(a, 'com.example.Hand', NAME_FLAG.ALLOW_REPLACEMENT);
+      await request(b, 'com.example.Hand', NAME_FLAG.REPLACE_EXISTING);
+      assert.strictEqual(
+        await release(b, 'com.example.Hand'),
+        RELEASE_NAME.RELEASED
+      );
+      const owner = await a.invokeDbus({
+        member: 'GetNameOwner',
+        signature: 's',
+        body: ['com.example.Hand']
+      });
+      assert.strictEqual(owner, a.name, 'back to the one that was replaced');
+    });
+
+    it('refuses a malformed name, a unique name and the bus name', async () => {
+      const bus = await client();
+      for (const name of ['no-dot', ':1.5', 'org.freedesktop.DBus', '']) {
+        await assert.rejects(
+          () => request(bus, name),
+          { dbusName: 'org.freedesktop.DBus.Error.InvalidArgs' },
+          name
+        );
+      }
+    });
+  });
+
+  describe('ReleaseName', () => {
+    it('releases a name it owns', async () => {
+      const bus = await client();
+      await request(bus, 'com.example.Drop');
+      assert.strictEqual(
+        await release(bus, 'com.example.Drop'),
+        RELEASE_NAME.RELEASED
+      );
+      assert.strictEqual(
+        await bus.invokeDbus({
+          member: 'NameHasOwner',
+          signature: 's',
+          body: ['com.example.Drop']
+        }),
+        false
+      );
+    });
+
+    it('reports a name nobody owns', async () => {
+      const bus = await client();
+      assert.strictEqual(
+        await release(bus, 'com.example.Nobody'),
+        RELEASE_NAME.NON_EXISTENT
+      );
+    });
+
+    it('reports a name owned by someone else', async () => {
+      const a = await client();
+      const b = await client();
+      await request(a, 'com.example.Theirs');
+      assert.strictEqual(
+        await release(b, 'com.example.Theirs'),
+        RELEASE_NAME.NOT_OWNER
+      );
+    });
+
+    it('promotes the next in the queue', async () => {
+      const a = await client();
+      const b = await client();
+      await request(a, 'com.example.Succeed');
+      await request(b, 'com.example.Succeed');
+      await release(a, 'com.example.Succeed');
+      const owner = await b.invokeDbus({
+        member: 'GetNameOwner',
+        signature: 's',
+        body: ['com.example.Succeed']
+      });
+      assert.strictEqual(owner, b.name);
+    });
+  });
+
+  describe('the bus object', () => {
+    it('lists names, and says who owns them', async () => {
+      const bus = await client();
+      await request(bus, 'com.example.Listed');
+      const names = await bus.invokeDbus({ member: 'ListNames' });
+      assert.ok(names.includes('org.freedesktop.DBus'));
+      assert.ok(names.includes(bus.name));
+      assert.ok(names.includes('com.example.Listed'));
+    });
+
+    it('answers NameHasOwner for the bus itself', async () => {
+      const bus = await client();
+      assert.strictEqual(
+        await bus.invokeDbus({
+          member: 'NameHasOwner',
+          signature: 's',
+          body: ['org.freedesktop.DBus']
+        }),
+        true
+      );
+    });
+
+    it('reports NameHasNoOwner for an unowned name', async () => {
+      const bus = await client();
+      await assert.rejects(
+        () =>
+          bus.invokeDbus({
+            member: 'GetNameOwner',
+            signature: 's',
+            body: ['com.example.Absent']
+          }),
+        { dbusName: 'org.freedesktop.DBus.Error.NameHasNoOwner' }
+      );
+    });
+
+    it('lists queued owners in order', async () => {
+      const a = await client();
+      const b = await client();
+      const c = await client();
+      await request(a, 'com.example.Order');
+      await request(b, 'com.example.Order');
+      await request(c, 'com.example.Order');
+      const queued = await a.invokeDbus({
+        member: 'ListQueuedOwners',
+        signature: 's',
+        body: ['com.example.Order']
+      });
+      assert.deepStrictEqual(queued, [a.name, b.name, c.name]);
+    });
+
+    it('answers GetId with a stable bus id', async () => {
+      const a = await client();
+      const b = await client();
+      const first = await a.invokeDbus({ member: 'GetId' });
+      assert.match(first, /^[0-9a-f]{32}$/);
+      assert.strictEqual(await b.invokeDbus({ member: 'GetId' }), first);
+    });
+
+    it('answers Peer.Ping and Peer.GetMachineId', async () => {
+      const bus = await client();
+      await bus.invoke({
+        ...DBUS,
+        interface: 'org.freedesktop.DBus.Peer',
+        member: 'Ping'
+      });
+      const id = await bus.invoke({
+        ...DBUS,
+        interface: 'org.freedesktop.DBus.Peer',
+        member: 'GetMachineId'
+      });
+      assert.match(id, /^[0-9a-f]{32}$/);
+    });
+
+    it('is introspectable, and the XML parses', async () => {
+      const bus = await client();
+      const xml = await bus.invoke({
+        ...DBUS,
+        interface: 'org.freedesktop.DBus.Introspectable',
+        member: 'Introspect'
+      });
+      const { parseStringPromise } = require('xml2js');
+      const doc = await parseStringPromise(xml);
+      const ifaces = doc.node.interface.map(i => i.$.name);
+      assert.ok(ifaces.includes('org.freedesktop.DBus'));
+      assert.ok(ifaces.includes('org.freedesktop.DBus.Peer'));
+    });
+
+    it('answers Properties.GetAll on itself', async () => {
+      const bus = await client();
+      const all = await bus.invoke({
+        ...DBUS,
+        interface: 'org.freedesktop.DBus.Properties',
+        member: 'GetAll',
+        signature: 's',
+        body: ['org.freedesktop.DBus']
+      });
+      assert.deepStrictEqual(
+        dbus.toPlain(all),
+        { Features: [], Interfaces: [] },
+        'the properties the daemon exposes'
+      );
+    });
+
+    it('has no activatable services, and says so', async () => {
+      const bus = await client();
+      await assert.rejects(
+        () =>
+          bus.invokeDbus({
+            member: 'StartServiceByName',
+            signature: 'su',
+            body: ['com.example.NotActivatable', 0]
+          }),
+        err => {
+          assert.strictEqual(
+            err.dbusName,
+            'org.freedesktop.DBus.Error.ServiceUnknown'
+          );
+          assert.match(err.message, /does not activate services/);
+          return true;
+        }
+      );
+    });
+
+    it('refuses an unknown method and an unknown object', async () => {
+      const bus = await client();
+      await assert.rejects(() => bus.invokeDbus({ member: 'Nonsense' }), {
+        dbusName: 'org.freedesktop.DBus.Error.UnknownMethod'
+      });
+      await assert.rejects(
+        () =>
+          bus.invoke({
+            ...DBUS,
+            path: '/org/freedesktop/Elsewhere',
+            member: 'ListNames'
+          }),
+        { dbusName: 'org.freedesktop.DBus.Error.UnknownObject' }
+      );
+    });
+  });
+
+  describe('match rules', () => {
+    it('accepts and removes a rule', async () => {
+      const bus = await client();
+      const rule = "type='signal',member='Pinged'";
+      await bus.invokeDbus({
+        member: 'AddMatch',
+        signature: 's',
+        body: [rule]
+      });
+      await bus.invokeDbus({
+        member: 'RemoveMatch',
+        signature: 's',
+        body: [rule]
+      });
+    });
+
+    it('refuses an invalid rule with MatchRuleInvalid', async () => {
+      const bus = await client();
+      await assert.rejects(
+        () =>
+          bus.invokeDbus({
+            member: 'AddMatch',
+            signature: 's',
+            body: ["nonsense='x'"]
+          }),
+        err => {
+          assert.strictEqual(
+            err.dbusName,
+            'org.freedesktop.DBus.Error.MatchRuleInvalid'
+          );
+          assert.match(err.message, /unknown key "nonsense"/);
+          return true;
+        }
+      );
+    });
+
+    it('reports removing a rule that was never added', async () => {
+      const bus = await client();
+      await assert.rejects(
+        () =>
+          bus.invokeDbus({
+            member: 'RemoveMatch',
+            signature: 's',
+            body: ["type='signal'"]
+          }),
+        { dbusName: 'org.freedesktop.DBus.Error.MatchRuleNotFound' }
+      );
+    });
+  });
+
+  describe('routing', () => {
+    it('carries a method call between two clients', async () => {
+      const service = await client();
+      const caller = await client();
+      await request(service, 'com.example.Routed');
+
+      const impl = Object.assign(Object.create(EventEmitter.prototype), {
+        Echo: text => `echoed: ${text}`
+      });
+      EventEmitter.call(impl);
+      service.exportInterface(impl, '/com/example/Routed', {
+        name: 'com.example.RoutedIface',
+        methods: { Echo: ['s', 's', ['text'], ['out']] },
+        signals: {},
+        properties: {}
+      });
+
+      const result = await caller.invoke({
+        destination: 'com.example.Routed',
+        path: '/com/example/Routed',
+        interface: 'com.example.RoutedIface',
+        member: 'Echo',
+        signature: 's',
+        body: ['hello']
+      });
+      assert.strictEqual(result, 'echoed: hello');
+    });
+
+    it('works through the proxy API, introspection and all', async () => {
+      const service = await client();
+      const caller = await client();
+      await request(service, 'com.example.Proxied');
+      const impl = Object.assign(Object.create(EventEmitter.prototype), {
+        Add: (a, b) => a + b,
+        Greeting: 'hi'
+      });
+      EventEmitter.call(impl);
+      service.exportInterface(impl, '/com/example/Proxied', {
+        name: 'com.example.ProxiedIface',
+        methods: { Add: ['uu', 'u', ['a', 'b'], ['sum']] },
+        signals: {},
+        properties: { Greeting: 's' }
+      });
+
+      const iface = await new Promise((resolve, reject) =>
+        caller.getInterface(
+          'com.example.Proxied',
+          '/com/example/Proxied',
+          'com.example.ProxiedIface',
+          (err, value) => (err ? reject(err) : resolve(value))
+        )
+      );
+      const sum = await new Promise((resolve, reject) =>
+        iface.Add(2, 3, (err, value) => (err ? reject(err) : resolve(value)))
+      );
+      assert.strictEqual(sum, 5);
+    });
+
+    it('reports a destination nobody owns', async () => {
+      const bus = await client();
+      await assert.rejects(
+        () =>
+          bus.invoke({
+            destination: 'com.example.Missing',
+            path: '/',
+            interface: 'com.example.I',
+            member: 'M'
+          }),
+        { dbusName: 'org.freedesktop.DBus.Error.NameHasNoOwner' }
+      );
+    });
+
+    it('refuses a method call with no destination', async () => {
+      const bus = await client();
+      await assert.rejects(
+        () =>
+          bus.invoke({
+            path: '/com/example/Obj',
+            interface: 'com.example.I',
+            member: 'M'
+          }),
+        { dbusName: 'org.freedesktop.DBus.Error.Failed' }
+      );
+    });
+
+    it('routes to a unique name as well as a well-known one', async () => {
+      const service = await client();
+      const caller = await client();
+      const impl = Object.assign(Object.create(EventEmitter.prototype), {
+        Who: () => 'unique'
+      });
+      EventEmitter.call(impl);
+      service.exportInterface(impl, '/com/example/Uniq', {
+        name: 'com.example.UniqIface',
+        methods: { Who: ['', 's', [], ['out']] },
+        signals: {},
+        properties: {}
+      });
+      const who = await caller.invoke({
+        destination: service.name,
+        path: '/com/example/Uniq',
+        interface: 'com.example.UniqIface',
+        member: 'Who'
+      });
+      assert.strictEqual(who, 'unique');
+    });
+  });
+
+  describe('signals', () => {
+    it('delivers a broadcast to a client whose rule matches', async () => {
+      const sender = await client();
+      const listener = await client();
+      const seen = await watch(
+        listener,
+        "type='signal',interface='com.example.Broadcast'",
+        msg => msg['interface'] === 'com.example.Broadcast'
+      );
+      sender.sendSignal(
+        '/com/example/Obj',
+        'com.example.Broadcast',
+        'Fired',
+        's',
+        ['payload']
+      );
+      await settle();
+      assert.strictEqual(seen.length, 1);
+      assert.deepStrictEqual(seen[0].body, ['payload']);
+      assert.strictEqual(seen[0].sender, sender.name);
+    });
+
+    it('does not deliver one nobody asked for', async () => {
+      const sender = await client();
+      const listener = await client();
+      const seen = [];
+      listener.connection.on('message', msg => {
+        if (msg['interface'] === 'com.example.Unwanted') seen.push(msg);
+      });
+      sender.sendSignal(
+        '/com/example/Obj',
+        'com.example.Unwanted',
+        'Fired',
+        's',
+        ['x']
+      );
+      await settle();
+      assert.deepStrictEqual(seen, []);
+    });
+
+    it('delivers a signal back to its own sender when a rule matches', async () => {
+      // Which is what dbus-daemon does; checked against it before implementing.
+      const bus = await client();
+      const seen = await watch(
+        bus,
+        "type='signal',interface='com.example.Echo'",
+        msg => msg['interface'] === 'com.example.Echo'
+      );
+      bus.sendSignal('/com/example/Obj', 'com.example.Echo', 'Fired', 's', [
+        'x'
+      ]);
+      await settle();
+      assert.strictEqual(seen.length, 1);
+    });
+
+    it('honours argN filtering', async () => {
+      const sender = await client();
+      const listener = await client();
+      const seen = await watch(
+        listener,
+        "type='signal',interface='com.example.Filtered',arg0='wanted'",
+        msg => msg['interface'] === 'com.example.Filtered'
+      );
+      for (const value of ['unwanted', 'wanted']) {
+        sender.sendSignal(
+          '/com/example/Obj',
+          'com.example.Filtered',
+          'Fired',
+          's',
+          [value]
+        );
+      }
+      await settle();
+      assert.strictEqual(seen.length, 1);
+      assert.deepStrictEqual(seen[0].body, ['wanted']);
+    });
+
+    it('drops a unicast signal to a name nobody owns', async () => {
+      const bus = await client();
+      // No reply is expected for a signal, so the check is that the bus
+      // survives and keeps answering.
+      bus.connection.message({
+        type: constants.messageType.signal,
+        serial: 4242,
+        destination: 'com.example.Gone',
+        path: '/com/example/Obj',
+        interface: 'com.example.I',
+        member: 'Fired'
+      });
+      await settle(60);
+      assert.ok(Array.isArray(await bus.invokeDbus({ member: 'ListNames' })));
+    });
+  });
+
+  describe('NameOwnerChanged', () => {
+    const RULE =
+      "type='signal',sender='org.freedesktop.DBus'," +
+      "interface='org.freedesktop.DBus',member='NameOwnerChanged'";
+
+    it('announces a name being taken and given up', async () => {
+      const watcher = await client();
+      const owner = await client();
+      const seen = await watch(
+        watcher,
+        RULE,
+        m => m.member === 'NameOwnerChanged'
+      );
+
+      await request(owner, 'com.example.Announced');
+      await release(owner, 'com.example.Announced');
+      await settle();
+
+      const ours = seen.filter(m => m.body[0] === 'com.example.Announced');
+      assert.deepStrictEqual(
+        ours.map(m => m.body),
+        [
+          ['com.example.Announced', '', owner.name],
+          ['com.example.Announced', owner.name, '']
+        ]
+      );
+    });
+
+    it('announces a connection arriving and leaving', async () => {
+      const watcher = await client();
+      const seen = await watch(
+        watcher,
+        RULE,
+        m => m.member === 'NameOwnerChanged'
+      );
+
+      const transient = await client();
+      const name = transient.name;
+      await settle();
+      transient.connection.stream.destroy();
+      await settle();
+
+      const arrived = seen.find(m => m.body[0] === name && m.body[2] === name);
+      const left = seen.find(m => m.body[0] === name && m.body[2] === '');
+      assert.ok(arrived, `no arrival for ${name}`);
+      assert.ok(left, `no departure for ${name}`);
+    });
+
+    it('hands a dead owner name to the next in the queue', async () => {
+      const watcher = await client();
+      const first = await client();
+      const second = await client();
+      const seen = await watch(
+        watcher,
+        RULE,
+        m => m.member === 'NameOwnerChanged'
+      );
+
+      await request(first, 'com.example.Inherited');
+      await request(second, 'com.example.Inherited');
+      first.connection.stream.destroy();
+      await settle(250);
+
+      const owner = await watcher.invokeDbus({
+        member: 'GetNameOwner',
+        signature: 's',
+        body: ['com.example.Inherited']
+      });
+      assert.strictEqual(owner, second.name);
+      assert.ok(
+        seen.some(
+          m =>
+            m.body[0] === 'com.example.Inherited' && m.body[2] === second.name
+        ),
+        'and it was announced'
+      );
+    });
+  });
+
+  describe('NameAcquired and NameLost', () => {
+    it('tells a connection its own unique name', async () => {
+      // Sent without any match rule, which is what libdbus relies on.
+      const bus = dbus.createClient({ busAddress: address });
+      opened.push(bus);
+      bus.connection.on('error', () => {});
+      const acquired = [];
+      bus.connection.on('message', msg => {
+        if (msg.member === 'NameAcquired') acquired.push(msg.body[0]);
+      });
+      await bus.getId();
+      await settle();
+      assert.ok(acquired.includes(bus.name), `got ${JSON.stringify(acquired)}`);
+    });
+
+    it('tells the loser and the winner when a name changes hands', async () => {
+      const a = await client();
+      const b = await client();
+      const lost = [];
+      const won = [];
+      a.connection.on('message', msg => {
+        if (msg.member === 'NameLost') lost.push(msg.body[0]);
+      });
+      b.connection.on('message', msg => {
+        if (msg.member === 'NameAcquired') won.push(msg.body[0]);
+      });
+
+      await request(a, 'com.example.Handover', NAME_FLAG.ALLOW_REPLACEMENT);
+      await request(b, 'com.example.Handover', NAME_FLAG.REPLACE_EXISTING);
+      await settle();
+
+      assert.ok(lost.includes('com.example.Handover'));
+      assert.ok(won.includes('com.example.Handover'));
+    });
+  });
+
+  // Forwarding here means unmarshalling a message and marshalling it again, so
+  // anything the reader and the writer disagree about becomes a routing bug.
+  // The first version of this lost 64-bit values: they were read as Numbers and
+  // then refused on the way out with "Number outside range".
+  describe('what survives being routed', () => {
+    const INT64_MAX = 9223372036854775807n;
+    const INT64_MIN = -9223372036854775808n;
+    const UINT64_MAX = 18446744073709551615n;
+
+    let service, caller;
+
+    before(async () => {
+      service = dbus.createClient({ busAddress: address, returnBigInt: true });
+      caller = dbus.createClient({ busAddress: address, returnBigInt: true });
+      service.connection.on('error', () => {});
+      caller.connection.on('error', () => {});
+      await Promise.all([service.getId(), caller.getId()]);
+      await service.invokeDbus({
+        member: 'RequestName',
+        signature: 'su',
+        body: ['com.example.Fidelity', 0]
+      });
+
+      const impl = Object.assign(Object.create(EventEmitter.prototype), {
+        EchoX: value => value,
+        EchoT: value => value,
+        EchoDict: value => value,
+        EchoBytes: value => value,
+        EchoVariant: value => value,
+        EchoNested: value => value
+      });
+      EventEmitter.call(impl);
+      service.exportInterface(impl, '/com/example/Fidelity', {
+        name: 'com.example.FidelityIface',
+        methods: {
+          EchoX: ['x', 'x', ['in'], ['out']],
+          EchoT: ['t', 't', ['in'], ['out']],
+          EchoDict: ['a{ss}', 'a{ss}', ['in'], ['out']],
+          EchoBytes: ['ay', 'ay', ['in'], ['out']],
+          EchoVariant: ['v', 'v', ['in'], ['out']],
+          EchoNested: ['a(sit)', 'a(sit)', ['in'], ['out']]
+        },
+        signals: {},
+        properties: {}
+      });
+    });
+
+    after(() => {
+      for (const bus of [service, caller]) {
+        try {
+          bus.connection.stream.destroy();
+        } catch {
+          /* already gone */
+        }
+      }
+    });
+
+    const echo = (member, signature, value) =>
+      caller.invoke({
+        destination: 'com.example.Fidelity',
+        path: '/com/example/Fidelity',
+        interface: 'com.example.FidelityIface',
+        member,
+        signature,
+        body: [value]
+      });
+
+    for (const value of [INT64_MAX, INT64_MIN, -1n, 0n, 1n]) {
+      it(`routes the signed 64-bit value ${value} intact`, async () => {
+        assert.strictEqual(await echo('EchoX', 'x', value), value);
+      });
+    }
+
+    for (const value of [UINT64_MAX, 0n, 1n]) {
+      it(`routes the unsigned 64-bit value ${value} intact`, async () => {
+        assert.strictEqual(await echo('EchoT', 't', value), value);
+      });
+    }
+
+    it('routes a dict intact', async () => {
+      const sent = [
+        ['alpha', 'one'],
+        ['beta', 'two']
+      ];
+      assert.deepStrictEqual(await echo('EchoDict', 'a{ss}', sent), sent);
+    });
+
+    it('routes a byte array intact', async () => {
+      const sent = Buffer.from([0, 1, 127, 128, 255]);
+      const back = await echo('EchoBytes', 'ay', sent);
+      assert.deepStrictEqual(Buffer.from(back), sent);
+    });
+
+    it('routes a variant intact', async () => {
+      const back = await echo('EchoVariant', 'v', ['s', 'inside a variant']);
+      assert.strictEqual(dbus.variantValue(back), 'inside a variant');
+      assert.strictEqual(dbus.variantSignature(back), 's');
+    });
+
+    it('routes a nested struct with a 64-bit field intact', async () => {
+      const sent = [
+        ['first', -7, UINT64_MAX],
+        ['second', 0, 0n]
+      ];
+      assert.deepStrictEqual(await echo('EchoNested', 'a(sit)', sent), sent);
+    });
+  });
+
+  describe('surviving misbehaviour', () => {
+    it('keeps serving other clients when one disappears mid-conversation', async () => {
+      const doomed = await client();
+      const survivor = await client();
+      await request(doomed, 'com.example.Doomed');
+      doomed.connection.stream.destroy();
+      await settle();
+      assert.ok(
+        Array.isArray(await survivor.invokeDbus({ member: 'ListNames' }))
+      );
+      assert.strictEqual(
+        await survivor.invokeDbus({
+          member: 'NameHasOwner',
+          signature: 's',
+          body: ['com.example.Doomed']
+        }),
+        false,
+        'and the dead name is gone'
+      );
+    });
+
+    it('answers a call to an unknown interface on the bus object', async () => {
+      const bus = await client();
+      await assert.rejects(
+        () =>
+          bus.invoke({
+            ...DBUS,
+            interface: 'com.example.NotABusInterface',
+            member: 'Whatever'
+          }),
+        { dbusName: 'org.freedesktop.DBus.Error.UnknownInterface' }
+      );
+    });
+  });
+});


### PR DESCRIPTION
The rest of ROADMAP §4.5. Stacked on #353 (the server handshake) and #354 (match rules) — **review those first**; this branch contains both.

`createServer` has always handed you one `DBusConnection` per accepted socket with nothing between them. Two clients could connect and neither could address the other, because nothing assigned names or routed anything. `lib/broker.js` is the missing part.

## What it does

Implements `org.freedesktop.DBus`: `Hello`, `RequestName`/`ReleaseName` with the full flag and queue behaviour, `ListNames`, `ListActivatableNames`, `NameHasOwner`, `GetNameOwner`, `ListQueuedOwners`, `AddMatch`/`RemoveMatch`, `GetId`, `GetConnectionUnixUser`, `GetConnectionUnixProcessID`, `StartServiceByName`, `UpdateActivationEnvironment`, plus `Peer`, `Introspectable` and `Properties`.

And it routes: unicast by destination (well-known or unique), signals by match rule, `NameOwnerChanged`/`NameAcquired`/`NameLost` as names change hands, and names released when a connection dies — handed to the next in the queue if there is one.

```js
const broker = dbus.createBroker();
broker.listen((err, address) => {
  const bus = dbus.createClient({ busAddress: address });
});
```

## The point of it

```bash
npm run test:integration:broker
```

runs **the whole integration suite against it** instead of against `dbus-daemon`:

```
=== against dbus-daemon ===      === against the broker ===
ℹ tests 131                      ℹ tests 131
ℹ pass 131                       ℹ pass 131
```

So contributors no longer need `dbus-daemon` installed to run the integration tests — which is what §4.5 promised — and from here on, anywhere the two buses disagree shows up as a test that passes against one and fails against the other.

`scripts/with-broker.js` mirrors `scripts/with-dbus.js` exactly, so the tests do not know which bus they are talking to.

## Two things this turned up

**The broker re-encodes what it forwards.** Forwarding here means unmarshalling a message and marshalling it again, so every value has to survive the round trip — and by default a 64-bit integer does not. It is read as a `Number`, lossy above 2^53, and then refused on the way out:

```
Error [DBusError]: Number outside range (Number type can only carry 53 bit integer)
  sender: 'org.freedesktop.DBus'          <- the bus itself produced this
```

The entire `test/integration/bigint.js` file failed against the broker before its own connections were set to read them exactly. A router should keep the body bytes and rewrite only the header fields it must; that needs the message layer to hand back the raw frame alongside the parsed one, which it does not do today. ROADMAP §4.5 now records that as the outstanding debt, and `test/broker.js` pins the fidelity of `x`, `t`, dicts, `ay`, variants and a nested struct with a 64-bit field so a regression is a failure rather than a rounding error.

**A reply the bus failed to marshal left the caller waiting forever** — which is the worst way for a bug in here to present itself, since it reads as a hung test rather than a broken one. `send()` now throws instead of swallowing, the message handler turns that into an error reply, and the test suite collects bus faults so the failure names itself.

## What it deliberately is not

Not a replacement for `dbus-daemon`, said plainly in `docs/api.md` and ROADMAP:

- **No security policy.** Any client may own any name and call anyone. The system bus refuses arbitrary well-known names for good reason; this does not.
- **No service activation.** `StartServiceByName` always answers `ServiceUnknown`.
- **No eavesdropping.** `BecomeMonitor` is unimplemented, so nothing sees unicast traffic addressed elsewhere.

Do not put it on a socket other processes can reach.

## Tests

58 in `test/broker.js`, all over real sockets through the real handshake and marshaller — the only unusual thing is that the bus lives in the test process. Hello and unique names (including that the bus stamps `sender` itself rather than trusting what a client claims), every `RequestName` and `ReleaseName` outcome, replacement and queue succession, the bus object, match rules, routing, signal delivery and filtering, `NameOwnerChanged` on arrival/departure/inheritance, `NameAcquired`/`NameLost`, and what survives being routed.

750 unit tests pass; 131 integration tests pass against both buses; lint, prettier and `tsc --noEmit` clean.