### PR TITLE
chore: a Docker end-to-end checkpoint against real desktop services

### DIFF
--- a/E2E_DOCKER_TESTING.md
+++ b/E2E_DOCKER_TESTING.md
@@ -1,0 +1,213 @@
+# End-to-end testing against a real desktop bus
+
+A Linux container running actual desktop D-Bus services, for exercising
+`dbus-native` against software nobody here wrote.
+
+**This is not part of CI.** `npm test` and `npm run test:integration` stay as
+they are — unit tests, and integration tests against a private `dbus-daemon`
+we start ourselves. This is a checkpoint you run deliberately, when you want to
+know whether the library still behaves against NetworkManager, UPower, GDBus,
+sd-bus and python-dbus rather than against a bus shaped like our expectations.
+
+```bash
+e2e/run.sh                 # everything
+e2e/run.sh 02-types.js     # one file
+e2e/run.sh --shell         # a prompt inside, both buses already up
+```
+
+Requires Docker. The first build takes a few minutes; after that a full run is
+about 40 seconds, most of it the 1.8s signal test and the container boot.
+
+---
+
+## Why this exists
+
+The unit suite and the `test/integration/` suite both talk to a bus we
+configured, exchanging values we chose. That leaves two blind spots:
+
+1. **We pick the types.** Every signature in the test suite is one somebody
+   here thought to write down. Real services emit `a(ss(sa{sv})tt)` and
+   `a(ayuayu)` without being asked.
+2. **We are both ends.** A test where dbus-native talks to dbus-native cannot
+   tell you that GDBus can parse our introspection XML, that sd-bus can write
+   our properties, or that python-dbus can read a hyphenated property name.
+
+The container closes both. It is also the only place the _server_-facing
+behaviour gets a real audience.
+
+---
+
+## What is in the container
+
+`node:24-bookworm` plus the desktop stack. `e2e/docker/start-services.sh`
+brings up a system bus, a session bus, an X server, and every service that will
+run without hardware; anything that will not start is reported and skipped.
+
+| bus     | services that come up                                                                                |
+| ------- | ---------------------------------------------------------------------------------------------------- |
+| system  | `DBus`, `UPower`, `Accounts`, `Avahi`, `NetworkManager`, `UDisks2`, `PolicyKit1`                     |
+| session | `DBus`, `Notifications` (dunst), `portal.Desktop`, `portal.Documents`, `impl.portal.PermissionStore` |
+
+Also present as clients: `gdbus` (GLib), `busctl` (systemd/sd-bus),
+`python3-dbus`, `dbus-send`, `dbus-monitor`.
+
+`systemd1`, `login1`, `hostname1`, `locale1` and `timedate1` appear in
+`ListActivatableNames` but do not start — there is no systemd as PID 1. The
+tests that want them skip rather than fail.
+
+---
+
+## What it covers
+
+`e2e/tests/`, run in order by `run.js`. 41 checks.
+
+### `01-bus.js` — connecting, naming, walking
+
+- Connect to the system bus and the session bus; confirm they are different buses
+- `Hello` and the unique name; `GetId`
+- `ListNames`, `ListActivatableNames`, `NameHasOwner`, `GetNameOwner`,
+  `GetConnectionUnixProcessID`
+- Introspect real services and **walk their whole object tree**, checking that
+  every child a parent advertises is itself reachable
+- `getInterface` / `getObject` / `as()` against a service we did not write
+- A **container path** — one that implements nothing and only holds children —
+  is reported as itself, with its children listed
+
+Real trees walked: UPower (3 objects, one container), NetworkManager (46
+objects, 6 levels deep), UDisks2, Accounts.
+
+### `02-types.js` — the type system, against types we did not choose
+
+The centrepiece is a catalogue: introspect everything on both buses, collect
+every distinct signature, and **assert that all of them parse**. This run found
+38, covering type codes `a b d h i o q s t u v x y`:
+
+```
+a(ssssssuuua{ss})   <- org.freedesktop.PolicyKit1.Authority.EnumerateActions
+a(ss(sa{sv})tt)     <- org.freedesktop.PolicyKit1.Authority.EnumerateTemporaryAuthorizations
+a{oa{sa{sv}}}       <- org.freedesktop.DBus.ObjectManager.GetManagedObjects
+a(xxa{sv})          <- org.freedesktop.Accounts.User.LoginHistory
+a(ayuayu)           <- org.freedesktop.NetworkManager.IP6Config.Routes
+a{sas}              <- org.freedesktop.DBus.Debug.Stats.GetAllMatchRules
+h                   <- org.freedesktop.UDisks2.Manager.LoopSetup
+```
+
+Then, reading real values:
+
+- `a{sv}` from `UPower.GetAll`, in the classic shape and again under
+  `plainValues`, and through `toPlain()`
+- `variantValue` / `variantSignature` against a real variant, in both shapes
+- A real 64-bit property (`NetworkManager.Device.Statistics.TxBytes`) as a
+  `number` and as a `bigint` under `returnBigInt`, checking they agree
+- **`a{oa{sa{sv}}}`** — `ObjectManager.GetManagedObjects` from NetworkManager,
+  42 managed objects. This is the deepest nesting in common use
+- `ao` as object paths, `ay`, `Peer.GetMachineId`
+- **UNIX_FD**: calls `UDisks2.Manager.LoopSetup`, which really does take an
+  `h`, and checks the refusal explains itself
+
+### `03-signals-errors.js` — signals, match rules, failure
+
+- `NameOwnerChanged` observed as a name is claimed and released
+- An `arg0=` match rule
+- `PropertiesChanged` from a real service (skips if none volunteers)
+- Error names from real peers: `ServiceUnknown`, `UnknownMethod`,
+  `UnknownProperty`, unknown object path
+- The caller stack stitched onto a rejection (`--- d-bus call made at ---`)
+- A per-call `timeout`, and cancellation through `AbortSignal`
+
+### `04-interop.js` — our service, consumed by everyone else
+
+Exports a service with methods (`s`, `uu`, `as`, `a{sv}` out), properties
+(readwrite, read-only, and a hyphenated one), a signal, and two child objects.
+Then, from outside:
+
+| client            | checked                                                                              |
+| ----------------- | ------------------------------------------------------------------------------------ |
+| `gdbus`           | introspect, call, read `a{sv}`, receive signals via `gdbus monitor`, error reporting |
+| `busctl` (sd-bus) | introspect, `tree`, call, get/set property, refusal on a read-only property          |
+| `python3-dbus`    | call, `Properties.Get`, `GetAll`                                                     |
+| dbus-native       | the same service through our own proxy API, for symmetry                             |
+
+Every external command runs **async** — `execFileSync` would block the event
+loop and our own service would never answer. That is worth remembering if you
+add to this file.
+
+---
+
+## What this run validated
+
+The tree under test had the six fixes merged after 0.11.0 (#346, #347, #348,
+#350, #351, #352). Several of them are visible here in a way no unit test can
+show:
+
+- **#346** — python-dbus reads `my-prop` and lists it in `GetAll`; sd-bus shows
+  `.my-prop property s "hyphens work"`.
+- **#347** — GDBus parses our introspection XML with an argument named
+  `fields & more` in it. Unescaped, the `&` would have made the whole document
+  unparseable and GDBus would have reported no interfaces at all.
+- **#350** — `/org/freedesktop/UPower/devices` comes back as _itself_, with
+  `nodes: ["DisplayDevice"]`. Before, it came back as `DisplayDevice`.
+- **#351** — `busctl tree com.example.E2EService` draws the children:
+
+  ```
+  └─/com/example/E2EService
+    ├─/com/example/E2EService/Alpha
+    └─/com/example/E2EService/Beta
+  ```
+
+  sd-bus can only draw that because our `Introspect` now lists them.
+
+---
+
+## Findings
+
+Things this turned up that are not bugs the tests fix, recorded so they are not
+rediscovered:
+
+1. **A marshalling failure is raised synchronously from `invoke()`**, not
+   delivered as a rejection or to the callback. `await bus.invoke(...)` inside
+   a `try` sees it, but `bus.invoke(...).catch(...)` does not, and the callback
+   form gets a throw where it expects `cb(err)`. Everything else since 0.7
+   delivers failures as a `DBusError`. Pinned by the UNIX_FD test in
+   `02-types.js` so a change in either direction is deliberate.
+
+2. **The system bus refuses arbitrary well-known names**, as it should:
+   `Connection ":1.11" is not allowed to own the service "com.example.E2EQuiet"
+due to security policies in the configuration file`. Tests that need to own
+   a name must use the session bus.
+
+3. **Introspecting every name is expensive** if a service exports one object
+   per unit. `02-types.js` caps the walk; without it, systemd-shaped services
+   turn a catalogue into thousands of round trips.
+
+4. **Activatable names block for the full bus timeout** when activation cannot
+   succeed. Every connection here sets a 5s per-call `timeout` for that reason;
+   without it a container full of unstartable services looks like a hang.
+
+---
+
+## What it cannot cover
+
+- **UNIX_FD passing.** Refusing it is checked; carrying one is not possible —
+  see ROADMAP §2.8.
+- **Big-endian messages.** Every peer here is little-endian. The unit suite
+  covers big-endian reads with fixtures.
+- **systemd, logind, hostnamed.** They need PID 1. Running the container with
+  `--privileged` and a systemd entrypoint would reach them, at the cost of a
+  much slower and more fragile setup.
+- **Real hardware.** UPower reports no batteries, UDisks2 no disks, so the
+  device trees are shallow. What is exercised is the shape of the protocol, not
+  the variety of the data.
+
+---
+
+## Adding to it
+
+Files matching `NN-*.js` in `e2e/tests/` are picked up automatically by
+`run.js`. `helpers.js` has the connection factories (both already carrying a
+per-call timeout), `walk()` for tree traversal, and `eventually()` for waiting
+on a signal.
+
+Anything that depends on a particular service should ask `listNames()` first
+and log a skip, the way `02-types.js` does for systemd. What starts inside a
+container is not something to hardcode.

--- a/e2e/docker/Dockerfile
+++ b/e2e/docker/Dockerfile
@@ -1,0 +1,34 @@
+# A Linux box with real desktop D-Bus services, for exercising dbus-native
+# against something other than a bus we started ourselves.
+#
+# Node is the base image so the library under test runs natively; everything
+# else is the desktop stack. See E2E_DOCKER_TESTING.md.
+FROM node:24-bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      dbus dbus-x11 \
+      systemd \
+      libglib2.0-bin \
+      python3-dbus python3-gi gir1.2-glib-2.0 \
+      xvfb \
+      upower \
+      accountsservice \
+      policykit-1 \
+      avahi-daemon avahi-utils \
+      network-manager \
+      udisks2 \
+      dunst \
+      xdg-desktop-portal \
+      procps iproute2 \
+    && rm -rf /var/lib/apt/lists/*
+
+# The services below are system-bus services and expect to be root; the point
+# here is protocol surface, not privilege separation.
+COPY start-services.sh /usr/local/bin/start-services.sh
+RUN chmod +x /usr/local/bin/start-services.sh
+
+WORKDIR /work
+ENTRYPOINT ["/usr/local/bin/start-services.sh"]
+CMD ["node", "/work/e2e/tests/run.js"]

--- a/e2e/docker/start-services.sh
+++ b/e2e/docker/start-services.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Bring up a system bus, a session bus, and as much of a desktop as will run
+# inside a container; then exec whatever we were asked to run.
+#
+# Nothing here is fatal: a service that will not start in a container (no
+# hardware, no udev, no kernel netlink) is reported and skipped, and the tests
+# check what is actually on the bus rather than what we hoped for.
+set -u
+
+log() { echo "[services] $*"; }
+
+mkdir -p /run/dbus /var/run/dbus
+
+log "system bus"
+dbus-daemon --system --fork --print-pid
+export DBUS_SYSTEM_BUS_ADDRESS=unix:path=/var/run/dbus/system_bus_socket
+
+log "X (dunst and the portals want a display)"
+Xvfb :99 -screen 0 1024x768x24 >/tmp/xvfb.log 2>&1 &
+export DISPLAY=:99
+
+log "session bus"
+eval "$(dbus-daemon --session --print-address=1 --fork --print-pid=1 | {
+  read -r addr; read -r pid
+  echo "export DBUS_SESSION_BUS_ADDRESS=$addr; export DBUS_SESSION_PID=$pid"
+})"
+log "  ${DBUS_SESSION_BUS_ADDRESS}"
+
+start() {
+  local name="$1"; shift
+  if ! command -v "${1}" >/dev/null 2>&1; then
+    log "  $name: not installed"
+    return
+  fi
+  "$@" >"/tmp/$name.log" 2>&1 &
+  log "  $name: started (pid $!)"
+}
+
+log "system services"
+start polkitd     /usr/lib/policykit-1/polkitd --no-debug
+start upowerd     /usr/libexec/upowerd
+start accounts    /usr/libexec/accounts-daemon
+start avahi       avahi-daemon --no-drop-root --no-chroot
+start udisksd     /usr/libexec/udisks2/udisksd --no-debug
+start nm          /usr/sbin/NetworkManager --no-daemon
+
+log "session services"
+start dunst       dunst
+
+# Give the daemons a moment to claim their names.
+sleep "${SERVICE_SETTLE_SECONDS:-4}"
+
+log "system bus names:"
+busctl --system list --no-pager --no-legend 2>/dev/null | awk '{print "    " $1}' | sort -u
+log "session bus names:"
+busctl --user --address="$DBUS_SESSION_BUS_ADDRESS" list --no-pager --no-legend 2>/dev/null |
+  awk '{print "    " $1}' | sort -u
+
+log "running: $*"
+exec "$@"

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Build the container and run the end-to-end checks against it.
+#
+#   e2e/run.sh                      # everything
+#   e2e/run.sh 02-types.js          # one file
+#   e2e/run.sh --shell              # a prompt inside, buses already up
+#
+# See E2E_DOCKER_TESTING.md.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo="$(cd "$here/.." && pwd)"
+image="${E2E_IMAGE:-dbus-native-e2e}"
+
+echo "building $image"
+docker build -q -t "$image" -f "$here/docker/Dockerfile" "$here/docker" >/dev/null
+
+mount=(-v "$repo:/work:ro")
+
+case "${1:-}" in
+  --shell)
+    exec docker run --rm -it "${mount[@]}" "$image" bash
+    ;;
+  '')
+    exec docker run --rm -t "${mount[@]}" "$image" node /work/e2e/tests/run.js
+    ;;
+  *)
+    exec docker run --rm -t "${mount[@]}" "$image" \
+      node --test-reporter=spec --test-timeout=60000 "/work/e2e/tests/$1"
+    ;;
+esac

--- a/e2e/tests/01-bus.js
+++ b/e2e/tests/01-bus.js
@@ -1,0 +1,210 @@
+// Connecting, naming, introspecting and walking real services.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('assert');
+const {
+  system,
+  session,
+  DBUS,
+  listNames,
+  introspect,
+  walk,
+  close
+} = require('./helpers');
+
+describe('bus basics', { timeout: 30000 }, () => {
+  let sys, ses;
+
+  before(async () => {
+    sys = system();
+    ses = session();
+    await Promise.all([sys.getId(), ses.getId()]);
+  });
+  after(() => close(sys, ses));
+
+  it('connects to the system bus and gets a unique name', async () => {
+    const name = await sys.invoke({ ...DBUS, member: 'GetId' });
+    assert.match(name, /^[0-9a-f]{32}$/, 'the bus GUID');
+    assert.match(sys.name, /^:\d+\.\d+$/, `unique name, got ${sys.name}`);
+  });
+
+  it('connects to the session bus, which is a different bus', async () => {
+    const [a, b] = await Promise.all([
+      sys.invoke({ ...DBUS, member: 'GetId' }),
+      ses.invoke({ ...DBUS, member: 'GetId' })
+    ]);
+    assert.notStrictEqual(a, b);
+  });
+
+  it('sees the desktop services on the system bus', async () => {
+    const names = await listNames(sys);
+    // UPower and Accounts start in a container; the rest depend on hardware.
+    for (const expected of ['org.freedesktop.UPower', 'org.freedesktop.DBus']) {
+      assert.ok(names.includes(expected), `${expected} is on the bus`);
+    }
+    assert.ok(
+      names.filter(n => n.startsWith(':')).length >= 2,
+      'and several unique names'
+    );
+  });
+
+  it('answers NameHasOwner and GetNameOwner consistently', async () => {
+    const owner = await sys.invoke({
+      ...DBUS,
+      member: 'GetNameOwner',
+      signature: 's',
+      body: ['org.freedesktop.UPower']
+    });
+    assert.match(owner, /^:\d+\.\d+$/);
+
+    const has = await sys.invoke({
+      ...DBUS,
+      member: 'NameHasOwner',
+      signature: 's',
+      body: ['org.freedesktop.UPower']
+    });
+    assert.strictEqual(has, true);
+
+    const missing = await sys.invoke({
+      ...DBUS,
+      member: 'NameHasOwner',
+      signature: 's',
+      body: ['com.example.NotThere']
+    });
+    assert.strictEqual(missing, false);
+  });
+
+  it('lists activatable names, which is a superset of what is running', async () => {
+    const [running, activatable] = await Promise.all([
+      listNames(sys),
+      sys.invoke({ ...DBUS, member: 'ListActivatableNames' })
+    ]);
+    assert.ok(activatable.length > 0, 'the container ships service files');
+    const wellKnownRunning = running.filter(n => !n.startsWith(':'));
+    assert.ok(
+      activatable.some(n => !wellKnownRunning.includes(n)),
+      'and at least one is not started yet'
+    );
+  });
+
+  it('reads a real service unique-name owner back to a pid', async () => {
+    const pid = await sys.invoke({
+      ...DBUS,
+      member: 'GetConnectionUnixProcessID',
+      signature: 's',
+      body: ['org.freedesktop.UPower']
+    });
+    assert.ok(Number.isInteger(pid) && pid > 0, `a pid, got ${pid}`);
+  });
+});
+
+describe('introspecting real services', { timeout: 60000 }, () => {
+  let sys, ses;
+  before(async () => {
+    sys = system();
+    ses = session();
+    await Promise.all([sys.getId(), ses.getId()]);
+  });
+  after(() => close(sys, ses));
+
+  it('parses UPower, which nests devices under a container path', async () => {
+    const xml = await introspect(
+      sys,
+      'org.freedesktop.UPower',
+      '/org/freedesktop/UPower'
+    );
+    assert.match(xml, /<node/);
+    assert.match(xml, /org\.freedesktop\.UPower/);
+  });
+
+  it('walks the whole UPower tree by introspection alone', async () => {
+    const tree = await walk(
+      sys,
+      'org.freedesktop.UPower',
+      '/org/freedesktop/UPower'
+    );
+    assert.ok(tree.length >= 1, 'at least the root');
+    // /org/freedesktop/UPower/devices is the classic container: it implements
+    // nothing and exists only to hold the devices.
+    const containers = tree.filter(n => n.interfaces.length === 0);
+    const withIfaces = tree.filter(n => n.interfaces.length > 0);
+    assert.ok(
+      withIfaces.length >= 1,
+      'and something that implements something'
+    );
+    console.log(
+      `    UPower: ${tree.length} objects, ${containers.length} containers`
+    );
+    for (const node of tree) {
+      console.log(
+        `      ${node.path}  [${node.interfaces.filter(i => !i.startsWith('org.freedesktop.DBus')).join(', ')}]`
+      );
+    }
+  });
+
+  it('walks a deep tree without losing a branch', async () => {
+    // NetworkManager and systemd both nest several levels; whichever is here.
+    for (const [name, root] of [
+      ['org.freedesktop.NetworkManager', '/org/freedesktop/NetworkManager'],
+      ['org.freedesktop.UDisks2', '/org/freedesktop/UDisks2'],
+      ['org.freedesktop.Accounts', '/org/freedesktop/Accounts']
+    ]) {
+      const names = await listNames(sys);
+      if (!names.includes(name)) {
+        console.log(`    ${name}: not on the bus, skipped`);
+        continue;
+      }
+      const tree = await walk(sys, name, root, 60);
+      const depth = Math.max(...tree.map(n => n.path.split('/').length));
+      console.log(`    ${name}: ${tree.length} objects, depth ${depth}`);
+      assert.ok(tree.length >= 1);
+      // Every child a parent advertised must itself be reachable.
+      const paths = new Set(tree.map(n => n.path));
+      for (const node of tree) {
+        for (const child of node.children) {
+          const childPath =
+            node.path === '/' ? `/${child}` : `${node.path}/${child}`;
+          assert.ok(
+            paths.has(childPath),
+            `${childPath} was advertised but not reachable`
+          );
+        }
+      }
+    }
+  });
+
+  it('builds a proxy for a real object through getInterface', async () => {
+    const iface = await new Promise((resolve, reject) =>
+      sys.getInterface(
+        'org.freedesktop.UPower',
+        '/org/freedesktop/UPower',
+        'org.freedesktop.UPower',
+        (err, value) => (err ? reject(err) : resolve(value))
+      )
+    );
+    assert.strictEqual(typeof iface.EnumerateDevices, 'function');
+    const devices = await new Promise((resolve, reject) =>
+      iface.EnumerateDevices((err, value) =>
+        err ? reject(err) : resolve(value)
+      )
+    );
+    assert.ok(Array.isArray(devices), 'ao comes back as an array');
+    console.log(`    EnumerateDevices -> ${JSON.stringify(devices)}`);
+  });
+
+  it('reports a container path as itself, and names its children', async () => {
+    // The regression that #350 fixed, against a service we did not write.
+    const object = await new Promise((resolve, reject) =>
+      sys.getObject(
+        'org.freedesktop.UPower',
+        '/org/freedesktop/UPower/devices',
+        (err, value) => (err ? reject(err) : resolve(value))
+      )
+    );
+    assert.strictEqual(object.name, '/org/freedesktop/UPower/devices');
+    assert.ok(Array.isArray(object.nodes), 'the children are listed');
+    console.log(
+      `    devices container -> nodes ${JSON.stringify(object.nodes)}`
+    );
+  });
+});

--- a/e2e/tests/02-types.js
+++ b/e2e/tests/02-types.js
@@ -1,0 +1,362 @@
+// The type system, against signatures real services actually use.
+//
+// The interesting part is that we do not get to choose the shapes here. A
+// service written by somebody else decides what comes down the wire, so this
+// is the closest thing to a fuzz corpus the ecosystem provides.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('assert');
+const {
+  dbus,
+  system,
+  session,
+  listNames,
+  introspect,
+  getProperty,
+  getAll,
+  walk,
+  close
+} = require('./helpers');
+
+const { parseStringPromise } = require('/work/node_modules/xml2js');
+
+describe('signature coverage', { timeout: 120000 }, () => {
+  let sys, ses;
+  before(async () => {
+    sys = system();
+    ses = session();
+    await Promise.all([sys.getId(), ses.getId()]);
+  });
+  after(() => close(sys, ses));
+
+  it('catalogues every signature the container advertises', async () => {
+    const signatures = new Map(); // signature -> where it was first seen
+    const parse = require('/work/lib/signature');
+    // systemd exports one object per unit and one per job, so an unbounded
+    // recursion is thousands of round trips for no extra type coverage: the
+    // units all implement the same two interfaces.
+    const MAX_OBJECTS = Number(process.env.E2E_MAX_OBJECTS || 250);
+    let visited = 0;
+
+    const collect = async (bus, name, path) => {
+      if (visited++ > MAX_OBJECTS) return;
+      let doc;
+      try {
+        doc = await parseStringPromise(await introspect(bus, name, path));
+      } catch {
+        return;
+      }
+      for (const iface of (doc.node || {}).interface || []) {
+        const note = (sig, where) => {
+          if (!sig) return;
+          if (!signatures.has(sig)) signatures.set(sig, where);
+        };
+        for (const method of iface.method || []) {
+          for (const arg of method.arg || []) {
+            note(arg.$.type, `${iface.$.name}.${method.$.name}`);
+          }
+        }
+        for (const signal of iface.signal || []) {
+          for (const arg of signal.arg || []) {
+            note(arg.$.type, `${iface.$.name}.${signal.$.name}`);
+          }
+        }
+        for (const prop of iface.property || []) {
+          note(prop.$.type, `${iface.$.name}.${prop.$.name}`);
+        }
+      }
+      for (const child of (doc.node || {}).node || []) {
+        if (child.$ && child.$.name) {
+          await collect(
+            bus,
+            name,
+            path === '/' ? `/${child.$.name}` : `${path}/${child.$.name}`
+          );
+        }
+      }
+    };
+
+    for (const [bus, label] of [
+      [sys, 'system'],
+      [ses, 'session']
+    ]) {
+      visited = 0;
+      for (const name of await listNames(bus)) {
+        if (name.startsWith(':')) continue;
+        visited = 0;
+        const root = `/${name.replace(/\./g, '/')}`;
+        await collect(bus, name, root);
+        visited = 0;
+        await collect(bus, name, '/');
+      }
+      console.log(`    after ${label}: ${signatures.size} distinct signatures`);
+    }
+
+    // Every one of them must parse. This is the real assertion: the parser
+    // meets whatever the desktop emits, not just what our tests invent.
+    const failures = [];
+    for (const [sig, where] of signatures) {
+      try {
+        parse(sig);
+      } catch (err) {
+        failures.push(`${sig} (${where}): ${err.message}`);
+      }
+    }
+    assert.deepStrictEqual(failures, [], 'every advertised signature parses');
+
+    const byLength = [...signatures.keys()].sort((a, b) => b.length - a.length);
+    console.log(`    ${signatures.size} distinct signatures. All of them:`);
+    for (const sig of byLength) {
+      console.log(`      ${sig.padEnd(22)} <- ${signatures.get(sig)}`);
+    }
+
+    // Which type codes turned up at all. The interesting entry is 'h', the
+    // one this library cannot carry -- see ROADMAP 2.8.
+    const codes = [...new Set([...signatures.keys()].flatMap(s => [...s]))]
+      .filter(c => /[a-z]/i.test(c))
+      .sort();
+    console.log(`    type codes seen: ${codes.join(' ')}`);
+
+    assert.ok(signatures.size > 30, `only ${signatures.size} signatures seen`);
+  });
+
+  it('reads a{sv} from a real service', async () => {
+    const all = await getAll(
+      sys,
+      'org.freedesktop.UPower',
+      '/org/freedesktop/UPower',
+      'org.freedesktop.UPower'
+    );
+    // The classic shape: an array of [key, [signatureTree, [value]]] pairs.
+    assert.ok(Array.isArray(all));
+    assert.ok(all.length > 0, 'UPower has properties');
+    for (const entry of all) {
+      assert.strictEqual(entry.length, 2, 'a dict entry is a pair');
+    }
+    const asObject = dbus.toPlain(all);
+    assert.strictEqual(typeof asObject, 'object');
+    console.log(`    UPower.GetAll -> ${JSON.stringify(asObject)}`);
+  });
+
+  it('reads the same a{sv} as a plain object under plainValues', async () => {
+    const plain = session({ plainValues: true });
+    const sysPlain = system({ plainValues: true });
+    await Promise.all([plain.getId(), sysPlain.getId()]);
+    try {
+      const all = await getAll(
+        sysPlain,
+        'org.freedesktop.UPower',
+        '/org/freedesktop/UPower',
+        'org.freedesktop.UPower'
+      );
+      assert.ok(!Array.isArray(all), 'a string-keyed dict becomes an object');
+      assert.ok('DaemonVersion' in all, `got keys ${Object.keys(all)}`);
+      assert.strictEqual(typeof all.DaemonVersion, 'string', 'unwrapped');
+      console.log(`    plainValues -> ${JSON.stringify(all)}`);
+    } finally {
+      close(plain, sysPlain);
+    }
+  });
+
+  it('unwraps a variant with variantValue in either shape', async () => {
+    const classic = await getProperty(
+      sys,
+      'org.freedesktop.UPower',
+      '/org/freedesktop/UPower',
+      'org.freedesktop.UPower',
+      'DaemonVersion'
+    );
+    assert.strictEqual(typeof dbus.variantValue(classic), 'string');
+    assert.strictEqual(dbus.variantSignature(classic), 's');
+
+    const plainBus = system({ plainValues: true });
+    await plainBus.getId();
+    try {
+      const plain = await getProperty(
+        plainBus,
+        'org.freedesktop.UPower',
+        '/org/freedesktop/UPower',
+        'org.freedesktop.UPower',
+        'DaemonVersion'
+      );
+      assert.strictEqual(typeof plain, 'string', 'already a plain value');
+      assert.strictEqual(dbus.variantValue(plain), plain, 'and idempotent');
+    } finally {
+      close(plainBus);
+    }
+  });
+
+  it('reads a 64-bit property as a number and as a bigint', async () => {
+    // Search for a readable t or x rather than guessing at a service: which
+    // ones start in a container is not something to hardcode.
+    const target = await (async () => {
+      for (const name of await listNames(sys)) {
+        if (name.startsWith(':')) continue;
+        // The 64-bit properties live on device objects, not on the root --
+        // NetworkManager keeps TxBytes per interface, UPower TimeToEmpty per
+        // battery -- so this has to descend.
+        const tree = await walk(sys, name, `/${name.replace(/\./g, '/')}`, 40);
+        for (const node of tree) {
+          let doc;
+          try {
+            doc = await parseStringPromise(
+              await introspect(sys, name, node.path)
+            );
+          } catch {
+            continue;
+          }
+          for (const iface of (doc.node || {}).interface || []) {
+            for (const prop of iface.property || []) {
+              const { type, access, name: propName } = prop.$;
+              if ((type !== 't' && type !== 'x') || access === 'write')
+                continue;
+              try {
+                await getProperty(sys, name, node.path, iface.$.name, propName);
+                return [name, node.path, iface.$.name, propName];
+              } catch {
+                /* not readable here; keep looking */
+              }
+            }
+          }
+        }
+      }
+      return null;
+    })();
+    if (!target)
+      return console.log('    no 64-bit property available, skipped');
+
+    const [name, path, iface, prop] = target;
+    console.log(`    using ${iface}.${prop} on ${name}`);
+    const asNumber = dbus.variantValue(
+      await getProperty(sys, name, path, iface, prop)
+    );
+    assert.strictEqual(typeof asNumber, 'number');
+
+    const big = system({ returnBigInt: true });
+    await big.getId();
+    try {
+      const asBigInt = dbus.variantValue(
+        await getProperty(big, name, path, iface, prop)
+      );
+      assert.strictEqual(typeof asBigInt, 'bigint');
+      assert.strictEqual(Number(asBigInt), asNumber, 'the same value');
+      console.log(`    ${prop}: ${asNumber} / ${asBigInt}n`);
+    } finally {
+      close(big);
+    }
+  });
+
+  it('reads the deepest nesting in common use: a{oa{sa{sv}}}', async () => {
+    // ObjectManager.GetManagedObjects. Dict of object path -> dict of
+    // interface -> dict of property -> variant.
+    const names = await listNames(sys);
+    const managers = [
+      ['org.freedesktop.UDisks2', '/org/freedesktop/UDisks2'],
+      ['org.freedesktop.Accounts', '/org/freedesktop/Accounts'],
+      ['org.freedesktop.NetworkManager', '/org/freedesktop']
+    ].filter(([name]) => names.includes(name));
+
+    let read = 0;
+    for (const [name, path] of managers) {
+      let managed;
+      try {
+        managed = await sys.invoke({
+          destination: name,
+          path,
+          interface: 'org.freedesktop.DBus.ObjectManager',
+          member: 'GetManagedObjects'
+        });
+      } catch (err) {
+        console.log(
+          `    ${name}: no ObjectManager (${err.dbusName || err.message})`
+        );
+        continue;
+      }
+      read++;
+      assert.ok(Array.isArray(managed), 'the outer dict is an array of pairs');
+      const plain = dbus.toPlain(managed);
+      const paths = Object.keys(plain);
+      console.log(`    ${name}: ${paths.length} managed objects`);
+      for (const objectPath of paths.slice(0, 3)) {
+        const ifaces = Object.keys(plain[objectPath]);
+        console.log(`      ${objectPath} -> ${ifaces.length} interfaces`);
+        assert.ok(objectPath.startsWith('/'), 'keyed by object path');
+      }
+    }
+    assert.ok(read > 0, 'at least one ObjectManager answered');
+  });
+
+  it('explains itself when a real method wants a UNIX_FD', async () => {
+    // UDisks2.Manager.LoopSetup takes an 'h'. Nothing in Node can send one --
+    // a file descriptor travels as ancillary data (SCM_RIGHTS) alongside the
+    // message, not in it. The message this produces is the whole feature, so
+    // it is worth checking against the service that actually asks for one.
+    const names = await listNames(sys);
+    if (!names.includes('org.freedesktop.UDisks2')) {
+      return console.log('    UDisks2 not on the bus, skipped');
+    }
+    const call = () =>
+      sys.invoke({
+        destination: 'org.freedesktop.UDisks2',
+        path: '/org/freedesktop/UDisks2/Manager',
+        interface: 'org.freedesktop.UDisks2.Manager',
+        member: 'LoopSetup',
+        signature: 'ha{sv}',
+        body: [0, []]
+      });
+
+    // Note the shape: this comes out of invoke() *synchronously*, because it
+    // fails while marshalling rather than on the wire. `await call()` and a
+    // try/catch both see it, but `call().catch(...)` does not, and the
+    // callback form gets a throw where it expects cb(err). Everything else
+    // since 0.7 delivers failures as a DBusError to the callback or the
+    // rejection; this is the one place that does not.
+    let thrown = null;
+    try {
+      await call();
+    } catch (err) {
+      thrown = err;
+    }
+    assert.ok(thrown, 'the call failed');
+    assert.match(thrown.message, /UNIX_FD \('h'\) is not supported/);
+    assert.match(thrown.message, /SCM_RIGHTS/, 'and says why');
+    assert.match(
+      thrown.message,
+      /ROADMAP\.md section 2\.8/,
+      'and where to look'
+    );
+
+    let synchronous = false;
+    try {
+      call();
+    } catch {
+      synchronous = true;
+    }
+    assert.strictEqual(synchronous, true, 'thrown before returning a thenable');
+    console.log(`    ${thrown.message.split('. ')[0]}.`);
+    console.log('    (raised synchronously from invoke, not as a rejection)');
+  });
+
+  it('reads ay as a Buffer, and ao as object paths', async () => {
+    const names = await listNames(sys);
+    if (!names.includes('org.freedesktop.UPower')) return;
+    const devices = await sys.invoke({
+      destination: 'org.freedesktop.UPower',
+      path: '/org/freedesktop/UPower',
+      interface: 'org.freedesktop.UPower',
+      member: 'EnumerateDevices'
+    });
+    assert.ok(Array.isArray(devices));
+    for (const p of devices) assert.match(p, /^\//, 'an object path');
+
+    // Machine id is the easiest ay-adjacent thing; use Peer.GetMachineId for a
+    // string and hostname1's machine id property when it is there.
+    const machineId = await sys.invoke({
+      destination: 'org.freedesktop.UPower',
+      path: '/org/freedesktop/UPower',
+      interface: 'org.freedesktop.DBus.Peer',
+      member: 'GetMachineId'
+    });
+    assert.match(machineId, /^[0-9a-f]{32}$/);
+  });
+});

