### PR TITLE
feat: call methods and read properties from the command line

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,8 +71,25 @@ Nothing needs to be running as a service. `scripts/dbus-daemon.js` starts a
 tests never touch (or depend on) the user's real session bus.
 
 - `npm run test:integration` wraps the test run in one automatically.
+- `npm run test:integration:broker` runs the same suite against
+  `lib/broker.js` instead, which needs nothing installed. Running it both ways
+  is how a disagreement between the two buses gets noticed.
 - `npm run dbus:session` starts one in the foreground and prints the
   `DBUS_SESSION_BUS_ADDRESS` export line, for poking at examples by hand.
+
+**The integration suite runs one file at a time** (`--test-concurrency=1`).
+That is deliberate. Every file shares the one daemon the wrapper started, and
+running them concurrently made roughly one run in five fail — a different test
+each time, always a service answering `UnknownObject` or `UnknownMethod` for
+something it had definitely exported. Measured on master before any of this
+was touched: 3 failures in 10 concurrent runs, 0 in 10 serial ones.
+
+The mechanism is not fully explained. One captured instance had a connection
+with an empty `exportedObjects` receiving a method call addressed to a
+well-known name it did not own, which should not be possible with unicast
+routing. It costs about three seconds to serialise (1.9s → 5.2s) and it makes
+the suite trustworthy, so it is serial until someone gets to the bottom of it.
+If you are chasing it, `--test-concurrency=8` in a loop reproduces.
 
 The integration tests **skip themselves** when `DBUS_SESSION_BUS_ADDRESS` is
 unset, so a bare `node --test` run stays green without a bus. If you add

--- a/bin/dbus-native.js
+++ b/bin/dbus-native.js
@@ -11,16 +11,42 @@ const { spawnSync } = require('child_process');
 const dbus = require('../index');
 const { parseIntrospection } = require('../lib/codegen/introspection');
 const { emitTypes } = require('../lib/codegen/emit-types');
+const cli = require('../lib/cli/call');
 
 const USAGE = `Usage: dbus-native <command> [options]
 
 Commands:
+  call         call a method, the way dbus-send does
+  get          read a property
+  set          write a property
+  list         list the names on the bus
   types        generate TypeScript declarations for a service
   introspect   print a service's raw introspection XML
   codemod      rewrite your source for a breaking change
   lint         report reads of value shapes that change in 2.0
 
-Options for both:
+Options for call/get/set/list:
+  --dest <name>      bus name to talk to (call, get, set)
+  --system           use the system bus (default: session)
+  --address <addr>   connect to this address instead
+  --json             print the reply as JSON
+  --timeout <ms>     give up after this long (default 25000)
+  --no-reply         send without waiting (call)
+  --no-auto-start    fail rather than activating the service (call)
+  --signature <sig>  give the signature explicitly, with --body
+  --body <json>      arguments as a JSON array, with --signature
+  --activatable      list what could be started, not what is running (list)
+  --all              include unique names like :1.7 (list)
+
+  Arguments to 'call' and 'set' are dbus-send's type:value form:
+    string:hello  int32:-7  uint64:18446744073709551615  boolean:true
+    byte:255  double:1.5  objpath:/com/example/Obj  signature:a{sv}
+    array:string:a,b,c    dict:string:uint32:width,800
+    variant:int32:42
+  Use --signature/--body for anything that cannot express -- structs,
+  deeper nesting, or a value containing a comma.
+
+Options for types/introspect:
   --service <name>   bus name, e.g. org.freedesktop.NetworkManager
   --path <path>      object path, e.g. /org/freedesktop/NetworkManager
   --system           use the system bus (default: session)
@@ -46,6 +72,18 @@ Options for 'lint':
   Exits non-zero when there are findings, so it can gate CI.
 
 Examples:
+  dbus-native list
+  dbus-native call --dest org.freedesktop.DBus \\
+    /org/freedesktop/DBus org.freedesktop.DBus.ListNames
+
+  dbus-native call --dest org.freedesktop.Notifications \\
+    /org/freedesktop/Notifications org.freedesktop.Notifications.Notify \\
+    string:hello uint32:0 string: string:Summary string:Body \\
+    array:string: dict:string:string: int32:5000
+
+  dbus-native get --system --dest org.freedesktop.UPower \\
+    /org/freedesktop/UPower org.freedesktop.UPower DaemonVersion
+
   dbus-native codemod errors-to-error-objects src/
   dbus-native lint --rule DBUS_DEP0002 src/
 
@@ -79,6 +117,15 @@ function parse(argv) {
         dry: { type: 'boolean', default: false },
         rule: { type: 'string' },
         'exit-zero': { type: 'boolean', default: false },
+        dest: { type: 'string' },
+        address: { type: 'string' },
+        json: { type: 'boolean', default: false },
+        timeout: { type: 'string' },
+        'no-reply': { type: 'boolean', default: false },
+        'no-auto-start': { type: 'boolean', default: false },
+        signature: { type: 'string' },
+        body: { type: 'string' },
+        activatable: { type: 'boolean', default: false },
         help: { type: 'boolean', default: false }
       },
       allowPositionals: true
@@ -260,6 +307,20 @@ async function main() {
     return runLint(positionals.slice(1), argv);
   }
 
+  // The bus-facing subcommands. Each returns text to print, or '' when there is
+  // nothing to say -- a successful `set` should be silent, like any good tool.
+  const busCommands = {
+    call: cli.call,
+    get: cli.get,
+    set: cli.set,
+    list: cli.list
+  };
+  if (busCommands[command]) {
+    const output = await busCommands[command](positionals.slice(1), argv);
+    if (output) console.log(output);
+    return;
+  }
+
   if (!['types', 'introspect'].includes(command)) {
     fail(`Unknown command '${command}'.\n\n${USAGE}`);
   }
@@ -296,5 +357,9 @@ async function main() {
 }
 
 main().catch(err => {
+  // A d-bus error's name is the part worth acting on -- UnknownMethod and
+  // AccessDenied want different responses, and the text alone does not say
+  // which you got. dbus-send prints both, and so should this.
+  if (err && err.dbusName) fail(`${err.dbusName}: ${err.message}`);
   fail(err && err.message ? err.message : String(err));
 });

--- a/docs/api.md
+++ b/docs/api.md
@@ -866,6 +866,75 @@ dc.subscribe('tracing:dbus:call:error', ctx =>
 
 ## CLI
 
+| command      |                                                     |
+| ------------ | --------------------------------------------------- |
+| `call`       | call a method, the way `dbus-send` does             |
+| `get`, `set` | read or write a property                            |
+| `list`       | the names on the bus                                |
+| `types`      | TypeScript declarations for a service               |
+| `introspect` | a service's raw introspection XML                   |
+| `codemod`    | rewrite your source for a breaking change           |
+| `lint`       | report reads of the value shapes that change in 2.0 |
+
+### Talking to the bus
+
+```sh
+npx dbus-native list
+npx dbus-native call --dest org.freedesktop.DBus \
+  /org/freedesktop/DBus org.freedesktop.DBus.ListNames
+
+npx dbus-native get --system --dest org.freedesktop.UPower \
+  /org/freedesktop/UPower org.freedesktop.UPower DaemonVersion
+```
+
+Arguments use `dbus-send`'s `type:value` form, so a command line you already
+have can be pasted in:
+
+| form                                  | signature |
+| ------------------------------------- | --------- |
+| `string:` `objpath:` `signature:`     | `s o g`   |
+| `byte:` `boolean:`                    | `y b`     |
+| `int16:` `uint16:` `int32:` `uint32:` | `n q i u` |
+| `int64:` `uint64:` `double:`          | `x t d`   |
+| `array:string:a,b,c`                  | `as`      |
+| `dict:string:uint32:width,800`        | `a{su}`   |
+| `variant:int32:42`                    | `v`       |
+| `dict:string:variant:urgency,byte:1`  | `a{sv}`   |
+| `array:variant:int32:1,string:two`    | `av`      |
+
+`variant` works as a container element type because a `type:value` pair contains
+no comma, so each element can carry its own. That matters because `a{sv}` is the
+most common dict on the bus — `Notify`'s hints, `Properties.GetAll`,
+NetworkManager's settings — and `dbus-send` cannot express it:
+
+```sh
+npx dbus-native call --dest org.freedesktop.Notifications \
+  /org/freedesktop/Notifications org.freedesktop.Notifications.Notify \
+  string:my-app uint32:0 string: string:Summary string:Body \
+  array:string: dict:string:variant:urgency,byte:1 int32:2000
+```
+
+Each value is range-checked before anything is sent, and the message names the
+type you typed rather than the signature character: `256 is out of range for y
+(0..255)`. 64-bit values are carried as `BigInt` and printed exactly, in both
+directions — a tool for inspecting values must not round them.
+
+For what that form cannot express — a struct, nesting past one level, a value
+containing a comma — give the signature and the body directly:
+
+```sh
+npx dbus-native call --dest com.example.Service /com/example/Obj \
+  com.example.Iface.Configure \
+  --signature 'a(si)' --body '[[["first", 1], ["second", 2]]]'
+```
+
+Other flags: `--system`, `--address`, `--json` (plain shapes, for a pipeline),
+`--timeout`, `--no-reply`, `--no-auto-start`, and for `list`, `--activatable`
+and `--all`. A failed call exits non-zero with the error **name** as well as its
+text, since `UnknownMethod` and `AccessDenied` want different responses.
+
+### Generating and checking code
+
 ```sh
 npx dbus-native types --system \
   --service org.freedesktop.NetworkManager \
