### PR TITLE
feat: the 2.0 shape gate, withClassicTypes, and the migration guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,12 +32,15 @@ lib/
   signature.js        signature string -> tree
   writer.js           growable output buffer with a write cursor
   handshake.js        client SASL auth (EXTERNAL, DBUS_COOKIE_SHA1, ANONYMOUS)
-  server-handshake.js server-side auth -- a STUB, see ROADMAP 4.5
+  server-handshake.js server-side SASL auth, the same three mechanisms
+  broker.js           an in-process message bus: org.freedesktop.DBus, routing
+  match-rule.js       match rule parsing and evaluation
   introspect.js       XML introspection -> proxy objects
   stdifaces.js        org.freedesktop.DBus.{Introspectable,Properties,Peer}
   constants.js        message types, header fields, endianness
-bin/                  dbus-native (types/introspect CLI), dbus2js (legacy
-                      codegen), dbus-dissect (traffic dumper)
+bin/                  dbus-native (call/get/set/list/types/introspect/codemod/
+                      lint), dbus2js (legacy codegen), dbus-dissect (dumper)
+lib/cli/              the dbus-send shaped subcommands
 lib/codegen/          introspection -> TypeScript declarations
 scripts/              dev helpers for running a private session bus
 test/                 unit tests (node:test)
@@ -76,6 +79,40 @@ tests never touch (or depend on) the user's real session bus.
   is how a disagreement between the two buses gets noticed.
 - `npm run dbus:session` starts one in the foreground and prints the
   `DBUS_SESSION_BUS_ADDRESS` export line, for poking at examples by hand.
+
+### The 2.0 shape gate
+
+```sh
+npm run test:integration:2.0          # against dbus-daemon
+npm run test:integration:2.0:broker   # against lib/broker.js
+```
+
+Same suite, run with the value shapes 2.0 makes the default: a variant reads as
+its value, a string-keyed `a{sv}` as a plain object, and `x`/`t` as `bigint`.
+`DBUS_TEST_SHAPE=2.0` turns them on through `test/utils/shape.js`, which every
+integration file gets its connections from.
+
+**This is the gate for the major.** Flipping those defaults is the largest
+break in RELEASE_PLAN, and until this passed there was no way to find out what
+it costs except by shipping it. Both runs are green today, which is the useful
+fact: the library already works in the flipped shape, so what remains is
+migration support rather than repair.
+
+Two rules keep it meaningful:
+
+- **A test asserts behaviour, not a shape.** Read values with `variantValue()`
+  and `toPlain()` from `lib/values.js` — the accessors we tell users to migrate
+  to, which are the identity in the new shape. Any test that reads `[1][0]` or
+  maps over dict pairs passes in exactly one of the two runs.
+- **A test that _is_ about a shape says so in its options.** `sessionBus()`
+  layers caller options over the defaults, so `{ returnBigInt: false }` keeps
+  meaning that after the flip. `PLAIN_VALUES` and `RETURN_BIGINT` are exported
+  for the handful of assertions that genuinely cannot be written both ways.
+
+`test/integration/shape.js` asserts that the requested shape is the shape a
+real connection delivers, because `DBUS_TEST_SHAPE` travels through two
+`npm run` hops and a wrapper process to get there. A broken chain would turn
+the whole gate green while testing nothing, which is worse than red.
 
 **The integration suite runs one file at a time** (`--test-concurrency=1`).
 That is deliberate. Every file shares the one daemon the wrapper started, and
@@ -159,11 +196,8 @@ These have each bitten someone before:
   ugly, widely depended on, and changing it is a breaking change (ROADMAP 4.1).
 - **`ay` is special-cased to a Buffer** (`options.ayBuffer`, default true), so
   byte arrays do not round-trip as plain arrays.
-- **64-bit types go through `long.js` and lose precision above 2^53** unless
-  `ReturnLongjs` is set. Replacing this with BigInt is planned (ROADMAP 3.2).
-- **`lib/server-handshake.js` is not a real implementation.** It replies with a
-  hardcoded GUID and cookie and logs to stdout. Do not treat `createServer` as
-  working infrastructure.
+- **64-bit types lose precision above 2^53** unless `returnBigInt` is set.
+  BigInt becomes the default in 2.0 (RELEASE_PLAN).
 - **`lib/address-x11.js` requires `x11`, which is not a dependency.** Requiring
   that file throws unless the user installed it separately. It is intentionally
   opt-in.

--- a/lib/cli/call.js
+++ b/lib/cli/call.js
@@ -11,13 +11,26 @@ const { variantValue, variantSignature, toPlain } = require('../values');
 
 const PROPERTIES = 'org.freedesktop.DBus.Properties';
 
+/**
+ * The value shapes this tool needs, stated rather than inherited.
+ *
+ * Both are pinned because printing a reply is not the same job as consuming
+ * one, and the defaults are tuned for consuming.
+ *
+ * `returnBigInt` because a tool whose job is to show you what came back must
+ * not round it on the way: read as a Number,
+ * uint64:18446744073709551615 comes out as 18446744073709552000.
+ *
+ * `plainValues: false` because `describe()` prints a variant as
+ * `variant u 501`, and the only place that `u` exists is the parsed signature
+ * tree that `plainValues` throws away. Left to follow the default, this
+ * command would silently stop printing types the day 2.0 flips it.
+ */
+const SHAPE = { returnBigInt: true, plainValues: false };
+
 /** Open the bus the flags asked for. */
 function connect(argv) {
-  // returnBigInt because this prints values for a person to read. A tool whose
-  // job is to show you what came back must not round it on the way: the default
-  // reads `x`/`t` as a Number, so uint64:18446744073709551615 comes out as
-  // 18446744073709552000.
-  const options = { returnBigInt: true };
+  const options = { ...SHAPE };
   if (argv.address) {
     return dbus.createClient({ busAddress: argv.address, ...options });
   }
@@ -266,4 +279,4 @@ async function list(positionals, argv) {
   }
 }
 
