### PR TITLE
fix: run the integration suite one file at a time

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,8 +71,25 @@ Nothing needs to be running as a service. `scripts/dbus-daemon.js` starts a
 tests never touch (or depend on) the user's real session bus.
 
 - `npm run test:integration` wraps the test run in one automatically.
+- `npm run test:integration:broker` runs the same suite against
+  `lib/broker.js` instead, which needs nothing installed. Running it both ways
+  is how a disagreement between the two buses gets noticed.
 - `npm run dbus:session` starts one in the foreground and prints the
   `DBUS_SESSION_BUS_ADDRESS` export line, for poking at examples by hand.
+
+**The integration suite runs one file at a time** (`--test-concurrency=1`).
+That is deliberate. Every file shares the one daemon the wrapper started, and
+running them concurrently made roughly one run in five fail — a different test
+each time, always a service answering `UnknownObject` or `UnknownMethod` for
+something it had definitely exported. Measured on master before any of this
+was touched: 3 failures in 10 concurrent runs, 0 in 10 serial ones.
+
+The mechanism is not fully explained. One captured instance had a connection
+with an empty `exportedObjects` receiving a method call addressed to a
+well-known name it did not own, which should not be possible with unicast
+routing. It costs about three seconds to serialise (1.9s → 5.2s) and it makes
+the suite trustworthy, so it is serial until someone gets to the bottom of it.
+If you are chasing it, `--test-concurrency=8` in a loop reproduces.
 
 The integration tests **skip themselves** when `DBUS_SESSION_BUS_ADDRESS` is
 unset, so a bare `node --test` run stays green without a bus. If you add

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "test": "npm run lint && npm run format:check && npm run test:types && npm run test:raw",
     "test:raw": "node --test --test-reporter=spec test/*.js",
     "test:integration": "node scripts/with-dbus.js -- npm run test:integration:raw",
-    "test:integration:raw": "node --test --test-reporter=spec test/integration/*.js",
+    "test:integration:raw": "node --test --test-concurrency=1 --test-reporter=spec test/integration/*.js",
     "test:integration:broker": "node scripts/with-broker.js -- npm run test:integration:raw",
     "dbus:session": "node scripts/dbus-session.js",
     "test:types": "tsc --noEmit"


### PR DESCRIPTION
The integration suite fails roughly **one run in five**, and has for a while. This is not new breakage — measured on `master`, before any of the recent branches:

```
concurrent (default):  ℹ fail 0  ℹ fail 1  ℹ fail 0 ... 3 failures in 10 runs
serial (concurrency 1): ℹ fail 0  ℹ fail 0  ℹ fail 0 ... 0 failures in 10 runs
```

It surfaced on #357's CI, which is what sent me looking: more integration tests means more chances for a run to trip.

## What it looks like

A different test each time, and always the same shape — a service answering `UnknownObject` or `UnknownMethod` for something it had definitely exported:

```
✖ method calls resolve
  No handler for "Add" on interface "...PromisesIface"
  at object path "/com/github/sidorares/dbusnative/Promises"

✖ returns a{sv} as a plain object
  No such object path "/com/github/sidorares/dbusnative/FutureShape"

✖ still reads a read-only property
✖ still reads and writes a readwrite property
```

## Why serialising

Every file shares the one daemon `scripts/with-dbus.js` starts, and node's test runner runs files concurrently — so the suite has a shared mutable fixture and no isolation between the processes using it. Serialising costs about **three seconds** (1.9s → 5.2s) and makes the suite trustworthy. 11 consecutive clean runs afterwards, against both `dbus-daemon` and the broker.

That is a defensible fix on its own terms rather than only a workaround: concurrent processes sharing one bus is precisely the arrangement that lets tests interfere, whatever the specific mechanism turns out to be.

## What is still unexplained

**This does not claim to have found the mechanism**, and the commit says so. Instrumenting `sendError` caught one instance worth recording:

```json
{"me":":1.17","exported":[],
 "msgPath":"/com/github/sidorares/dbusnative/Promises",
 "msgDest":"com.github.sidorares.dbusnative.Promises",
 "msgSender":":1.25",
 "errorText":"No handler for \"Echo\" ..."}
```

A connection whose `exportedObjects` is **empty** received a method call addressed to a well-known name it does not own. Unicast routing should make that impossible. The same connection also logged receiving an `AddMatch` addressed to `org.freedesktop.DBus` with itself as sender.

Ruled out along the way:
- **Name collisions between files** — every `SERVICE` constant is unique; checked.
- **Eavesdropping** — every rule the tests install is a narrow `type='signal'` rule; no `eavesdrop=true`, no `BecomeMonitor`.
- **A member name that prints as `Add` but is not** — instrumented the byte values at the no-handler branch; never triggered in 15 runs.

`AGENTS.md` records the observation, the measurement, and that `--test-concurrency=8` in a loop reproduces, so whoever picks it up does not start from scratch.

## Note on #357

That PR's one CI failure was this, not the CLI. Once this lands I will rebase it.