@@ -876,13 +945,6 @@ npx dbus-native introspect --service org.example --path /org/example
 npx dbus-native codemod errors-to-error-objects --dry src/
 npx dbus-native lint src/
 ```
-
-| command      |                                                     |
-| ------------ | --------------------------------------------------- |
-| `types`      | TypeScript declarations for a service               |
-| `introspect` | a service's raw introspection XML                   |
-| `codemod`    | rewrite your source for a breaking change           |
-| `lint`       | report reads of the value shapes that change in 2.0 |
 
 `lint` exits non-zero when there are findings, so it can gate CI. `--exit-zero`
 reports without failing; `--rule DBUS_DEP0002` selects individual codes. It

--- a/lib/broker.js
+++ b/lib/broker.js
@@ -101,6 +101,10 @@ const BUS_INTROSPECTION = `<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Obje
     <method name="GetId">
       <arg direction="out" type="s"/>
     </method>
+    <method name="GetConnectionCredentials">
+      <arg direction="in" type="s"/>
+      <arg direction="out" type="a{sv}"/>
+    </method>
     <method name="GetConnectionUnixUser">
       <arg direction="in" type="s"/>
       <arg direction="out" type="u"/>
@@ -534,24 +538,45 @@ function createBroker(opts = {}) {
       case 'GetId':
         return reply(client, msg, 's', [id]);
 
+      case 'GetConnectionCredentials':
       case 'GetConnectionUnixUser':
       case 'GetConnectionUnixProcessID': {
-        const target = resolve(String(arg));
-        if (!target) {
-          return replyError(
-            client,
-            msg,
-            ERR('NameHasNoOwner'),
-            `Could not get owner of name "${arg}": no such name`
-          );
+        // Node cannot read a peer's credentials from a socket, so the only
+        // honest answers are the uid the handshake was told and our own pid --
+        // right for an in-process bus, and meaningless for anything else.
+        //
+        // The bus answers for its own name too, as dbus-daemon does: it is a
+        // connection like any other from a caller's point of view.
+        const own =
+          typeof process.getuid === 'function' ? process.getuid() : null;
+        let uid;
+        if (arg === BUS_NAME) {
+          uid = own;
+        } else {
+          const target = resolve(String(arg));
+          if (!target) {
+            return replyError(
+              client,
+              msg,
+              ERR('NameHasNoOwner'),
+              `Could not get owner of name "${arg}": no such name`
+            );
+          }
+          uid = target.identity ? target.identity.uid : null;
         }
-        // Node cannot read the peer's credentials from a socket, so the only
-        // honest answers are the ones the handshake was told and our own pid --
-        // which is right for an in-process bus and wrong for anything else.
-        const value =
-          member === 'GetConnectionUnixUser'
-            ? target.identity && target.identity.uid
-            : process.pid;
+
+        if (member === 'GetConnectionCredentials') {
+          // The modern replacement for the other two, and what most code asks
+          // for now. Fields it cannot answer are left out rather than guessed:
+          // the dict is defined as open-ended.
+          const credentials = [['ProcessID', ['u', process.pid]]];
+          if (uid !== null && uid !== undefined) {
+            credentials.push(['UnixUserID', ['u', uid]]);
+          }
+          return reply(client, msg, 'a{sv}', [credentials]);
+        }
+
+        const value = member === 'GetConnectionUnixUser' ? uid : process.pid;
         if (value === null || value === undefined) {
           return replyError(
             client,

--- a/lib/cli/call.js
+++ b/lib/cli/call.js
@@ -1,0 +1,269 @@
+// The `dbus-send` shaped subcommands: call a method, read or write a property,
+// list what is on the bus.
+//
+// Issue #56 asked how to run a particular `dbus-send` line with this library,
+// and thirteen comments later the honest answer was still "write a script". The
+// script is small; not having to write it is the point.
+
+const dbus = require('../../index');
+const { parseArguments, parseArgument } = require('./dbus-args');
+const { variantValue, variantSignature, toPlain } = require('../values');
+
+const PROPERTIES = 'org.freedesktop.DBus.Properties';
+
+/** Open the bus the flags asked for. */
+function connect(argv) {
+  // returnBigInt because this prints values for a person to read. A tool whose
+  // job is to show you what came back must not round it on the way: the default
+  // reads `x`/`t` as a Number, so uint64:18446744073709551615 comes out as
+  // 18446744073709552000.
+  const options = { returnBigInt: true };
+  if (argv.address) {
+    return dbus.createClient({ busAddress: argv.address, ...options });
+  }
+  if (argv.system) {
+    return dbus.createClient({
+      busAddress:
+        process.env.DBUS_SYSTEM_BUS_ADDRESS ||
+        'unix:path=/var/run/dbus/system_bus_socket',
+      ...options
+    });
+  }
+  return dbus.sessionBus(options);
+}
+
+/**
+ * Split `com.example.Iface.Member` into its two halves.
+ *
+ * The whole thing is one positional argument because that is how dbus-send
+ * takes it, and copying a dbus-send line is the reason this exists.
+ */
+function splitMember(text) {
+  if (typeof text !== 'string' || !text.includes('.')) {
+    throw new Error(
+      `Expected INTERFACE.MEMBER, got "${text}" -- e.g. org.freedesktop.DBus.ListNames`
+    );
+  }
+  const at = text.lastIndexOf('.');
+  return { interfaceName: text.slice(0, at), member: text.slice(at + 1) };
+}
+
+/**
+ * Render a reply for a person to read.
+ *
+ * `--json` is there for a pipeline, and prints the plain shape rather than the
+ * wire shape: a variant as its value, a dict as an object. A BigInt has no JSON
+ * representation, so it becomes a string rather than throwing.
+ */
+function render(values, argv) {
+  if (argv.json) {
+    return JSON.stringify(
+      toPlain(values.length === 1 ? values[0] : values),
+      (key, value) => (typeof value === 'bigint' ? value.toString() : value),
+      2
+    );
+  }
+  if (values.length === 0) return '';
+  return values.map(value => describe(value, 0)).join('\n');
+}
+
+/** One value, in something close to dbus-send's output. */
+function describe(value, depth) {
+  const pad = '  '.repeat(depth);
+
+  const signature = variantSignature(value);
+  if (signature !== undefined) {
+    return `${pad}variant ${signature} ${describe(variantValue(value), 0).trim()}`;
+  }
+  if (Buffer.isBuffer(value)) {
+    return `${pad}bytes [${[...value].join(' ')}]`;
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) return `${pad}[]`;
+    // An array of pairs is almost always a dict; printing it as one is what a
+    // reader wants, and being wrong about it costs nothing but a shape.
+    const looksLikeDict = value.every(
+      entry => Array.isArray(entry) && entry.length === 2
+    );
+    if (looksLikeDict) {
+      const body = value
+        .map(
+          ([key, item]) =>
+            `${pad}  ${describe(key, 0).trim()} -> ${describe(item, 0).trim()}`
+        )
+        .join('\n');
+      return `${pad}{\n${body}\n${pad}}`;
+    }
+    return `${pad}[\n${value.map(item => describe(item, depth + 1)).join('\n')}\n${pad}]`;
+  }
+  if (value === null || value === undefined) return `${pad}${value}`;
+  if (typeof value === 'bigint') return `${pad}${value}`;
+  if (typeof value === 'string') return `${pad}"${value}"`;
+  if (typeof value === 'object') {
+    return `${pad}${JSON.stringify(value, (k, v) => (typeof v === 'bigint' ? v.toString() : v))}`;
+  }
+  return `${pad}${value}`;
+}
+
+/** A body from either the `type:value` shorthand or --signature plus --body. */
+function buildBody(argv, args) {
+  if (argv.signature !== undefined) {
+    if (args.length > 0) {
+      throw new Error(
+        'Use either --signature with --body, or type:value arguments -- not both'
+      );
+    }
+    let body;
+    try {
+      body = argv.body === undefined ? [] : JSON.parse(argv.body);
+    } catch (err) {
+      throw new Error(`--body is not valid JSON: ${err.message}`, {
+        cause: err
+      });
+    }
+    if (!Array.isArray(body)) {
+      throw new Error('--body must be a JSON array of arguments');
+    }
+    return { signature: argv.signature, body };
+  }
+  return parseArguments(args);
+}
+
+/** dbus-native call --dest NAME PATH INTERFACE.MEMBER [args...] */
+async function call(positionals, argv) {
+  const [path, memberSpec, ...args] = positionals;
+  if (!argv.dest) throw new Error('Need --dest, the bus name to call');
+  if (!path || !memberSpec) {
+    throw new Error(
+      'Need an object path and INTERFACE.MEMBER, e.g. /org/freedesktop/DBus org.freedesktop.DBus.ListNames'
+    );
+  }
+  const { interfaceName, member } = splitMember(memberSpec);
+  const { signature, body } = buildBody(argv, args);
+
+  const bus = connect(argv);
+  try {
+    const msg = {
+      destination: argv.dest,
+      path,
+      interface: interfaceName,
+      member,
+      ...(signature ? { signature, body } : {})
+    };
+    if (argv['no-auto-start']) {
+      msg.flags = require('../constants').flags.noAutoStart;
+    }
+    if (argv['no-reply']) {
+      msg.flags =
+        (msg.flags || 0) | require('../constants').flags.noReplyExpected;
+      bus.connection.message({ ...msg, serial: bus.nextSerial() });
+      // Nothing comes back, so the only thing left to do is let the write land.
+      await new Promise(resolve => setImmediate(resolve));
+      return '';
+    }
+    // The callback form rather than the promise: awaiting a call flattens a
+    // one-value reply, which makes `as` indistinguishable from two values. The
+    // callback gets every value separately, and `this.signature` says what the
+    // reply actually was -- worth printing, as dbus-send does.
+    const { signature: replySignature, values } = await new Promise(
+      (resolve, reject) => {
+        bus.invoke(
+          msg,
+          { timeout: Number(argv.timeout) || 25000 },
+          function reply(err, ...received) {
+            if (err) return reject(err);
+            resolve({
+              signature: this && this.signature,
+              values: received
+            });
+          }
+        );
+      }
+    );
+    const output = render(values, argv);
+    if (argv.json || !replySignature) return output;
+    return `reply ${replySignature}\n${output}`;
+  } finally {
+    bus.connection.end();
+  }
+}
+
+/** dbus-native get --dest NAME PATH INTERFACE PROPERTY */
+async function get(positionals, argv) {
+  const [path, interfaceName, property] = positionals;
+  if (!argv.dest) throw new Error('Need --dest, the bus name to read from');
+  if (!path || !interfaceName || !property) {
+    throw new Error('Need PATH INTERFACE PROPERTY');
+  }
+  const bus = connect(argv);
+  try {
+    const reply = await bus.invoke(
+      {
+        destination: argv.dest,
+        path,
+        interface: PROPERTIES,
+        member: 'Get',
+        signature: 'ss',
+        body: [interfaceName, property]
+      },
+      { timeout: Number(argv.timeout) || 25000 }
+    );
+    return render([reply], argv);
+  } finally {
+    bus.connection.end();
+  }
+}
+
+/** dbus-native set --dest NAME PATH INTERFACE PROPERTY type:value */
+async function set(positionals, argv) {
+  const [path, interfaceName, property, value] = positionals;
+  if (!argv.dest) throw new Error('Need --dest, the bus name to write to');
+  if (!path || !interfaceName || !property || value === undefined) {
+    throw new Error(
+      'Need PATH INTERFACE PROPERTY VALUE, where VALUE is type:value e.g. string:hello'
+    );
+  }
+  // A property is always written as a variant, so the type has to be given --
+  // there is nothing to infer it from.
+  const parsed = parseArgument(value);
+  const variant =
+    parsed.signature === 'v' ? parsed.value : [parsed.signature, parsed.value];
+
+  const bus = connect(argv);
+  try {
+    await bus.invoke(
+      {
+        destination: argv.dest,
+        path,
+        interface: PROPERTIES,
+        member: 'Set',
+        signature: 'ssv',
+        body: [interfaceName, property, variant]
+      },
+      { timeout: Number(argv.timeout) || 25000 }
+    );
+    return '';
+  } finally {
+    bus.connection.end();
+  }
+}
+
+/** dbus-native list [--activatable] */
+async function list(positionals, argv) {
+  const bus = connect(argv);
+  try {
+    const names = await bus.invokeDbus(
+      { member: argv.activatable ? 'ListActivatableNames' : 'ListNames' },
+      { timeout: Number(argv.timeout) || 25000 }
+    );
+    const wanted = argv.all
+      ? names
+      : names.filter(name => !name.startsWith(':'));
+    if (argv.json) return JSON.stringify(wanted.sort(), null, 2);
+    return wanted.sort().join('\n');
+  } finally {
+    bus.connection.end();
+  }
+}
+
+module.exports = { call, get, set, list, splitMember, describe, render };

--- a/lib/cli/dbus-args.js
+++ b/lib/cli/dbus-args.js
@@ -1,0 +1,216 @@
+// `type:value` command-line arguments, the way dbus-send spells them.
+//
+//   string:hello  int32:-7  boolean:true  objpath:/com/example/Obj
+//   array:string:a,b,c      dict:string:uint32:width,800,height,600
+//   variant:int32:42
+//
+// The point of copying dbus-send's syntax rather than inventing one is that
+// people arrive with a dbus-send command line they want to run. What it cannot
+// express -- structs, nesting past one level, a value containing a comma -- is
+// what `--signature` with a JSON body is for, which is a shape this library is
+// better at than dbus-send is.
+
+/** dbus-send's type words, and the signature character each stands for. */
+const TYPES = {
+  string: 's',
+  objpath: 'o',
+  signature: 'g',
+  byte: 'y',
+  boolean: 'b',
+  int16: 'n',
+  uint16: 'q',
+  int32: 'i',
+  uint32: 'u',
+  int64: 'x',
+  uint64: 't',
+  double: 'd'
+};
+
+// Inclusive bounds per integer type. The marshaller checks these too, but it
+// speaks in signature characters -- a message about `q` is no help to someone
+// who typed `uint16`.
+const RANGES = {
+  y: [0n, 255n],
+  n: [-32768n, 32767n],
+  q: [0n, 65535n],
+  i: [-2147483648n, 2147483647n],
+  u: [0n, 4294967295n],
+  x: [-9223372036854775808n, 9223372036854775807n],
+  t: [0n, 18446744073709551615n]
+};
+
+// Above this a Number cannot be trusted, so 64-bit values stay BigInt. The
+// marshaller takes either.
+const EXACT = new Set(['x', 't']);
+
+const fail = message => {
+  throw new Error(message);
+};
+
+/** Split on the first colon only, so a value may contain colons. */
+function splitOnce(text) {
+  const at = text.indexOf(':');
+  if (at === -1) return [text, null];
+  return [text.slice(0, at), text.slice(at + 1)];
+}
+
+function scalarType(word) {
+  const type = TYPES[word];
+  if (!type) {
+    fail(
+      `Unknown type "${word}". Known types: ${Object.keys(TYPES).join(', ')}`
+    );
+  }
+  return type;
+}
+
+/** Turn the text after `type:` into a value of that signature character. */
+function parseScalar(type, text, where) {
+  const at = where ? ` in ${where}` : '';
+  if (text === null) fail(`Missing value after "${type}"${at}`);
+
+  switch (type) {
+    case 's':
+    case 'o':
+    case 'g':
+      return text;
+
+    case 'b':
+      if (text === 'true' || text === '1') return true;
+      if (text === 'false' || text === '0') return false;
+      return fail(`boolean${at} must be true or false, got "${text}"`);
+
+    case 'd': {
+      const value = Number(text);
+      if (!Number.isFinite(value)) {
+        return fail(`double${at} must be a finite number, got "${text}"`);
+      }
+      return value;
+    }
+
+    default: {
+      if (!/^[+-]?\d+$/.test(text)) {
+        return fail(`${type}${at} must be an integer, got "${text}"`);
+      }
+      const value = BigInt(text);
+      const [low, high] = RANGES[type];
+      if (value < low || value > high) {
+        return fail(
+          `${text} is out of range for ${type}${at} (${low}..${high})`
+        );
+      }
+      return EXACT.has(type) ? value : Number(value);
+    }
+  }
+}
+
+/**
+ * Split a comma-separated element list.
+ *
+ * dbus-send has no escape for a comma inside an element and neither does this;
+ * the error says what to use instead rather than silently splitting the value.
+ */
+function elements(text, where) {
+  if (text === null) fail(`Missing elements${where ? ` in ${where}` : ''}`);
+  if (text === '') return [];
+  return text.split(',');
+}
+
+/**
+ * One element of a container of variants: its own `type:value`.
+ *
+ * Returned as `[signature, value]`, which is what the marshaller wants for a
+ * variant.
+ */
+function parseVariantElement(text, where) {
+  const [word, rest] = splitOnce(text);
+  const type = scalarType(word);
+  return [type, parseScalar(type, rest, where)];
+}
+
+/**
+ * Parse one `type:value` argument.
+ *
+ * @returns {{signature: string, value: unknown}}
+ */
+function parseArgument(text) {
+  if (typeof text !== 'string')
+    fail(`Argument must be a string, got ${typeof text}`);
+  const [word, rest] = splitOnce(text);
+
+  if (word === 'array') {
+    const [elementWord, list] = splitOnce(rest === null ? '' : rest);
+    const where = `array:${elementWord}`;
+    if (elementWord === 'variant') {
+      return {
+        signature: 'av',
+        value: elements(list, where).map(item =>
+          parseVariantElement(item, where)
+        )
+      };
+    }
+    const element = scalarType(elementWord);
+    return {
+      signature: `a${element}`,
+      value: elements(list, where).map(item =>
+        parseScalar(element, item, where)
+      )
+    };
+  }
+
+  if (word === 'dict') {
+    const [keyWord, afterKey] = splitOnce(rest === null ? '' : rest);
+    const [valueWord, list] = splitOnce(afterKey === null ? '' : afterKey);
+    const key = scalarType(keyWord);
+    const where = `dict:${keyWord}:${valueWord}`;
+    // a{sv} is the single most common dict on the bus -- Notify's hints,
+    // Properties.GetAll, NetworkManager's settings -- so `variant` has to be
+    // usable as the value type. Each element then carries its own type, which
+    // works because a type:value pair contains no comma.
+    const variantValues = valueWord === 'variant';
+    const value = variantValues ? 'v' : scalarType(valueWord);
+
+    const flat = elements(list, where);
+    if (flat.length % 2 !== 0) {
+      fail(`${where} needs an even number of elements, got ${flat.length}`);
+    }
+    const pairs = [];
+    for (let i = 0; i < flat.length; i += 2) {
+      pairs.push([
+        parseScalar(key, flat[i], where),
+        variantValues
+          ? parseVariantElement(flat[i + 1], where)
+          : parseScalar(value, flat[i + 1], where)
+      ]);
+    }
+    return { signature: `a{${key}${value}}`, value: pairs };
+  }
+
+  if (word === 'variant') {
+    const [innerWord, inner] = splitOnce(rest === null ? '' : rest);
+    const type = scalarType(innerWord);
+    // The marshaller takes a variant as [signature, value].
+    return {
+      signature: 'v',
+      value: [type, parseScalar(type, inner, `variant:${innerWord}`)]
+    };
+  }
+
+  const type = scalarType(word);
+  return { signature: type, value: parseScalar(type, rest) };
+}
+
+/**
+ * Parse a whole argument list into the signature and body a call needs.
+ *
+ * @returns {{signature: string, body: unknown[]}}
+ */
+function parseArguments(args) {
+  const parsed = (args || []).map(parseArgument);
+  return {
+    signature: parsed.map(arg => arg.signature).join(''),
+    body: parsed.map(arg => arg.value)
+  };
+}
+
+module.exports = { parseArgument, parseArguments, parseScalar, TYPES };

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "test": "npm run lint && npm run format:check && npm run test:types && npm run test:raw",
     "test:raw": "node --test --test-reporter=spec test/*.js",
     "test:integration": "node scripts/with-dbus.js -- npm run test:integration:raw",
-    "test:integration:raw": "node --test --test-reporter=spec test/integration/*.js",
+    "test:integration:raw": "node --test --test-concurrency=1 --test-reporter=spec test/integration/*.js",
     "test:integration:broker": "node scripts/with-broker.js -- npm run test:integration:raw",
     "dbus:session": "node scripts/dbus-session.js",
     "test:types": "tsc --noEmit"

--- a/test/broker.js
+++ b/test/broker.js
@@ -348,6 +348,41 @@ describe('broker', { timeout: 20000 }, () => {
       assert.deepStrictEqual(queued, [a.name, b.name, c.name]);
     });
 
+    it('answers GetConnectionCredentials, as the daemon does', async () => {
+      // The modern replacement for GetConnectionUnix{User,ProcessID}, and what
+      // most code asks for now. Added because a CLI test that used it passed
+      // against dbus-daemon and failed here -- which is the whole point of
+      // running the integration suite against both.
+      const a = await client();
+      const b = await client();
+      await request(a, 'com.example.Credentials');
+      const credentials = dbus.toPlain(
+        await b.invokeDbus({
+          member: 'GetConnectionCredentials',
+          signature: 's',
+          body: ['com.example.Credentials']
+        })
+      );
+      assert.strictEqual(typeof credentials.ProcessID, 'number');
+      assert.ok(credentials.ProcessID > 0);
+      if (typeof process.getuid === 'function') {
+        assert.strictEqual(credentials.UnixUserID, process.getuid());
+      }
+    });
+
+    it('reports NameHasNoOwner from GetConnectionCredentials', async () => {
+      const bus = await client();
+      await assert.rejects(
+        () =>
+          bus.invokeDbus({
+            member: 'GetConnectionCredentials',
+            signature: 's',
+            body: ['com.example.Absent']
+          }),
+        { dbusName: 'org.freedesktop.DBus.Error.NameHasNoOwner' }
+      );
+    });
+
     it('answers GetId with a stable bus id', async () => {
       const a = await client();
       const b = await client();

--- a/test/cli-args.js
+++ b/test/cli-args.js
@@ -1,0 +1,258 @@
+// `type:value` arguments, as dbus-send spells them.
+
+const { describe, it } = require('node:test');
+const assert = require('assert');
+const { parseArgument, parseArguments } = require('../lib/cli/dbus-args');
+
+describe('cli arguments: scalars', () => {
+  const cases = [
+    ['string:hello', 's', 'hello'],
+    ['string:', 's', ''],
+    ['string:with:colons', 's', 'with:colons'],
+    ['string:with spaces', 's', 'with spaces'],
+    ['objpath:/com/example/Obj', 'o', '/com/example/Obj'],
+    ['signature:a{sv}', 'g', 'a{sv}'],
+    ['boolean:true', 'b', true],
+    ['boolean:false', 'b', false],
+    ['boolean:1', 'b', true],
+    ['boolean:0', 'b', false],
+    ['byte:0', 'y', 0],
+    ['byte:255', 'y', 255],
+    ['int16:-32768', 'n', -32768],
+    ['uint16:65535', 'q', 65535],
+    ['int32:-7', 'i', -7],
+    ['int32:+7', 'i', 7],
+    ['uint32:4294967295', 'u', 4294967295],
+    ['double:1.5', 'd', 1.5],
+    ['double:-0.25', 'd', -0.25],
+    ['double:3', 'd', 3]
+  ];
+  for (const [text, signature, value] of cases) {
+    it(`parses ${text}`, () => {
+      assert.deepStrictEqual(parseArgument(text), { signature, value });
+    });
+  }
+
+  it('keeps 64-bit values exact, as BigInt', () => {
+    // A Number could not carry these, and the whole point of the type is that
+    // it can.
+    assert.deepStrictEqual(parseArgument('int64:9223372036854775807'), {
+      signature: 'x',
+      value: 9223372036854775807n
+    });
+    assert.deepStrictEqual(parseArgument('int64:-9223372036854775808'), {
+      signature: 'x',
+      value: -9223372036854775808n
+    });
+    assert.deepStrictEqual(parseArgument('uint64:18446744073709551615'), {
+      signature: 't',
+      value: 18446744073709551615n
+    });
+  });
+
+  it('leaves the smaller integers as numbers', () => {
+    assert.strictEqual(typeof parseArgument('int32:7').value, 'number');
+    assert.strictEqual(typeof parseArgument('int64:7').value, 'bigint');
+  });
+});
+
+describe('cli arguments: containers', () => {
+  it('parses an array', () => {
+    assert.deepStrictEqual(parseArgument('array:string:a,b,c'), {
+      signature: 'as',
+      value: ['a', 'b', 'c']
+    });
+  });
+
+  it('parses an empty array', () => {
+    assert.deepStrictEqual(parseArgument('array:string:'), {
+      signature: 'as',
+      value: []
+    });
+  });
+
+  it('parses an array of numbers, checking each element', () => {
+    assert.deepStrictEqual(parseArgument('array:uint32:1,2,3'), {
+      signature: 'au',
+      value: [1, 2, 3]
+    });
+    assert.throws(
+      () => parseArgument('array:byte:1,300'),
+      /300 is out of range for y in array:byte/
+    );
+  });
+
+  it('parses a dict', () => {
+    assert.deepStrictEqual(
+      parseArgument('dict:string:uint32:width,800,height,600'),
+      {
+        signature: 'a{su}',
+        value: [
+          ['width', 800],
+          ['height', 600]
+        ]
+      }
+    );
+  });
+
+  it('refuses a dict with an odd number of elements', () => {
+    assert.throws(
+      () => parseArgument('dict:string:string:a,b,c'),
+      /needs an even number of elements, got 3/
+    );
+  });
+
+  it('parses a dict of variants, where each value carries its own type', () => {
+    // a{sv} is the most common dict on the bus, so it has to be expressible.
+    assert.deepStrictEqual(
+      parseArgument('dict:string:variant:urgency,byte:2,resident,boolean:true'),
+      {
+        signature: 'a{sv}',
+        value: [
+          ['urgency', ['y', 2]],
+          ['resident', ['b', true]]
+        ]
+      }
+    );
+  });
+
+  it('parses an empty dict of variants', () => {
+    assert.deepStrictEqual(parseArgument('dict:string:variant:'), {
+      signature: 'a{sv}',
+      value: []
+    });
+  });
+
+  it('parses an array of variants', () => {
+    assert.deepStrictEqual(parseArgument('array:variant:int32:1,string:two'), {
+      signature: 'av',
+      value: [
+        ['i', 1],
+        ['s', 'two']
+      ]
+    });
+  });
+
+  it('checks the type inside a variant element', () => {
+    assert.throws(
+      () => parseArgument('dict:string:variant:k,byte:999'),
+      /999 is out of range for y in dict:string:variant/
+    );
+    assert.throws(
+      () => parseArgument('dict:string:variant:k,nonsense:1'),
+      /Unknown type "nonsense"/
+    );
+  });
+
+  it('parses a variant as [signature, value]', () => {
+    assert.deepStrictEqual(parseArgument('variant:int32:42'), {
+      signature: 'v',
+      value: ['i', 42]
+    });
+    assert.deepStrictEqual(parseArgument('variant:string:hi'), {
+      signature: 'v',
+      value: ['s', 'hi']
+    });
+  });
+});
+
+describe('cli arguments: what it refuses', () => {
+  const bad = [
+    ['int32:notanumber', /i must be an integer, got "notanumber"/],
+    ['int32:1.5', /must be an integer/],
+    ['byte:256', /256 is out of range for y \(0\.\.255\)/],
+    ['byte:-1', /out of range for y/],
+    ['int16:32768', /out of range for n/],
+    ['uint32:-1', /out of range for u/],
+    ['uint64:18446744073709551616', /out of range for t/],
+    ['int64:9223372036854775808', /out of range for x/],
+    ['boolean:yes', /boolean must be true or false, got "yes"/],
+    ['double:abc', /double must be a finite number/],
+    ['double:Infinity', /must be a finite number/],
+    ['nonsense:1', /Unknown type "nonsense"/],
+    ['array:nonsense:a', /Unknown type "nonsense"/],
+    ['string', /Missing value after "s"/],
+    ['array:string', /Missing elements in array:string/]
+  ];
+  for (const [text, message] of bad) {
+    it(`refuses ${text}`, () =>
+      assert.throws(() => parseArgument(text), { message }));
+  }
+
+  it('names the known types when given an unknown one', () => {
+    assert.throws(() => parseArgument('float:1'), /string, objpath, signature/);
+  });
+
+  it('refuses a non-string argument', () => {
+    assert.throws(() => parseArgument(42), /must be a string/);
+  });
+});
+
+describe('cli arguments: whole lists', () => {
+  it('joins the signatures and collects the values', () => {
+    assert.deepStrictEqual(
+      parseArguments(['string:hello', 'int32:7', 'boolean:true']),
+      { signature: 'sib', body: ['hello', 7, true] }
+    );
+  });
+
+  it('handles an empty list, for a method that takes nothing', () => {
+    assert.deepStrictEqual(parseArguments([]), { signature: '', body: [] });
+    assert.deepStrictEqual(parseArguments(undefined), {
+      signature: '',
+      body: []
+    });
+  });
+
+  it('builds the Notify call everyone reaches for first', () => {
+    // org.freedesktop.Notifications.Notify(susssasa{sv}i)
+    const { signature, body } = parseArguments([
+      'string:my-app',
+      'uint32:0',
+      'string:',
+      'string:summary',
+      'string:body',
+      'array:string:',
+      'dict:string:string:',
+      'int32:5000'
+    ]);
+    assert.strictEqual(signature, 'susssasa{ss}i');
+    assert.deepStrictEqual(body, [
+      'my-app',
+      0,
+      '',
+      'summary',
+      'body',
+      [],
+      [],
+      5000
+    ]);
+  });
+
+  it('round-trips through the marshaller', () => {
+    // The real test of the shapes: the marshaller has to accept them.
+    const marshall = require('../lib/marshall');
+    const { signature, body } = parseArguments([
+      'string:hello',
+      'int64:9223372036854775807',
+      'array:uint32:1,2,3',
+      'dict:string:string:a,b',
+      'variant:int32:42',
+      'objpath:/com/example/Obj',
+      'double:1.5',
+      'boolean:true'
+    ]);
+    assert.doesNotThrow(() => marshall(signature, body));
+    const buffer = marshall(signature, body);
+    const DBusBuffer = require('../lib/dbus-buffer');
+    const back = new DBusBuffer(buffer, 0, { returnBigInt: true }).read(
+      signature
+    );
+    assert.strictEqual(back[0], 'hello');
+    assert.strictEqual(back[1], 9223372036854775807n);
+    assert.deepStrictEqual(back[2], [1, 2, 3]);
+    assert.strictEqual(back[5], '/com/example/Obj');
+    assert.strictEqual(back[6], 1.5);
+    assert.strictEqual(back[7], true);
+  });
+});

--- a/test/integration/cli.js
+++ b/test/integration/cli.js
@@ -1,0 +1,356 @@
+// The bus-facing CLI, run as a command against a real bus.
+//
+// Unit tests cover the argument grammar; this covers the part that only shows
+// up when the binary actually runs -- that it connects, that a reply renders,
+// that a failure exits non-zero with the error name on it.
+//
+// Every spawn is async on purpose: the test process is also the service under
+// test, so blocking the event loop would mean the CLI's call never gets an
+// answer.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('assert');
+const { execFile } = require('child_process');
+const { promisify } = require('util');
+const path = require('path');
+const { EventEmitter } = require('events');
+const dbus = require('../../index');
+
+const run = promisify(execFile);
+const BIN = path.join(__dirname, '..', '..', 'bin', 'dbus-native.js');
+
+const NO_BUS =
+  !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
+
+const SERVICE = 'com.github.sidorares.dbusnative.Cli';
+const OBJECT_PATH = '/com/github/sidorares/dbusnative/Cli';
+const IFACE = 'com.github.sidorares.dbusnative.CliIface';
+
+const cli = args => run(process.execPath, [BIN, ...args], { encoding: 'utf8' });
+
+describe('integration: the CLI', { timeout: 30000, skip: NO_BUS }, () => {
+  let bus, impl;
+
+  before(async () => {
+    // returnBigInt because one of these echoes a 64-bit value straight back.
+    // Without it the service reads `t` as a Number, which is lossy above 2^53,
+    // and then cannot marshal it again -- the CLI sends the value exactly, and
+    // it is the echo that would lose it.
+    bus = dbus.sessionBus({ returnBigInt: true });
+    await bus.getId();
+    await new Promise((resolve, reject) =>
+      bus.requestName(SERVICE, 0, err => (err ? reject(err) : resolve()))
+    );
+    impl = Object.assign(Object.create(EventEmitter.prototype), {
+      Echo: text => text,
+      Add: (a, b) => a + b,
+      Big: value => value,
+      Tags: parts => parts.join('|'),
+      Greeting: 'hello',
+      Locked: true
+    });
+    EventEmitter.call(impl);
+    bus.exportInterface(impl, OBJECT_PATH, {
+      name: IFACE,
+      methods: {
+        Echo: ['s', 's', ['text'], ['out']],
+        Add: ['uu', 'u', ['a', 'b'], ['sum']],
+        Big: ['t', 't', ['value'], ['out']],
+        Tags: ['as', 's', ['parts'], ['out']]
+      },
+      signals: {},
+      properties: {
+        Greeting: 's',
+        Locked: { type: 'b', access: 'read' }
+      }
+    });
+  });
+
+  after(() => {
+    if (bus) bus.connection.end();
+  });
+
+  describe('call', () => {
+    it('calls a method with no arguments', async () => {
+      const { stdout } = await cli([
+        'call',
+        '--dest',
+        'org.freedesktop.DBus',
+        '/org/freedesktop/DBus',
+        'org.freedesktop.DBus.GetId'
+      ]);
+      assert.match(stdout, /reply s/);
+      assert.match(stdout, /"[0-9a-f]{32}"/);
+    });
+
+    it('passes type:value arguments through', async () => {
+      const { stdout } = await cli([
+        'call',
+        '--dest',
+        SERVICE,
+        OBJECT_PATH,
+        `${IFACE}.Echo`,
+        'string:hello from the cli'
+      ]);
+      assert.match(stdout, /"hello from the cli"/);
+    });
+
+    it('passes several arguments, with their types', async () => {
+      const { stdout } = await cli([
+        'call',
+        '--dest',
+        SERVICE,
+        OBJECT_PATH,
+        `${IFACE}.Add`,
+        'uint32:20',
+        'uint32:22'
+      ]);
+      assert.match(stdout, /reply u/);
+      assert.match(stdout, /42/);
+    });
+
+    it('carries a 64-bit value the CLI could not hold as a number', async () => {
+      const { stdout } = await cli([
+        'call',
+        '--dest',
+        SERVICE,
+        OBJECT_PATH,
+        `${IFACE}.Big`,
+        'uint64:18446744073709551615'
+      ]);
+      assert.match(stdout, /18446744073709551615/);
+    });
+
+    it('passes an array', async () => {
+      const { stdout } = await cli([
+        'call',
+        '--dest',
+        SERVICE,
+        OBJECT_PATH,
+        `${IFACE}.Tags`,
+        'array:string:a,b,c'
+      ]);
+      assert.match(stdout, /"a\|b\|c"/);
+    });
+
+    it('prints JSON when asked', async () => {
+      const { stdout } = await cli([
+        'call',
+        '--json',
+        '--dest',
+        SERVICE,
+        OBJECT_PATH,
+        `${IFACE}.Echo`,
+        'string:as json'
+      ]);
+      assert.strictEqual(JSON.parse(stdout), 'as json');
+    });
+
+    it('renders a dict reply readably', async () => {
+      const { stdout } = await cli([
+        'call',
+        '--dest',
+        'org.freedesktop.DBus',
+        '/org/freedesktop/DBus',
+        'org.freedesktop.DBus.GetConnectionCredentials',
+        'string:org.freedesktop.DBus'
+      ]);
+      assert.match(stdout, /reply a\{sv\}/);
+      assert.match(stdout, /"UnixUserID" -> variant u \d+/);
+    });
+
+    it('takes --signature and --body for what type:value cannot say', async () => {
+      const { stdout } = await cli([
+        'call',
+        '--signature',
+        's',
+        '--body',
+        JSON.stringify(['via json']),
+        '--dest',
+        SERVICE,
+        OBJECT_PATH,
+        `${IFACE}.Echo`
+      ]);
+      assert.match(stdout, /"via json"/);
+    });
+
+    it('refuses both forms at once', async () => {
+      await assert.rejects(
+        () =>
+          cli([
+            'call',
+            '--signature',
+            's',
+            '--body',
+            '["x"]',
+            '--dest',
+            SERVICE,
+            OBJECT_PATH,
+            `${IFACE}.Echo`,
+            'string:y'
+          ]),
+        err => {
+          assert.match(err.stderr, /not both/);
+          return true;
+        }
+      );
+    });
+
+    it('exits non-zero on a d-bus error, naming it', async () => {
+      await assert.rejects(
+        () =>
+          cli([
+            'call',
+            '--dest',
+            SERVICE,
+            OBJECT_PATH,
+            `${IFACE}.NoSuchMethod`
+          ]),
+        err => {
+          assert.strictEqual(err.code, 1);
+          assert.match(err.stderr, /org\.freedesktop\.DBus\.Error\./);
+          return true;
+        }
+      );
+    });
+
+    it('exits non-zero on a bad argument, before connecting', async () => {
+      await assert.rejects(
+        () =>
+          cli([
+            'call',
+            '--dest',
+            SERVICE,
+            OBJECT_PATH,
+            `${IFACE}.Echo`,
+            'byte:999'
+          ]),
+        err => {
+          assert.match(err.stderr, /out of range for y/);
+          return true;
+        }
+      );
+    });
+
+    it('says what it needs when --dest is missing', async () => {
+      await assert.rejects(
+        () => cli(['call', OBJECT_PATH, `${IFACE}.Echo`]),
+        err => {
+          assert.match(err.stderr, /Need --dest/);
+          return true;
+        }
+      );
+    });
+
+    it('says what it needs when the member is not qualified', async () => {
+      await assert.rejects(
+        () => cli(['call', '--dest', SERVICE, OBJECT_PATH, 'Echo']),
+        err => {
+          assert.match(err.stderr, /Expected INTERFACE\.MEMBER/);
+          return true;
+        }
+      );
+    });
+  });
+
+  describe('get and set', () => {
+    it('reads a property', async () => {
+      const { stdout } = await cli([
+        'get',
+        '--dest',
+        SERVICE,
+        OBJECT_PATH,
+        IFACE,
+        'Greeting'
+      ]);
+      assert.match(stdout, /variant s "hello"/);
+    });
+
+    it('reads a property as JSON', async () => {
+      const { stdout } = await cli([
+        'get',
+        '--json',
+        '--dest',
+        SERVICE,
+        OBJECT_PATH,
+        IFACE,
+        'Greeting'
+      ]);
+      assert.strictEqual(JSON.parse(stdout), 'hello');
+    });
+
+    it('writes a property, and says nothing on success', async () => {
+      const { stdout } = await cli([
+        'set',
+        '--dest',
+        SERVICE,
+        OBJECT_PATH,
+        IFACE,
+        'Greeting',
+        'string:written by the cli'
+      ]);
+      assert.strictEqual(stdout.trim(), '');
+      assert.strictEqual(impl.Greeting, 'written by the cli');
+    });
+
+    it('reports a write to a read-only property', async () => {
+      await assert.rejects(
+        () =>
+          cli([
+            'set',
+            '--dest',
+            SERVICE,
+            OBJECT_PATH,
+            IFACE,
+            'Locked',
+            'boolean:false'
+          ]),
+        err => {
+          assert.match(err.stderr, /PropertyReadOnly/);
+          return true;
+        }
+      );
+      assert.strictEqual(impl.Locked, true);
+    });
+
+    it('needs a type on the value it is given', async () => {
+      await assert.rejects(
+        () =>
+          cli([
+            'set',
+            '--dest',
+            SERVICE,
+            OBJECT_PATH,
+            IFACE,
+            'Greeting',
+            'oops'
+          ]),
+        err => {
+          assert.match(err.stderr, /Missing value after "s"|Unknown type/);
+          return true;
+        }
+      );
+    });
+  });
+
+  describe('list', () => {
+    it('lists the well-known names', async () => {
+      const { stdout } = await cli(['list']);
+      assert.match(stdout, /org\.freedesktop\.DBus/);
+      assert.match(stdout, new RegExp(SERVICE.replace(/\./g, '\\.')));
+      assert.doesNotMatch(stdout, /^:\d/m, 'unique names hidden by default');
+    });
+
+    it('includes unique names with --all', async () => {
+      const { stdout } = await cli(['list', '--all']);
+      assert.match(stdout, /^:\d+\.\d+$/m);
+    });
+
+    it('lists activatable names', async () => {
+      // A private bus has none, so the check is that it asks the right question
+      // and exits cleanly rather than that anything comes back.
+      const { stdout } = await cli(['list', '--activatable', '--json']);
+      assert.ok(Array.isArray(JSON.parse(stdout)));
+    });
+  });
+});


### PR DESCRIPTION
Closes #56, open since 2015. The ask was how to run a particular `dbus-send` line with this library; thirteen comments later the honest answer was still "write a script".

```sh
dbus-native list
dbus-native call --dest org.freedesktop.DBus \
  /org/freedesktop/DBus org.freedesktop.DBus.ListNames
dbus-native get --system --dest org.freedesktop.UPower \
  /org/freedesktop/UPower org.freedesktop.UPower DaemonVersion
dbus-native set --dest com.example.S /obj com.example.I Greeting string:hi
```

Arguments use `dbus-send`'s `type:value` form, deliberately: the reason this exists is that people arrive with a `dbus-send` command line to run, and a command line you already have should paste in.

## Against real services

From the e2e container, on the system bus:

```
=== UPower GetAll ===
reply a{sv}
{
  "DaemonVersion" -> variant s "0.99.20"
  "OnBattery" -> variant b false
  "LidIsClosed" -> variant b false
  "LidIsPresent" -> variant b false
}
```

## Two places it goes further than dbus-send

**`variant` works as a container element type**, so `a{sv}` is expressible:

```sh
dbus-native call --dest org.freedesktop.Notifications \
  /org/freedesktop/Notifications org.freedesktop.Notifications.Notify \
  string:my-app uint32:0 string: string:Summary string:Body \
  array:string: dict:string:variant:urgency,byte:1 int32:2000
# reply u
# 2
```

That works because a `type:value` pair contains no comma, so each element can carry its own type. It matters because `a{sv}` is the most common dict on the bus — `Notify`'s hints, `Properties.GetAll`, NetworkManager's settings — and `dbus-send` has no way to say it. Sending a real notification through the container's notification daemon was the check; `dict:string:string:` had failed with `does not match expected type “(susssasa{sv}i)”`.

**64-bit values are exact in both directions.** A tool whose job is to show you what came back must not round it, so the CLI's own connection reads `x`/`t` as `BigInt` — otherwise `uint64:18446744073709551615` prints as `18446744073709552000`.

## Errors say what happened

Every value is range-checked before anything is sent, and the message names the type that was **typed** rather than the signature character:

```
$ dbus-native call ... byte:999
256 is out of range for y (0..255)          # not a complaint about `y`
$ dbus-native call ... com.example.I.Nope
org.freedesktop.DBus.Error.UnknownMethod: ...
```

Non-zero exit, with the error **name** as well as its text — `UnknownMethod` and `AccessDenied` want different responses, and the text alone does not say which you got.

## The escape hatch

For what `type:value` cannot express — a struct, nesting past one level, a value containing a comma — give the signature and body directly, which is a shape this library is better at than `dbus-send` is:

```sh
dbus-native call --dest com.example.S /obj com.example.I.Configure \
  --signature 'a(si)' --body '[[["first", 1], ["second", 2]]]'
```

## A broker gap this found

`GetConnectionCredentials` was missing from `lib/broker.js`. A CLI test that used it **passed against `dbus-daemon` and failed against the broker** — which is exactly what running the integration suite against both is for, and the first time that has paid off. Added, along with answering for the bus's own name as the daemon does.

## Tests

- `test/cli-args.js` (53) — the argument grammar: every scalar, ranges at both ends, containers, variant elements, and a round trip through the marshaller so the shapes are ones it accepts
- `test/integration/cli.js` (21) — the binary run as a command against a real bus, including a service exported by the test process so `set` has something to write. Every spawn is async: the test *is* the service, so blocking the loop would mean the CLI's call never gets an answer

805 unit tests pass. 152 integration tests pass against **both** `dbus-daemon` and the broker. Lint, prettier and `tsc --noEmit` clean.