-module.exports = { call, get, set, list, splitMember, describe, render };
+module.exports = { call, get, set, list, splitMember, describe, render, SHAPE };

--- a/package.json
+++ b/package.json
@@ -81,6 +81,8 @@
     "test:integration": "node scripts/with-dbus.js -- npm run test:integration:raw",
     "test:integration:raw": "node --test --test-concurrency=1 --test-reporter=spec test/integration/*.js",
     "test:integration:broker": "node scripts/with-broker.js -- npm run test:integration:raw",
+    "test:integration:2.0": "DBUS_TEST_SHAPE=2.0 npm run test:integration",
+    "test:integration:2.0:broker": "DBUS_TEST_SHAPE=2.0 npm run test:integration:broker",
     "dbus:session": "node scripts/dbus-session.js",
     "test:types": "tsc --noEmit"
   },

--- a/test/cli-shape.js
+++ b/test/cli-shape.js
@@ -1,0 +1,42 @@
+// The CLI pins the value shapes it reads, rather than following the defaults.
+//
+// `describe()` prints a variant as `variant u 501`. That `u` only exists in the
+// parsed signature tree, which `plainValues` discards -- so the day 2.0 flips
+// that default, a CLI that inherited it would quietly stop printing types.
+// These tests are here to fail if the pin is ever removed.
+
+const { describe, it } = require('node:test');
+const assert = require('assert');
+const DBusBuffer = require('../lib/dbus-buffer');
+const marshall = require('../lib/marshall');
+const { SHAPE, describe: render } = require('../lib/cli/call');
+
+// A `v` holding a `u`, read back the way the given options would read it.
+const readVariant = options => {
+  const buffer = marshall('v', [['u', 501]]);
+  return new DBusBuffer(buffer, 0, options).read('v')[0];
+};
+
+describe('cli value shapes', () => {
+  it('asks for the tree shape and for bigints', () => {
+    assert.deepStrictEqual(SHAPE, { returnBigInt: true, plainValues: false });
+  });
+
+  it('prints a variant with its signature under the pinned shape', () => {
+    assert.strictEqual(render(readVariant(SHAPE), 0), 'variant u 501');
+  });
+
+  it('cannot print the signature once plainValues has discarded it', () => {
+    // Not a wish, a demonstration: this is what the output becomes if the pin
+    // goes away. 2.0 needs a way to ask for `Variant` wrappers before the CLI
+    // can use the modern shape at all.
+    const plain = readVariant({ ...SHAPE, plainValues: true });
+    assert.strictEqual(render(plain, 0), '501');
+  });
+
+  it('does not round a 64-bit value on the way to the terminal', () => {
+    const buffer = marshall('t', [18446744073709551615n]);
+    const [value] = new DBusBuffer(buffer, 0, SHAPE).read('t');
+    assert.strictEqual(render(value, 0), '18446744073709551615');
+  });
+});

--- a/test/integration/basic.js
+++ b/test/integration/basic.js
@@ -2,10 +2,14 @@
 //
 // Run with `npm run test:integration`, which starts a private session bus and
 // exports DBUS_SESSION_BUS_ADDRESS for us.
+//
+// These use the callback form deliberately: `(err, result)` is public API, so
+// something has to keep exercising it.
 
 const { describe, it, before, after } = require('node:test');
 const assert = require('assert');
-const dbus = require('../../index');
+const { variantValue, toPlain } = require('../../lib/values');
+const { sessionBus } = require('../utils/shape');
 
 // node:test skips a whole suite from its options, evaluated at load time.
 const NO_BUS =
@@ -50,6 +54,25 @@ function makeImpl() {
   return impl;
 }
 
+/**
+ * Turn an invoke callback into a passing or failing test.
+ *
+ * node:test cannot see a throw from inside a callback it did not call, so a
+ * failed assertion in there becomes an uncaughtException and takes down the
+ * whole file. One bad assertion used to report as eight failures plus a ten
+ * second timeout, which buries the one that matters.
+ */
+const check = (done, assertions) =>
+  function reply(err, ...values) {
+    if (err) return done(err);
+    try {
+      assertions.apply(this, values);
+      done();
+    } catch (failure) {
+      done(failure);
+    }
+  };
+
 describe(
   'integration: real session bus',
   { timeout: 10000, skip: NO_BUS },
@@ -67,8 +90,8 @@ describe(
       });
 
     before(async () => {
-      serviceBus = dbus.sessionBus();
-      clientBus = dbus.sessionBus();
+      serviceBus = sessionBus();
+      clientBus = sessionBus();
       impl = makeImpl();
 
       await Promise.all([whenReady(serviceBus), whenReady(clientBus)]);
@@ -95,11 +118,14 @@ describe(
     });
 
     it('lists the well-known bus name we requested', (t, done) => {
-      clientBus.listNames((err, names) => {
-        if (err) return done(err);
-        assert.ok(names.includes(SERVICE), `${SERVICE} missing from ListNames`);
-        done();
-      });
+      clientBus.listNames(
+        check(done, names =>
+          assert.ok(
+            names.includes(SERVICE),
+            `${SERVICE} missing from ListNames`
+          )
+        )
+      );
     });
 
     it('round-trips a method call with a string argument', (t, done) => {
@@ -112,11 +138,7 @@ describe(
           signature: 's',
           body: ['round trip']
         },
-        (err, result) => {
-          if (err) return done(err);
-          assert.strictEqual(result, 'round trip');
-          done();
-        }
+        check(done, result => assert.strictEqual(result, 'round trip'))
       );
     });
 
@@ -130,11 +152,7 @@ describe(
           signature: 'ii',
           body: [40, 2]
         },
-        (err, result) => {
-          if (err) return done(err);
-          assert.strictEqual(result, 42);
-          done();
-        }
+        check(done, result => assert.strictEqual(result, 42))
       );
     });
 
@@ -146,10 +164,7 @@ describe(
           interface: IFACE,
           member: 'Fail'
         },