--- a/e2e/tests/03-signals-errors.js
+++ b/e2e/tests/03-signals-errors.js
@@ -1,0 +1,263 @@
+// Signals, match rules, errors and cancellation, against real peers.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('assert');
+const { execFileSync } = require('child_process');
+const {
+  dbus,
+  system,
+  session,
+  DBUS,
+  listNames,
+  eventually,
+  close
+} = require('./helpers');
+
+describe('signals from real services', { timeout: 40000 }, () => {
+  let sys, ses;
+  before(async () => {
+    sys = system();
+    ses = session();
+    await Promise.all([sys.getId(), ses.getId()]);
+  });
+  after(() => close(sys, ses));
+
+  it('receives NameOwnerChanged when a name comes and goes', async () => {
+    const seen = [];
+    await ses.addMatch(
+      "type='signal',sender='org.freedesktop.DBus',interface='org.freedesktop.DBus',member='NameOwnerChanged'"
+    );
+    ses.connection.on('message', msg => {
+      if (msg.member === 'NameOwnerChanged') seen.push(msg.body);
+    });
+
+    // A second connection claiming a name is the cheapest way to cause one.
+    const other = session();
+    await other.getId();
+    const NAME = 'com.example.E2ETransient';
+    await new Promise((resolve, reject) =>
+      other.requestName(NAME, 0, err => (err ? reject(err) : resolve()))
+    );
+    await eventually(
+      () => seen.find(body => body[0] === NAME && body[2] !== ''),
+      { label: `${NAME} acquired` }
+    );
+    close(other);
+    const lost = await eventually(
+      () => seen.find(body => body[0] === NAME && body[2] === ''),
+      { label: `${NAME} released` }
+    );
+    assert.strictEqual(lost[0], NAME);
+    assert.strictEqual(lost[2], '', 'no new owner');
+    console.log(`    saw ${seen.length} NameOwnerChanged signals`);
+  });
+
+  it('filters with an arg0 match rule', async () => {
+    const NAME = 'com.example.E2EArgZero';
+    const matched = [];
+    await ses.addMatch(
+      `type='signal',interface='org.freedesktop.DBus',member='NameOwnerChanged',arg0='${NAME}'`
+    );
+    ses.connection.on('message', msg => {
+      if (msg.member === 'NameOwnerChanged') matched.push(msg.body[0]);
+    });
+
+    const noise = session();
+    await noise.getId();
+    await new Promise((resolve, reject) =>
+      noise.requestName('com.example.E2ENoise', 0, err =>
+        err ? reject(err) : resolve()
+      )
+    );
+    const wanted = session();
+    await wanted.getId();
+    await new Promise((resolve, reject) =>
+      wanted.requestName(NAME, 0, err => (err ? reject(err) : resolve()))
+    );
+
+    await eventually(() => matched.includes(NAME), { label: 'the arg0 match' });
+    close(noise, wanted);
+    // The rule above is not the only one this connection has, so we cannot
+    // assert nothing else arrived -- only that the one we asked for did.
+    assert.ok(matched.includes(NAME));
+  });
+
+  it('receives PropertiesChanged emitted by a real service', async () => {
+    // Ask systemd to reload, or poke UPower; whichever is present will emit
+    // something. Fall back to reporting that nothing volunteered.
+    const names = await listNames(sys);
+    if (!names.includes('org.freedesktop.systemd1')) {
+      return console.log('    systemd1 not on the system bus, skipped');
+    }
+    const changes = [];
+    await sys.addMatch(
+      "type='signal',interface='org.freedesktop.DBus.Properties',member='PropertiesChanged'"
+    );
+    sys.connection.on('message', msg => {
+      if (msg.member === 'PropertiesChanged') changes.push(msg);
+    });
+    try {
+      execFileSync('busctl', [
+        'call',
+        'org.freedesktop.systemd1',
+        '/org/freedesktop/systemd1',
+        'org.freedesktop.systemd1.Manager',
+        'Reload'
+      ]);
+    } catch {
+      /* reload is not always permitted in a container */
+    }
+    const change = await eventually(() => changes[0], {
+      timeout: 8000,
+      label: 'a PropertiesChanged'
+    }).catch(() => null);
+    if (!change) return console.log('    nothing emitted one, skipped');
+    assert.strictEqual(typeof change.body[0], 'string', 'the interface name');
+    console.log(`    PropertiesChanged from ${change.body[0]}`);
+  });
+});
+
+describe('errors from real services', { timeout: 30000 }, () => {
+  let sys;
+  before(async () => {
+    sys = system();
+    await sys.getId();
+  });
+  after(() => close(sys));
+
+  it('reports an unknown service as ServiceUnknown', async () => {
+    await assert.rejects(
+      () =>
+        sys.invoke({
+          destination: 'com.example.NotRunning',
+          path: '/',
+          interface: 'com.example.Iface',
+          member: 'Nope'
+        }),
+      err => {
+        assert.ok(err instanceof dbus.DBusError, 'a DBusError');
+        assert.strictEqual(
+          err.dbusName,
+          'org.freedesktop.DBus.Error.ServiceUnknown'
+        );
+        assert.ok(err.message.length > 0, 'with the daemon message');
+        return true;
+      }
+    );
+  });
+
+  it('reports an unknown method on a real service', async () => {
+    await assert.rejects(
+      () =>
+        sys.invoke({
+          destination: 'org.freedesktop.UPower',
+          path: '/org/freedesktop/UPower',
+          interface: 'org.freedesktop.UPower',
+          member: 'NoSuchMethod'
+        }),
+      err => {
+        assert.match(err.dbusName, /UnknownMethod|UnknownInterface/);
+        return true;
+      }
+    );
+  });
+
+  it('reports an unknown object path', async () => {
+    await assert.rejects(
+      () =>
+        sys.invoke({
+          destination: 'org.freedesktop.UPower',
+          path: '/org/freedesktop/UPower/nope/nope',
+          interface: 'org.freedesktop.DBus.Properties',
+          member: 'GetAll',
+          signature: 's',
+          body: ['org.freedesktop.UPower']
+        }),
+      err => {
+        assert.ok(err.dbusName, `a named error, got ${err.message}`);
+        return true;
+      }
+    );
+  });
+
+  it('reports an unknown property', async () => {
+    await assert.rejects(
+      () =>
+        sys.invoke({
+          destination: 'org.freedesktop.UPower',
+          path: '/org/freedesktop/UPower',
+          interface: 'org.freedesktop.DBus.Properties',
+          member: 'Get',
+          signature: 'ss',
+          body: ['org.freedesktop.UPower', 'NoSuchProperty']
+        }),
+      err => {
+        assert.match(err.dbusName, /UnknownProperty|InvalidArgs/);
+        return true;
+      }
+    );
+  });
+
+  it('carries the caller stack on a rejection', async () => {
+    const err = await sys
+      .invoke({
+        destination: 'com.example.NotRunning',
+        path: '/',
+        interface: 'x.y',
+        member: 'z'
+      })
+      .catch(e => e);
+    assert.match(err.stack, /d-bus call made at/);
+    assert.match(err.stack, /03-signals-errors/, 'and points back here');
+  });
+
+  it('times out or errors on a peer that owns a name but serves nothing', async () => {
+    // On the session bus, because the system bus only lets allow-listed names
+    // be owned -- "not allowed to own the service ... due to security policies
+    // in the configuration file" is the system bus working as intended.
+    const quiet = session();
+    const caller = session();
+    await Promise.all([quiet.getId(), caller.getId()]);
+    const NAME = 'com.example.E2EQuiet';
+    await new Promise((resolve, reject) =>
+      quiet.requestName(NAME, 0, err => (err ? reject(err) : resolve()))
+    );
+    try {
+      await assert.rejects(
+        () =>
+          caller.invoke(
+            {
+              destination: NAME,
+              path: '/nowhere',
+              interface: 'com.example.Iface',
+              member: 'Hang'
+            },
+            { timeout: 400 }
+          ),
+        err => {
+          // This library answers an unrouted call with an error of its own, so
+          // either outcome is correct -- what matters is that the caller is
+          // not left waiting forever.
+          assert.ok(
+            err.code === 'ETIMEDOUT' || err.dbusName,
+            `expected a timeout or a named error, got ${err.message}`
+          );
+          console.log(`    -> ${err.dbusName || err.code}`);
+          return true;
+        }
+      );
+    } finally {
+      close(quiet, caller);
+    }
+  });
+
+  it('cancels an in-flight call through an AbortSignal', async () => {
+    const controller = new AbortController();
+    const call = sys.invoke(
+      { ...DBUS, member: 'ListNames' },
+      { signal: controller.signal }
+    );
+    controller.abort();
+    await assert.rejects(() => call, { code: 'ABORT_ERR' });
+  });
+});