-        err => {
-          assert.ok(err, 'expected an error');
-          done();
-        }
+        err => done(err ? undefined : new Error('expected an error'))
       );
     });
 
@@ -163,12 +178,9 @@ describe(
           signature: 'ss',
           body: [IFACE, 'Greeting']
         },
-        (err, result) => {
-          if (err) return done(err);
-          // a variant unmarshalls as [signatureTree, [value]]
-          assert.strictEqual(result[1][0], 'hello');
-          done();
-        }
+        // A variant unmarshals as [signatureTree, [value]] classically and as
+        // the value itself under `plainValues`; variantValue() reads both.
+        check(done, result => assert.strictEqual(variantValue(result), 'hello'))
       );
     });
 
@@ -182,11 +194,7 @@ describe(
           signature: 'ssv',
           body: [IFACE, 'Greeting', ['s', 'updated']]
         },
-        err => {
-          if (err) return done(err);
-          assert.strictEqual(impl.Greeting, 'updated');
-          done();
-        }
+        check(done, () => assert.strictEqual(impl.Greeting, 'updated'))
       );
     });
 
@@ -201,7 +209,7 @@ describe(
           body: [IFACE, 'NoSuchProperty']
         },
         err => {
-          assert.ok(err, 'expected an error for an unknown property');
+          if (!err) return done(new Error('expected an error'));
           done();
         }
       );
@@ -217,13 +225,12 @@ describe(
           signature: 's',
           body: [IFACE]
         },
-        (err, result) => {
-          if (err) return done(err);
-          const names = result.map(entry => entry[0]);
+        check(done, result => {
+          // Pairs classically, a plain object under `plainValues`.
+          const names = Object.keys(toPlain(result));
           assert.ok(names.includes('Greeting'));
           assert.ok(names.includes('Count'));
-          done();
-        }
+        })
       );
     });
 
@@ -235,11 +242,9 @@ describe(
           interface: 'org.freedesktop.DBus.Peer',
           member: 'GetMachineId'
         },
-        (err, id) => {
-          if (err) return done(err);
-          assert.ok(/^[0-9a-f]{32}$/.test(id), `unexpected machine id: ${id}`);
-          done();
-        }
+        check(done, id =>
+          assert.ok(/^[0-9a-f]{32}$/.test(id), `unexpected machine id: ${id}`)
+        )
       );
     });
 
@@ -251,13 +256,11 @@ describe(
           interface: 'org.freedesktop.DBus.Introspectable',
           member: 'Introspect'
         },
-        (err, xml) => {
-          if (err) return done(err);
+        check(done, xml => {
           assert.ok(xml.includes(`<interface name="${IFACE}">`));
           assert.ok(xml.includes('<method name="Echo">'));
           assert.ok(xml.includes('<signal name="Pinged">'));
-          done();
-        }
+        })
       );
     });
 
@@ -266,9 +269,15 @@ describe(
       clientBus.addMatch(match, err => {
         if (err) return done(err);
         const key = clientBus.mangle(OBJECT_PATH, IFACE, 'Pinged');
+        // A signal handler takes the body, not (err, result), so it gets the
+        // same try/catch by hand rather than through check().
         clientBus.signals.once(key, body => {
-          assert.deepStrictEqual(body, ['ping payload']);
-          done();
+          try {
+            assert.deepStrictEqual(body, ['ping payload']);
+            done();
+          } catch (failure) {
+            done(failure);
+          }
         });
         impl.emit('Pinged', 'ping payload');
       });

--- a/test/integration/bigint.js
+++ b/test/integration/bigint.js
@@ -7,7 +7,7 @@
 const { describe, it, before, after } = require('node:test');
 const assert = require('assert');
 const { EventEmitter } = require('events');
-const dbus = require('../../index');
+const { sessionBus } = require('../utils/shape');
 
 const NO_BUS =
   !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
@@ -56,11 +56,14 @@ describe('integration: BigInt', { timeout: 10000, skip: NO_BUS }, () => {
     // the option too. Without it an `x` argument arrives as a lossy number,
     // and echoing that back fails the 53-bit check on marshall -- loudly,
     // which is better than the silent truncation it would otherwise be.
-    serviceBus = dbus.sessionBus({ returnBigInt: true });
+    serviceBus = sessionBus({ returnBigInt: true });
     // The option is per connection, so the same daemon and the same service
     // can be read either way -- which is what makes migration incremental.
-    bigClient = dbus.sessionBus({ returnBigInt: true });
-    plainClient = dbus.sessionBus();
+    bigClient = sessionBus({ returnBigInt: true });
+    // Explicitly off rather than merely unset: this connection exists to show
+    // the lossy path, and it has to keep showing it once `returnBigInt`
+    // becomes the default.
+    plainClient = sessionBus({ returnBigInt: false });
 
     const impl = Object.assign(Object.create(EventEmitter.prototype), {
       EchoX: v => v,

--- a/test/integration/cli.js
+++ b/test/integration/cli.js
@@ -14,7 +14,7 @@ const { execFile } = require('child_process');
 const { promisify } = require('util');
 const path = require('path');
 const { EventEmitter } = require('events');
-const dbus = require('../../index');
+const { sessionBus } = require('../utils/shape');
 
 const run = promisify(execFile);
 const BIN = path.join(__dirname, '..', '..', 'bin', 'dbus-native.js');
@@ -36,7 +36,7 @@ describe('integration: the CLI', { timeout: 30000, skip: NO_BUS }, () => {
     // Without it the service reads `t` as a Number, which is lossy above 2^53,
     // and then cannot marshal it again -- the CLI sends the value exactly, and
     // it is the echo that would lose it.
-    bus = dbus.sessionBus({ returnBigInt: true });
+    bus = sessionBus({ returnBigInt: true });
     await bus.getId();
     await new Promise((resolve, reject) =>
       bus.requestName(SERVICE, 0, err => (err ? reject(err) : resolve()))

--- a/test/integration/codegen.js
+++ b/test/integration/codegen.js
@@ -18,7 +18,7 @@ const path = require('path');
 const { execFile } = require('child_process');
 const { promisify } = require('util');
 const { EventEmitter } = require('events');
-const dbus = require('../../index');
+const { sessionBus } = require('../utils/shape');
 
 // node:test skips a whole suite from its options, evaluated at load time.
 const NO_BUS =
@@ -68,7 +68,7 @@ describe(
     let tmp;
 
     before(async () => {
-      serviceBus = dbus.sessionBus();
+      serviceBus = sessionBus();
       const impl = Object.assign(Object.create(EventEmitter.prototype), {
         Greeting: 'hello',
         Count: 1,

--- a/test/integration/dbus2js.js
+++ b/test/integration/dbus2js.js
@@ -9,7 +9,7 @@ const path = require('path');
 const { execFile } = require('child_process');
 const { promisify } = require('util');
 const { EventEmitter } = require('events');
-const dbus = require('../../index');
+const { sessionBus } = require('../utils/shape');
 
 // node:test skips a whole suite from its options, evaluated at load time.
 const NO_BUS =
@@ -32,7 +32,7 @@ describe(
     let tmp;
 
     before(async () => {
-      serviceBus = dbus.sessionBus();
+      serviceBus = sessionBus();
       const impl = Object.assign(Object.create(EventEmitter.prototype), {
         Greeting: 'hello',
         Echo: s => s

--- a/test/integration/diagnostics.js
+++ b/test/integration/diagnostics.js
@@ -4,7 +4,7 @@ const { describe, it, before, after } = require('node:test');
 const assert = require('assert');
 const dc = require('node:diagnostics_channel');
 const { EventEmitter } = require('events');
-const dbus = require('../../index');
+const { sessionBus } = require('../utils/shape');
 
 // node:test skips a whole suite from its options, evaluated at load time.
 const NO_BUS =
@@ -44,8 +44,8 @@ describe(
     let serviceBus, clientBus;
 
     before(async () => {
-      serviceBus = dbus.sessionBus();
-      clientBus = dbus.sessionBus();
+      serviceBus = sessionBus();
+      clientBus = sessionBus();
 
       const impl = Object.assign(Object.create(EventEmitter.prototype), {
         Echo: input => input,

--- a/test/integration/dicts.js
+++ b/test/integration/dicts.js
@@ -7,8 +7,8 @@
 const { describe, it, before, after } = require('node:test');
 const assert = require('assert');
 const { EventEmitter } = require('events');
-const dbus = require('../../index');
-const { Variant, toPlain } = require('../../lib/values');
+const { Variant, toPlain, variantSignature } = require('../../lib/values');
+const { sessionBus, PLAIN_VALUES } = require('../utils/shape');
 
 const NO_BUS =
   !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
@@ -42,8 +42,8 @@ describe(
       );
 
     before(async () => {
-      serviceBus = dbus.sessionBus();
-      clientBus = dbus.sessionBus();
+      serviceBus = sessionBus();
+      clientBus = sessionBus();
 
       const impl = Object.assign(Object.create(EventEmitter.prototype), {
         Describe(options) {
@@ -110,7 +110,7 @@ describe(
       assert.deepStrictEqual(JSON.parse(description), { tags: ['a', 'b'] });
     });
 
-    it('the service sees the types the client asked for', async () => {
+    it('the service sees the values the client asked for', async () => {
       await iface.Describe({
         n: 1,
         d: 1.5,
@@ -118,10 +118,34 @@ describe(
         b: true,
         u: new Variant('u', 9)
       });
-      // The service reads variants in the classic shape, so the parsed
-      // signature tree is right there on each value.
+      assert.deepStrictEqual(toPlain(received), {
+        n: 1,
+        d: 1.5,
+        s: 'x',
+        b: true,
+        u: 9
+      });
+    });
+
+    // A variant's signature is only recoverable from a shape that carries it.
+    // Under `plainValues` the parser has already discarded it and
+    // variantSignature() returns undefined -- there is no way for a service to
+    // ask what types an a{sv} argument arrived with. That is a real gap in the
+    // 2.0 plan, which promises `Variant` "when explicitly requested" without
+    // yet providing a way to request it. See ROADMAP 4.1.
+    it('the service sees the types too, in the shape that carries them', () => {
+      if (PLAIN_VALUES) {
+        assert.strictEqual(
+          variantSignature(Object.values(received)[0]),
+          undefined,
+          'plainValues discards signatures; nothing to assert here'
+        );
+        return;
+      }
       const signatures = {};
-      for (const [key, value] of received) signatures[key] = value[0][0].type;
+      for (const [key, value] of received) {
+        signatures[key] = variantSignature(value);
+      }
       assert.deepStrictEqual(signatures, {
         n: 'i',
         d: 'd',

--- a/test/integration/forward-compat.js
+++ b/test/integration/forward-compat.js
@@ -5,6 +5,7 @@ const { describe, it, before, after } = require('node:test');
 const assert = require('assert');
 const { EventEmitter } = require('events');
 const dbus = require('../../index');
+const { sessionBus, PLAIN_VALUES } = require('../utils/shape');
 const { Variant, variantValue, toPlain } = dbus;
 const { toClassicError } = require('../../lib/compat');
 
@@ -35,8 +36,8 @@ describe(
       );
 
     before(async () => {
-      serviceBus = dbus.sessionBus();
-      clientBus = dbus.sessionBus();
+      serviceBus = sessionBus();
+      clientBus = sessionBus();
 
       impl = Object.assign(Object.create(EventEmitter.prototype), {
         Greeting: 'hello',
@@ -85,8 +86,15 @@ describe(
         body: [IFACE, 'Greeting']
       });
       assert.ifError(err);
-      // the shape people complain about, and the shape that survives 2.0
-      assert.strictEqual(result[1][0], 'hello');
+      // The shape people complain about -- and, under `plainValues`, the shape
+      // that replaces it. Asserted explicitly on both sides because the whole
+      // point of the next line is that it does not have to care.
+      if (PLAIN_VALUES) {
+        assert.strictEqual(result, 'hello');
+      } else {
+        assert.strictEqual(result[1][0], 'hello');
+      }
+      // the shape that survives 2.0
       assert.strictEqual(variantValue(result), 'hello');
     });
 

--- a/test/integration/launchd.js
+++ b/test/integration/launchd.js
@@ -13,7 +13,7 @@ const assert = require('assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const dbus = require('../../index');
+const { sessionBus } = require('../utils/shape');
 
 const NO_BUS =
   !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
@@ -56,7 +56,7 @@ exit 0
     });
 
     it('completes the handshake and serves calls', async () => {
-      const bus = dbus.sessionBus({
+      const bus = sessionBus({
         busAddress: 'launchd:env=DBUS_LAUNCHD_TEST_BUS'
       });
       try {
@@ -74,7 +74,7 @@ exit 0
     });
 
     it('gets a unique name, so Hello went through', async () => {
-      const bus = dbus.sessionBus({
+      const bus = sessionBus({
         busAddress: 'launchd:env=DBUS_LAUNCHD_TEST_BUS'
       });
       try {

--- a/test/integration/match-rules.js
+++ b/test/integration/match-rules.js
@@ -12,7 +12,7 @@
 
 const { describe, it, before, after } = require('node:test');
 const assert = require('assert');
-const dbus = require('../../index');
+const { sessionBus } = require('../utils/shape');
 const { parse } = require('../../lib/match-rule');
 
 const NO_BUS =
@@ -61,7 +61,7 @@ describe(
     let bus;
 
     before(async () => {
-      bus = dbus.sessionBus();
+      bus = sessionBus();
       await bus.getId();
     });
 
@@ -146,7 +146,7 @@ describe(
         if (msg.member === 'NameOwnerChanged') delivered.push(msg);
       });
 
-      const other = dbus.sessionBus();
+      const other = sessionBus();
       await other.getId();
       await new Promise((resolve, reject) =>
         other.requestName('com.example.MatchRuleProbe', 0, err =>

--- a/test/integration/method-returns.js
+++ b/test/integration/method-returns.js
@@ -12,7 +12,7 @@
 const { describe, it, before, after } = require('node:test');
 const assert = require('assert');
 const { EventEmitter } = require('events');
-const dbus = require('../../index');
+const { sessionBus } = require('../utils/shape');
 
 const NO_BUS =
   !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
@@ -51,8 +51,8 @@ describe(
       );
 
     before(async () => {
-      serviceBus = dbus.sessionBus();
-      clientBus = dbus.sessionBus();
+      serviceBus = sessionBus();
+      clientBus = sessionBus();
 
       const impl = Object.assign(Object.create(EventEmitter.prototype), {
         Void: () => undefined,

--- a/test/integration/object-paths.js
+++ b/test/integration/object-paths.js
@@ -7,7 +7,7 @@
 const { describe, it, before, after } = require('node:test');
 const assert = require('assert');
 const { EventEmitter } = require('events');
-const dbus = require('../../index');
+const { sessionBus } = require('../utils/shape');
 
 const NO_BUS =
   !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
@@ -36,8 +36,8 @@ describe('integration: object paths', { timeout: 10000, skip: NO_BUS }, () => {
   let serviceBus, clientBus, service;
 
   before(async () => {
-    serviceBus = dbus.sessionBus();
-    clientBus = dbus.sessionBus();
+    serviceBus = sessionBus();
+    clientBus = sessionBus();
     await Promise.all([serviceBus.getId(), clientBus.getId()]);
     await new Promise((resolve, reject) =>
       serviceBus.requestName(SERVICE, 0, err => (err ? reject(err) : resolve()))

--- a/test/integration/promises.js
+++ b/test/integration/promises.js
@@ -5,6 +5,7 @@ const { describe, it, before, after } = require('node:test');
 const assert = require('assert');
 const { EventEmitter } = require('events');
 const dbus = require('../../index');
+const { sessionBus } = require('../utils/shape');
 const { DBusError } = require('../../lib/errors');
 
 // node:test skips a whole suite from its options, evaluated at load time.
@@ -31,8 +32,8 @@ describe('integration: promises', { timeout: 10000, skip: NO_BUS }, () => {
   let serviceBus, clientBus, impl;
 
   before(async () => {
-    serviceBus = dbus.sessionBus();
-    clientBus = dbus.sessionBus();
+    serviceBus = sessionBus();
+    clientBus = sessionBus();
 
     impl = Object.assign(Object.create(EventEmitter.prototype), {
       Greeting: 'hello',

--- a/test/integration/properties.js
+++ b/test/integration/properties.js
@@ -4,7 +4,8 @@
 const { describe, it, before, after } = require('node:test');
 const assert = require('assert');
 const { EventEmitter } = require('events');
-const dbus = require('../../index');
+const { variantValue, toPlain } = require('../../lib/values');
+const { sessionBus } = require('../utils/shape');
 
 const NO_BUS =
   !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
@@ -49,8 +50,8 @@ describe('integration: properties', { timeout: 10000, skip: NO_BUS }, () => {
     });
 
   before(async () => {
-    serviceBus = dbus.sessionBus();
-    clientBus = dbus.sessionBus();
+    serviceBus = sessionBus();
+    clientBus = sessionBus();
     impl = Object.assign(Object.create(EventEmitter.prototype), {
       Greeting: 'hello',
       Locked: true,
@@ -83,7 +84,9 @@ describe('integration: properties', { timeout: 10000, skip: NO_BUS }, () => {
       clientBus.signals.once(key, body =>
         resolve({
           interfaceName: body[0],
-          changed: Object.fromEntries(body[1].map(([k, v]) => [k, v[1][0]])),
+          // `a{sv}` of pairs-of-variants classically, a plain object under
+          // `plainValues`. toPlain() flattens both to the same thing.
+          changed: toPlain(body[1]),
           invalidated: body[2]
         })
       );
@@ -126,11 +129,11 @@ describe('integration: properties', { timeout: 10000, skip: NO_BUS }, () => {
 
     it('reads and writes', async () => {
       const before = await call('Get', 'ss', [IFACE, 'my-prop']);
-      assert.strictEqual(before[1][0], 'hyphen works');
+      assert.strictEqual(variantValue(before), 'hyphen works');
       await call('Set', 'ssv', [IFACE, 'my-prop', ['s', 'and writes']]);
       assert.strictEqual(impl['my-prop'], 'and writes');
       const after = await call('Get', 'ss', [IFACE, 'my-prop']);
-      assert.strictEqual(after[1][0], 'and writes');
+      assert.strictEqual(variantValue(after), 'and writes');
     });
 
     it('is carried by PropertiesChanged', async () => {
@@ -167,20 +170,23 @@ describe('integration: properties', { timeout: 10000, skip: NO_BUS }, () => {
 
     it('omits write-only properties from GetAll', async () => {
       const all = await call('GetAll', 's', [IFACE]);
-      const names = all.map(([k]) => k);
-      assert.deepStrictEqual(names, ['Greeting', 'Locked', 'my-prop']);
+      assert.deepStrictEqual(Object.keys(toPlain(all)), [
+        'Greeting',
+        'Locked',
+        'my-prop'
+      ]);
     });
 
     it('still reads and writes a readwrite property', async () => {
       await call('Set', 'ssv', [IFACE, 'Greeting', ['s', 'written']]);
       assert.strictEqual(impl.Greeting, 'written');
       const value = await call('Get', 'ss', [IFACE, 'Greeting']);
-      assert.strictEqual(value[1][0], 'written');
+      assert.strictEqual(variantValue(value), 'written');
     });
 
     it('still reads a read-only property', async () => {
       const value = await call('Get', 'ss', [IFACE, 'Locked']);
-      assert.strictEqual(value[1][0], true);
+      assert.strictEqual(variantValue(value), true);
     });
 
     it('still rejects an undeclared property', async () => {

--- a/test/integration/shape.js
+++ b/test/integration/shape.js
@@ -1,0 +1,104 @@
+// Proves the run is testing the shape it claims to be testing.
+//
+// `npm run test:integration:2.0` is only worth anything if DBUS_TEST_SHAPE
+// actually reaches the tests -- it travels through two `npm run` hops and a
+// wrapper process to get here. If a rename or a lost `env` spread ever breaks
+// that chain the whole suite goes green while exercising nothing new, which is
+// worse than a red one. So the shape is asserted against a real daemon rather
+// than assumed.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const { variantValue, variantSignature } = require('../../lib/values');
+const { sessionBus, PLAIN_VALUES, RETURN_BIGINT } = require('../utils/shape');
+
+const NO_BUS =
+  !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
+
+const SERVICE = 'com.github.sidorares.dbusnative.Shape';
+const OBJECT_PATH = '/com/github/sidorares/dbusnative/Shape';
+const IFACE = 'com.github.sidorares.dbusnative.ShapeIface';
+const PROPS = 'org.freedesktop.DBus.Properties';
+
+const ifaceDesc = {
+  name: IFACE,
+  methods: { Big: ['', 't', [], ['value']] },
+  signals: {},
+  properties: { Greeting: 's' }
+};
+
+describe(
+  'integration: the shape under test',
+  { timeout: 10000, skip: NO_BUS },
+  () => {
+    let serviceBus, clientBus;
+
+    const whenReady = bus =>
+      new Promise((resolve, reject) =>
+        bus.getId(err => (err ? reject(err) : resolve()))
+      );
+
+    before(async () => {
+      serviceBus = sessionBus();
+      clientBus = sessionBus();
+      const impl = Object.assign(Object.create(EventEmitter.prototype), {
+        Greeting: 'hello',
+        // 2^63, which no Number can hold exactly.
+        Big: () => 9223372036854775808n
+      });
+      EventEmitter.call(impl);
+
+      await Promise.all([whenReady(serviceBus), whenReady(clientBus)]);
+      await new Promise((resolve, reject) =>
+        serviceBus.requestName(SERVICE, 0, err => {
+          if (err) return reject(err);
+          serviceBus.exportInterface(impl, OBJECT_PATH, ifaceDesc);
+          resolve();
+        })
+      );
+    });
+
+    after(() => {
+      for (const bus of [serviceBus, clientBus]) if (bus) bus.connection.end();
+    });
+
+    const get = () =>
+      clientBus.invoke({
+        destination: SERVICE,
+        path: OBJECT_PATH,
+        interface: PROPS,
+        member: 'Get',
+        signature: 'ss',
+        body: [IFACE, 'Greeting']
+      });
+
+    it(`reads a variant in the ${PLAIN_VALUES ? '2.0' : 'classic'} shape`, async () => {
+      const value = await get();
+      if (PLAIN_VALUES) {
+        assert.strictEqual(value, 'hello', 'plainValues did not take effect');
+        assert.strictEqual(variantSignature(value), undefined);
+      } else {
+        assert.ok(Array.isArray(value), 'expected the classic [tree, [value]]');
+        assert.strictEqual(variantSignature(value), 's');
+      }
+      // Whichever it was, the accessor reads it. This is the promise itself.
+      assert.strictEqual(variantValue(await get()), 'hello');
+    });
+
+    it(`reads 't' as a ${RETURN_BIGINT ? 'bigint' : 'number'}`, async () => {
+      const value = await clientBus.invoke({
+        destination: SERVICE,
+        path: OBJECT_PATH,
+        interface: IFACE,
+        member: 'Big'
+      });
+      assert.strictEqual(
+        typeof value,
+        RETURN_BIGINT ? 'bigint' : 'number',
+        'returnBigInt did not take effect'
+      );
+      if (RETURN_BIGINT) assert.strictEqual(value, 9223372036854775808n);
+    });
+  }
+);

--- a/test/integration/signals.js
+++ b/test/integration/signals.js
@@ -6,7 +6,8 @@
 const { describe, it, before, after } = require('node:test');
 const assert = require('assert');
 const { EventEmitter } = require('events');
-const dbus = require('../../index');
+const { toPlain } = require('../../lib/values');
+const { sessionBus } = require('../utils/shape');
 
 const NO_BUS =
   !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
@@ -50,8 +51,8 @@ describe('integration: proxy signals', { timeout: 10000, skip: NO_BUS }, () => {
     });
 
   before(async () => {
-    serviceBus = dbus.sessionBus();
-    clientBus = dbus.sessionBus();
+    serviceBus = sessionBus();
+    clientBus = sessionBus();
     impl = Object.assign(Object.create(EventEmitter.prototype), {
       Greeting: 'hello'
     });
@@ -209,9 +210,8 @@ describe('integration: proxy signals', { timeout: 10000, skip: NO_BUS }, () => {
       const [ifaceName, changed, invalidated] = await received;
       assert.strictEqual(ifaceName, IFACE);
       assert.deepStrictEqual(invalidated, []);
-      // Still the classic variant shape: [name, [signatureTree, [value]]].
-      assert.strictEqual(changed[0][0], 'Greeting');
-      assert.strictEqual(changed[0][1][1][0], 'hello again');
+      // Pairs-of-variants classically, a plain object under `plainValues`.
+      assert.deepStrictEqual(toPlain(changed), { Greeting: 'hello again' });
     });
 
     it('is emitted by Properties.Set as well', async () => {
@@ -221,8 +221,9 @@ describe('integration: proxy signals', { timeout: 10000, skip: NO_BUS }, () => {
       await props.Set(IFACE, 'Greeting', ['s', 'set by the client']);
 
       const [, changed] = await received;
-      assert.strictEqual(changed[0][0], 'Greeting');
-      assert.strictEqual(changed[0][1][1][0], 'set by the client');
+      assert.deepStrictEqual(toPlain(changed), {
+        Greeting: 'set by the client'
+      });
     });
   });
 });

--- a/test/integration/timeouts.js
+++ b/test/integration/timeouts.js
@@ -4,7 +4,7 @@
 const { describe, it, before, after } = require('node:test');
 const assert = require('assert');
 const { EventEmitter } = require('events');
-const dbus = require('../../index');
+const { sessionBus } = require('../utils/shape');
 
 // node:test skips a whole suite from its options, evaluated at load time.
 const NO_BUS =
@@ -31,8 +31,8 @@ describe(
     let serviceBus, clientBus;
 
     before(async () => {
-      serviceBus = dbus.sessionBus();
-      clientBus = dbus.sessionBus();
+      serviceBus = sessionBus();
+      clientBus = sessionBus();
 
       const impl = Object.assign(Object.create(EventEmitter.prototype), {
         Quick: () => 'here',
@@ -109,7 +109,7 @@ describe(
     });
 
     it('honours a client-wide default timeout', async () => {
-      const impatient = dbus.sessionBus({ timeout: 120 });
+      const impatient = sessionBus({ timeout: 120 });
       try {
         await impatient.getId();
         await assert.rejects(() => impatient.invoke(call('NeverReplies')), {

--- a/test/utils/shape.js
+++ b/test/utils/shape.js
@@ -1,0 +1,39 @@
+// Lets the integration suite be run under the 2.0 value shapes, so the flag
+// day can be rehearsed on a released version instead of discovered after it.
+//
+// `DBUS_TEST_SHAPE=2.0` turns on the options that 2.0 makes the default
+// (RELEASE_PLAN.md): a variant reads as its value and a string-keyed dict as a
+// plain object, and 64-bit integers read as `bigint`. Everything in
+// test/integration should pass either way, because that is exactly the promise
+// the 0.6 accessors make to users -- code written against `variantValue()` and
+// `toPlain()` does not care which shape it is looking at.
+//
+// A test that reads a raw shape directly is a test *about* the shape. Those ask
+// which world they are in with PLAIN_VALUES / RETURN_BIGINT rather than
+// pretending to be agnostic.
+
+const dbus = require('../../index');
+
+const TWO_OH = process.env.DBUS_TEST_SHAPE === '2.0';
+
+/** True when a variant reads as its value and an a{sv} as a plain object. */
+const PLAIN_VALUES = TWO_OH;
+
+/** True when `x` and `t` read as `bigint` rather than a lossy `number`. */
+const RETURN_BIGINT = TWO_OH;
+
+const DEFAULTS = TWO_OH ? { plainValues: true, returnBigInt: true } : {};
+
+/**
+ * A session bus with the shape this run asked for.
+ *
+ * Caller options are layered *over* the defaults, not under them, because that
+ * is what changing a default means: a test that states a shape explicitly --
+ * `{ returnBigInt: false }` -- gets it in both runs, and keeps testing the
+ * thing it was written to test.
+ */
+function sessionBus(opts) {
+  return dbus.sessionBus({ ...DEFAULTS, ...opts });
+}
+
+module.exports = { sessionBus, PLAIN_VALUES, RETURN_BIGINT, TWO_OH };


### PR DESCRIPTION
Flipping `plainValues` and `returnBigInt` to on is the largest break in RELEASE_PLAN §2.0, and until now there was no way to find out what it costs short of shipping it. This adds the gate:

```sh
npm run test:integration:2.0          # against dbus-daemon
npm run test:integration:2.0:broker   # against lib/broker.js
```

## What the measurement said

Forcing both options onto every connection and running the existing suite:

```
ℹ tests 152   ℹ pass 123   ℹ fail 9   ℹ cancelled 20
```

Every one of the 9 traces to a **test** asserting a classic shape, not to the library:

- `assert.strictEqual(before[1][0], 'hyphen works')` → got `'y'`, from indexing into a plain string
- `all.map is not a function` — `GetAll` returns an object now
- `basic.js` reported 7 failures that were really one, cascading (see below)

So the honest headline is that **the library already works in the flipped shape**; what was missing was any way to demonstrate that. Both gate runs are now 155/155, as are both classic runs.

## The tests now read values the way we tell users to

`variantValue()` and `toPlain()` are the identity in the new shape — that is the whole point of shipping them in 0.6. Using them in our own suite is the dogfooding that was missing: if it is awkward for us, it is awkward for the people we are asking to do it.

Two rules, documented in AGENTS.md:

- a test asserts behaviour, not a shape;
- a test that *is* about a shape states it in its connection options, so `{ returnBigInt: false }` still means that after the default flips.

`test/utils/shape.js` layers caller options **over** the 2.0 defaults rather than under them, because that is what changing a default means. `bigint.js`'s lossy-path client now says `returnBigInt: false` explicitly instead of relying on the absence of an option.

## Three things this turned up

**The CLI needed the tree shape, and now says so.** `describe()` prints `variant u 501`, and that `u` exists only in the parsed signature tree that `plainValues` discards. Following the default, `dbus-native call` would have quietly stopped printing types on the flag day. `lib/cli/call.js` pins `{ returnBigInt: true, plainValues: false }` with the reason; `test/cli-shape.js` demonstrates both halves — including what the output degrades to — rather than asserting an intention.

**A failed assertion inside an `invoke` callback took the whole file down.** node:test cannot see a throw from a callback it did not call, so it became an uncaughtException: one bad assertion in `basic.js` reported as 8 failures plus a 10s timeout, burying the one that mattered. `check()` routes them through `done`. Verified by deliberately breaking one assertion — 1 failure, 11 pass, 25ms.

**There is no way to ask what signature an `a{sv}` argument arrived with** once `plainValues` has dropped it. RELEASE_PLAN promises `Variant` "when explicitly requested" but there is no way to request it, so a service inspecting its own argument types has nothing to read. `test/integration/dicts.js` records the gap at the point where it bites; worth resolving before 2.0, not in this PR.

## Guarding the gate itself

`DBUS_TEST_SHAPE` crosses two `npm run` hops and a wrapper process. If that chain ever breaks, the whole suite goes green while exercising nothing new — worse than red. `test/integration/shape.js` asserts that the requested shape is the shape a real connection delivers, and names it in the test output:

```
✔ reads a variant in the 2.0 shape
✔ reads 't' as a bigint
```

versus `classic shape` / `as a number` in the default run.

## Also

Drops two AGENTS.md landmines that went stale: `server-handshake.js` stopped being a stub in #353, and 64-bit reads go through BigInt now rather than long.js. Layout section gains `broker.js`, `match-rule.js` and `lib/cli/`.

## Verification

| | dbus-daemon | broker |
|---|---|---|
| classic | 155/155 | 155/155 |
| `DBUS_TEST_SHAPE=2.0` | 155/155 | 155/155 |

Plus `npm test` (809 unit tests, lint, format, tsc) green.

---

# Second commit: `withClassicTypes`, and the 2.0 guide

RELEASE_PLAN §2.0 lists three migration mechanisms. The 0.6 accessors shipped, the lint rule shipped; the third — `dbus-native/compat` — was a code sample. `lib/compat.js` contained only `toClassicError`. The bigint guide page the plan says the change "deserves its own guide page" did not exist either.

```js
const { withClassicTypes } = require('dbus-native/compat');
const bus = withClassicTypes(dbus.sessionBus());
```

1.x shapes on a 2.0 connection. It ships now, where it is a no-op, so the import can land *before* the flag day rather than during it.

## It is not the implementation the plan described

The plan said "a wrapper, not a mode. It cannot leak into unrelated code." That turned out not to be buildable, so **the plan is corrected rather than the code**.

`plainValues` discards a variant's inner signature as it reads it. Nothing downstream can rebuild `[signatureTree, [value]]` without inventing the tree — and a fabricated signature is worse than no signature, because `result[0][0].type` would then confidently return a guess. So it asks the parser instead, via a new `connection.setValueShapes()`, restricted to the three value-shape keys (`maxMessageSize` and the transport options are read once at setup; letting those be poked afterwards would do nothing except confuse whoever tried).

The consequence is that it configures the bus it is given and returns it: scoped to the **connection**, not to the reference. There is one parser per socket, so an independent 2.0 view of the same connection is not a thing that can exist. `test/integration/compat-classic-types.js` shows the real scope by running a wrapped and an unwrapped bus side by side in one process — under `DBUS_TEST_SHAPE=2.0` one gives `[tree, ['hello']]` and the other gives `'hello'`.

It also **restores the old lossiness** along with the old shapes: `x`/`t` come back rounded. Correct for code that needs a Number, and a trap for anyone reaching for this to silence a BigInt error, so it is said plainly in the JSDoc, the guide and the plan.

## docs/migrating-to-2.0.md

Leads with `bigint`, per the plan, because it is the only one of the three changes that breaks code *far away from the D-Bus call* — a metrics counter or an HTTP handler throws with a stack pointing at the serialiser, not at the call that produced the value.

Every sample in it was executed rather than written from memory. That caught two things I had wrong:

- plain-object dict writing landed in **0.11.0**, not 0.9 (#335 is after the 0.10.0 release commit)
- "string-keyed" means `s`, `o` **and** `g` — `STRING_KEYS` in `lib/dbus-buffer.js`

and confirmed the rest, including the linter's exit codes (1 with findings, 0 with `--exit-zero`) and that `--target next` really does emit `bigint` and `Record<string, unknown>`.

## Verification, both commits

| | dbus-daemon | broker |
|---|---|---|
| classic | 161/161 | 161/161 |
| `DBUS_TEST_SHAPE=2.0` | 161/161 | 161/161 |

`npm test` (809 unit tests, lint, format, tsc) green.