--- a/e2e/tests/04-interop.js
+++ b/e2e/tests/04-interop.js
@@ -1,0 +1,372 @@
+// A service written with dbus-native, consumed by other implementations.
+//
+// This is the direction the unit tests cannot cover: whether GDBus, sd-bus and
+// python-dbus can introspect, call, read, write and subscribe to what we
+// export. Every external command runs async on purpose -- execFileSync would
+// block the event loop, and our own service would never answer.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('assert');
+const { execFile } = require('child_process');
+const { promisify } = require('util');
+const { EventEmitter } = require('events');
+const { session, eventually, close } = require('./helpers');
+
+const run = promisify(execFile);
+
+const SERVICE = 'com.example.E2EService';
+const ROOT = '/com/example/E2EService';
+const IFACE = 'com.example.E2EIface';
+
+const gdbus = args => run('gdbus', args, { encoding: 'utf8' });
+// --address rather than --user: there is no systemd user session in the
+// container, so busctl would go looking for $XDG_RUNTIME_DIR/bus.
+const busctl = args =>
+  run(
+    'busctl',
+    [
+      `--address=${process.env.DBUS_SESSION_BUS_ADDRESS}`,
+      '--no-pager',
+      ...args
+    ],
+    { encoding: 'utf8' }
+  );
+
+describe(
+  'our service, seen by other implementations',
+  { timeout: 60000 },
+  () => {
+    let bus, impl;
+
+    before(async () => {
+      bus = session();
+      await bus.getId();
+      await new Promise((resolve, reject) =>
+        bus.requestName(SERVICE, 0, err => (err ? reject(err) : resolve()))
+      );
+
+      impl = Object.assign(Object.create(EventEmitter.prototype), {
+        Echo: text => text,
+        Add: (a, b) => a + b,
+        Concat: parts => parts.join('|'),
+        Describe: () => [
+          ['name', ['s', 'e2e']],
+          ['count', ['u', 7]]
+        ],
+        Greeting: 'hello',
+        Locked: true,
+        'my-prop': 'hyphens work'
+      });
+      EventEmitter.call(impl);
+
+      bus.exportInterface(impl, ROOT, {
+        name: IFACE,
+        methods: {
+          Echo: ['s', 's', ['text'], ['echoed']],
+          Add: ['uu', 'u', ['a', 'b'], ['sum']],
+          Concat: ['as', 's', ['parts'], ['joined']],
+          // An argument name that has to be escaped in the introspection XML.
+          Describe: ['', 'a{sv}', [], ['fields & more']]
+        },
+        signals: { Pinged: ['s', 'who'] },
+        properties: {
+          Greeting: 's',
+          Locked: { type: 'b', access: 'read' },
+          // Rejected outright before 0.11.1.
+          'my-prop': 's'
+        }
+      });
+
+      // A small tree, so the child-node listing can be checked from outside.
+      for (const child of ['Alpha', 'Beta']) {
+        const leaf = Object.assign(Object.create(EventEmitter.prototype), {
+          Who: () => child
+        });
+        EventEmitter.call(leaf);
+        bus.exportInterface(leaf, `${ROOT}/${child}`, {
+          name: `${IFACE}.Child`,
+          methods: { Who: ['', 's', [], ['name']] },
+          signals: {},
+          properties: {}
+        });
+      }
+    });
+
+    after(() => close(bus));
+
+    it('is introspectable by GDBus, arg names and all', async () => {
+      const { stdout } = await gdbus([
+        'introspect',
+        '--session',
+        '--dest',
+        SERVICE,
+        '--object-path',
+        ROOT
+      ]);
+      assert.match(stdout, /interface com\.example\.E2EIface/);
+      assert.match(stdout, /Echo\(/);
+      assert.match(stdout, /my-prop/, 'a hyphenated property survives');
+      // GDBus parsed the document, which it could not have done if the '&' in
+      // the arg name had gone in unescaped.
+      assert.match(stdout, /Describe/);
+      console.log(
+        stdout
+          .split('\n')
+          .filter(l => /interface|readwrite|readonly|\(/.test(l))
+          .slice(0, 14)
+          .map(l => `      ${l.trim()}`)
+          .join('\n')
+      );
+    });
+
+    it('is introspectable by sd-bus', async () => {
+      const { stdout } = await busctl(['introspect', SERVICE, ROOT]);
+      assert.match(stdout, /com\.example\.E2EIface/);
+      assert.match(stdout, /\.my-prop\s+property/);
+      assert.match(stdout, /\.Echo\s+method/);
+    });
+
+    it('advertises its children, so sd-bus can draw the tree', async () => {
+      const { stdout } = await busctl(['tree', SERVICE]);
+      console.log(
+        stdout
+          .split('\n')
+          .map(l => `      ${l}`)
+          .join('\n')
+      );
+      assert.match(stdout, /\/com\/example\/E2EService/);
+      assert.match(stdout, /Alpha/, 'the first child is listed');
+      assert.match(stdout, /Beta/, 'and so is the second');
+    });
+
+    it('answers method calls from GDBus', async () => {
+      const echo = await gdbus([
+        'call',
+        '--session',
+        '--dest',
+        SERVICE,
+        '--object-path',
+        ROOT,
+        '--method',
+        `${IFACE}.Echo`,
+        'hello from gdbus'
+      ]);
+      assert.match(echo.stdout, /hello from gdbus/);
+
+      const sum = await gdbus([
+        'call',
+        '--session',
+        '--dest',
+        SERVICE,
+        '--object-path',
+        ROOT,
+        '--method',
+        `${IFACE}.Add`,
+        '20',
+        '22'
+      ]);
+      assert.match(sum.stdout, /42/);
+
+      const joined = await gdbus([
+        'call',
+        '--session',
+        '--dest',
+        SERVICE,
+        '--object-path',
+        ROOT,
+        '--method',
+        `${IFACE}.Concat`,
+        "['a', 'b', 'c']"
+      ]);
+      assert.match(joined.stdout, /a\|b\|c/);
+    });
+
+    it('returns a{sv} that GDBus can read', async () => {
+      const { stdout } = await gdbus([
+        'call',
+        '--session',
+        '--dest',
+        SERVICE,
+        '--object-path',
+        ROOT,
+        '--method',
+        `${IFACE}.Describe`
+      ]);
+      assert.match(stdout, /'name': <'e2e'>/);
+      assert.match(stdout, /'count': <uint32 7>/);
+    });
+
+    it('answers method calls from sd-bus', async () => {
+      const { stdout } = await busctl([
+        'call',
+        SERVICE,
+        ROOT,
+        IFACE,
+        'Echo',
+        's',
+        'hello from busctl'
+      ]);
+      assert.match(stdout, /hello from busctl/);
+    });
+
+    it('answers method calls from python-dbus', async () => {
+      const { stdout } = await run(
+        'python3',
+        [
+          '-c',
+          `
+import dbus
+bus = dbus.SessionBus()
+obj = bus.get_object('${SERVICE}', '${ROOT}')
+i = dbus.Interface(obj, '${IFACE}')
+print('echo:', i.Echo('hello from python'))
+print('add:', i.Add(dbus.UInt32(2), dbus.UInt32(3)))
+p = dbus.Interface(obj, 'org.freedesktop.DBus.Properties')
+print('greeting:', p.Get('${IFACE}', 'Greeting'))
+print('hyphen:', p.Get('${IFACE}', 'my-prop'))
+print('all:', sorted(dict(p.GetAll('${IFACE}')).keys()))
+`
+        ],
+        { encoding: 'utf8' }
+      );
+      assert.match(stdout, /echo: hello from python/);
+      assert.match(stdout, /add: 5/);
+      assert.match(stdout, /greeting: hello/);
+      assert.match(stdout, /hyphen: hyphens work/);
+      assert.match(stdout, /'my-prop'/, 'GetAll includes the hyphenated one');
+      console.log(
+        stdout
+          .split('\n')
+          .map(l => `      ${l}`)
+          .join('\n')
+          .trimEnd()
+      );
+    });
+
+    it('serves properties to sd-bus, including a write', async () => {
+      const before = await busctl([
+        'get-property',
+        SERVICE,
+        ROOT,
+        IFACE,
+        'Greeting'
+      ]);
+      assert.match(before.stdout, /s "hello"/);
+
+      await busctl([
+        'set-property',
+        SERVICE,
+        ROOT,
+        IFACE,
+        'Greeting',
+        's',
+        'written by sd-bus'
+      ]);
+      const after = await busctl([
+        'get-property',
+        SERVICE,
+        ROOT,
+        IFACE,
+        'Greeting'
+      ]);
+      assert.match(after.stdout, /written by sd-bus/);
+      assert.strictEqual(impl.Greeting, 'written by sd-bus');
+    });
+
+    it('refuses a write to a read-only property, in a way sd-bus reports', async () => {
+      await assert.rejects(
+        () =>
+          busctl([
+            'set-property',
+            SERVICE,
+            ROOT,
+            IFACE,
+            'Locked',
+            'b',
+            'false'
+          ]),
+        err => {
+          assert.match(err.stderr || err.message, /read|denied|Property/i);
+          return true;
+        }
+      );
+      assert.strictEqual(impl.Locked, true, 'and the value did not move');
+    });
+
+    it('emits signals that GDBus receives', async () => {
+      const monitor = execFile(
+        'gdbus',
+        ['monitor', '--session', '--dest', SERVICE],
+        { encoding: 'utf8' }
+      );
+      const seen = [];
+      monitor.stdout.on('data', chunk => seen.push(chunk));
+
+      // gdbus takes a moment to install its match rule.
+      await new Promise(resolve => setTimeout(resolve, 1200));
+      for (let i = 0; i < 5; i++) {
+        impl.emit('Pinged', `ping-${i}`);
+        await new Promise(resolve => setTimeout(resolve, 120));
+      }
+      const text = await eventually(
+        () => (seen.join('').includes('Pinged') ? seen.join('') : null),
+        { timeout: 8000, label: 'a Pinged signal at gdbus' }
+      );
+      monitor.kill();
+      // gdbus prints the body as a tuple, so a one-argument signal comes out as
+      // ('ping-0',) -- trailing comma and all.
+      assert.match(text, /Pinged \('ping-\d',?\)/);
+      console.log(
+        `      ${text.split('\n').filter(l => l.includes('Pinged'))[0]}`
+      );
+    });
+
+    it('reports an error the way a real client expects', async () => {
+      await assert.rejects(
+        () =>
+          gdbus([
+            'call',
+            '--session',
+            '--dest',
+            SERVICE,
+            '--object-path',
+            ROOT,
+            '--method',
+            `${IFACE}.NoSuchMethod`
+          ]),
+        err => {
+          assert.match(err.stderr, /UnknownMethod|No such method|Error/);
+          return true;
+        }
+      );
+    });
+
+    it('is reachable through this library as well, for symmetry', async () => {
+      const client = session();
+      await client.getId();
+      try {
+        const iface = await new Promise((resolve, reject) =>
+          client.getInterface(SERVICE, ROOT, IFACE, (err, value) =>
+            err ? reject(err) : resolve(value)
+          )
+        );
+        const echoed = await new Promise((resolve, reject) =>
+          iface.Echo('round trip', (err, value) =>
+            err ? reject(err) : resolve(value)
+          )
+        );
+        assert.strictEqual(echoed, 'round trip');
+
+        const object = await new Promise((resolve, reject) =>
+          client.getObject(SERVICE, ROOT, (err, value) =>
+            err ? reject(err) : resolve(value)
+          )
+        );
+        assert.deepStrictEqual(object.nodes.sort(), ['Alpha', 'Beta']);
+        assert.strictEqual(object.name, ROOT);
+      } finally {
+        close(client);
+      }
+    });
+  }
+);

--- a/e2e/tests/helpers.js
+++ b/e2e/tests/helpers.js
@@ -1,0 +1,145 @@
+// Shared plumbing for the Docker end-to-end checks.
+//
+// These run against the real desktop services in the container, so anything
+// that depends on a particular service being present asks first and skips
+// rather than failing: what starts inside a container varies with the kernel,
+// with udev, and with whether there is any hardware to talk about.
+
+const dbus = require('/work/index');
+
+// Every call gets a deadline. Introspecting a service that is activatable but
+// not running makes the daemon start it, and a container has plenty that will
+// never come up -- without this the default 25 second bus timeout applies to
+// each one in turn and the suite appears to hang.
+const CALL_TIMEOUT = Number(process.env.E2E_CALL_TIMEOUT || 5000);
+
+const system = (opts = {}) =>
+  dbus.createClient({
+    busAddress:
+      process.env.DBUS_SYSTEM_BUS_ADDRESS ||
+      'unix:path=/var/run/dbus/system_bus_socket',
+    timeout: CALL_TIMEOUT,
+    ...opts
+  });
+
+const session = (opts = {}) =>
+  dbus.createClient({
+    busAddress: process.env.DBUS_SESSION_BUS_ADDRESS,
+    timeout: CALL_TIMEOUT,
+    ...opts
+  });
+
+const DBUS = {
+  destination: 'org.freedesktop.DBus',
+  path: '/org/freedesktop/DBus',
+  interface: 'org.freedesktop.DBus'
+};
+
+/** Every name currently on the bus, well-known and unique. */
+const listNames = bus => bus.invoke({ ...DBUS, member: 'ListNames' });
+
+/** Raw Introspect, without going through the proxy layer. */
+const introspect = (bus, destination, path) =>
+  bus.invoke({
+    destination,
+    path,
+    interface: 'org.freedesktop.DBus.Introspectable',
+    member: 'Introspect'
+  });
+
+const getProperty = (bus, destination, path, iface, name) =>
+  bus.invoke({
+    destination,
+    path,
+    interface: 'org.freedesktop.DBus.Properties',
+    member: 'Get',
+    signature: 'ss',
+    body: [iface, name]
+  });
+
+const getAll = (bus, destination, path, iface) =>
+  bus.invoke({
+    destination,
+    path,
+    interface: 'org.freedesktop.DBus.Properties',
+    member: 'GetAll',
+    signature: 's',
+    body: [iface]
+  });
+
+/**
+ * Walk an object tree from `path`, depth first, using Introspect alone.
+ *
+ * Returns `[{path, interfaces, children}]`. This is the operation that could
+ * not be done at all before the introspection fixes: a path with no interfaces
+ * used to come back as its own first child, and the child list dropped
+ * whichever child came first.
+ */
+async function walk(bus, destination, path = '/', limit = 400) {
+  const { parseStringPromise } = require('/work/node_modules/xml2js');
+  const found = [];
+  const queue = [path];
+  const seen = new Set();
+  while (queue.length && found.length < limit) {
+    const at = queue.shift();
+    if (seen.has(at)) continue;
+    seen.add(at);
+    let doc;
+    try {
+      doc = await parseStringPromise(await introspect(bus, destination, at));
+    } catch {
+      continue;
+    }
+    const node = doc.node || {};
+    const interfaces = (node.interface || []).map(i => i.$.name);
+    const children = (node.node || [])
+      .map(n => n.$ && n.$.name)
+      .filter(Boolean);
+    found.push({ path: at, interfaces, children });
+    for (const child of children) {
+      queue.push(at === '/' ? `/${child}` : `${at}/${child}`);
+    }
+  }
+  return found;
+}
+
+/** Wait for `fn()` to return something truthy, or give up. */
+async function eventually(fn, { timeout = 5000, label = 'condition' } = {}) {
+  const started = Date.now();
+  for (;;) {
+    const value = await fn();
+    if (value) return value;
+    if (Date.now() - started > timeout) {
+      throw new Error(`timed out waiting for ${label}`);
+    }
+    await new Promise(resolve => setTimeout(resolve, 50));
+  }
+}
+
+const close = (...buses) => {
+  for (const bus of buses) {
+    try {
+      bus.connection.end();
+      // end() half-closes and waits for the peer, which keeps the socket -- and
+      // so the event loop -- alive after the tests are done. These connections
+      // exist for the length of one file; drop them outright.
+      bus.connection.stream.destroy();
+    } catch {
+      /* already gone */
+    }
+  }
+};
+
+module.exports = {
+  dbus,
+  system,
+  session,
+  DBUS,
+  listNames,
+  introspect,
+  getProperty,
+  getAll,
+  walk,
+  eventually,
+  close
+};

--- a/e2e/tests/run.js
+++ b/e2e/tests/run.js
@@ -1,0 +1,26 @@
+// Runs the Docker end-to-end checks with the spec reporter.
+//
+// Deliberately not wired into `npm test`: these need a Linux box with a
+// desktop bus, and they are a checkpoint rather than a gate. See
+// E2E_DOCKER_TESTING.md.
+
+const { run } = require('node:test');
+const { spec } = require('node:test/reporters');
+const path = require('path');
+const fs = require('fs');
+
+const dir = __dirname;
+const files = fs
+  .readdirSync(dir)
+  .filter(f => /^\d\d-.*\.js$/.test(f))
+  .sort()
+  .map(f => path.join(dir, f));
+
+console.log(`running ${files.length} end-to-end files\n`);
+
+let failed = 0;
+run({ files, concurrency: 1, timeout: 180000 })
+  .on('test:fail', () => failed++)
+  .compose(spec)
+  .pipe(process.stdout)
+  .on('finish', () => process.exit(failed ? 1 : 0));


### PR DESCRIPTION
A container running actual desktop D-Bus services, so the library can be exercised against software nobody here wrote.

**Deliberately outside CI.** `npm test` globs `test/*.js` and `test/integration/*.js`, so `e2e/` is invisible to it. This needs Docker and a Linux desktop stack, and it is a checkpoint you run on purpose:

```bash
e2e/run.sh                 # everything
e2e/run.sh 02-types.js     # one file
e2e/run.sh --shell         # a prompt inside, both buses already up
```

## Why

The unit suite and `test/integration/` both talk to a bus we configured, trading values we chose. Two blind spots follow, and this closes both.

**We pick the types.** Real services emit `a(ss(sa{sv})tt)` and `a(ayuayu)` without being asked. `02-types.js` introspects everything on both buses, collects every distinct signature and asserts they all parse — 38 in this container, covering type codes `a b d h i o q s t u v x y`:

```
a(ssssssuuua{ss})   <- PolicyKit1.Authority.EnumerateActions
a(ss(sa{sv})tt)     <- PolicyKit1.Authority.EnumerateTemporaryAuthorizations
a{oa{sa{sv}}}       <- ObjectManager.GetManagedObjects
a(xxa{sv})          <- Accounts.User.LoginHistory
h                   <- UDisks2.Manager.LoopSetup
```

It then reads the hard ones: `GetManagedObjects` from NetworkManager (42 managed objects), a real 64-bit property as both `number` and `bigint`, `a{sv}` in the classic and `plainValues` shapes. And it calls `UDisks2.Manager.LoopSetup` — a real method that genuinely takes an `h` — to check the refusal explains itself.

**We are both ends.** A test where dbus-native talks to dbus-native cannot show that GDBus parses our introspection XML, that sd-bus writes our properties, or that python-dbus reads a hyphenated property name. `04-interop.js` exports a service and has all three consume it.

## What is in the container

`node:24-bookworm` plus the desktop stack; `start-services.sh` brings up a system bus, a session bus and Xvfb, and reports anything that will not start rather than failing.

| bus | services |
| --- | --- |
| system | `DBus`, `UPower`, `Accounts`, `Avahi`, `NetworkManager`, `UDisks2`, `PolicyKit1` |
| session | `DBus`, `Notifications` (dunst), `portal.Desktop`, `portal.Documents`, `PermissionStore` |

Plus `gdbus`, `busctl`, `python3-dbus`, `dbus-send`, `dbus-monitor` as peers.

## 41 checks, all passing

Three of the fixes merged since 0.11.0 are only observable from outside:

- **#351** — `busctl tree` draws `Alpha` and `Beta` under our service. sd-bus can only do that because our `Introspect` advertises them.
- **#347** — GDBus parses our XML with an argument named `fields & more`. Unescaped, the `&` would have made the whole document unparseable and GDBus would have reported *no* interfaces.
- **#350** — `/org/freedesktop/UPower/devices` comes back as itself with `nodes: ["DisplayDevice"]`, against a service we did not write.

## Two findings recorded, not fixed

1. **A marshalling failure is raised synchronously from `invoke()`**, not delivered as a rejection or to the callback. `await bus.invoke(...)` in a `try` sees it; `bus.invoke(...).catch(...)` does not, and the callback form gets a throw where it expects `cb(err)`. Since 0.7 everything else delivers a `DBusError`. Pinned by a test so a change in either direction is deliberate.
2. **The system bus refuses arbitrary well-known names**, correctly. Anything owning a name in a test has to use the session bus.

Both, plus what the container cannot cover (fd passing, big-endian peers, systemd without PID 1, real hardware), are written up in `E2E_DOCKER_TESTING.md`.