### PR TITLE
feat: withClassicTypes, and a guide for the 2.0 value shapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,6 +551,23 @@ rest rather than guessing. See
 [`dbus-native/compat`](docs/migrating-to-0.7.md#the-escape-hatch) if you need the
 old shape while you migrate.
 
+### The 2.0 value shapes
+
+The next major changes what values look like: a variant becomes the value it
+holds, a string-keyed dict becomes a plain object, and `x`/`t` become `bigint`.
+
+**None of it has to wait for the release.** Both shapes are options today, per
+connection, so you can migrate a subsystem at a time against your real bus:
+
+```js
+const bus = dbus.sessionBus({ plainValues: true, returnBigInt: true });
+```
+
+Code written against `variantValue()` and `toPlain()` needs no change at all —
+they read either shape. `npx dbus-native lint src/` finds the rest.
+[docs/migrating-to-2.0.md](docs/migrating-to-2.0.md) is the guide, and leads
+with `bigint`, which is the part that breaks code far away from the call.
+
 ### Names
 
 Object paths, interface names, error names and member names each have their own

--- a/RELEASE_PLAN.md
+++ b/RELEASE_PLAN.md
@@ -276,11 +276,25 @@ deserves its own guide page.
 
    ```js
    import { withClassicTypes } from 'dbus-native/compat';
-   const bus = withClassicTypes(await sessionBus()); // 1.x shapes, on 2.0
+   const bus = withClassicTypes(sessionBus()); // 1.x shapes, on 2.0
    ```
 
-   A wrapper, not a mode. It cannot leak into unrelated code, and deleting it
-   is one line.
+   Shipped ahead of 2.0, where it is a no-op, so the import can go in before
+   the flag day rather than during it.
+
+   **Scoped to a connection, not to a reference.** The first draft of this
+   section said "a wrapper, not a mode", which turned out not to be buildable:
+   it asks the parser for the old shapes rather than converting values after
+   the fact, because `plainValues` discards a variant's inner signature as it
+   reads it. Nothing downstream can reconstruct `[signatureTree, [value]]`
+   without inventing the tree, and a fabricated signature is worse than none.
+   So it configures the bus it is given and returns it — unrelated code with
+   its own bus is unaffected, but two references to _this_ bus both see 1.x.
+
+   Note it restores the old **lossiness** along with the old shapes: `x`/`t`
+   come back as a rounded `number` again. That is the point for code that
+   expects a Number, and a trap for anyone reaching for it to silence a BigInt
+   error without reading further.
 
 ---
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -72,6 +72,9 @@ becomes the default — the failure mode is a `TypeError` in production rather
 than a subtly wrong value, so it is better found deliberately than on upgrade
 day.
 
+Migration: [docs/migrating-to-2.0.md](./migrating-to-2.0.md), which leads with
+this one.
+
 ---
 
 ## DBUS_DEP0002
@@ -109,6 +112,8 @@ Reading only — the marshaller has taken plain objects and `Variant` since 0.11
 so a value read this way can be written straight back out. Set it on a service
 too if it takes variants as arguments, since it reads them through the same
 parser. See [docs/api.md](./api.md#reading-the-20-shapes-today-plainvalues).
+
+Migration: [docs/migrating-to-2.0.md](./migrating-to-2.0.md).
 
 Related: [#3](https://github.com/sidorares/dbus-native/issues/3),
 [#67](https://github.com/sidorares/dbus-native/issues/67),
@@ -159,6 +164,8 @@ you want.
 
 Writing is unaffected: a plain object has been accepted anywhere a dict is
 expected since 0.11, so this is symmetric.
+
+Migration: [docs/migrating-to-2.0.md](./migrating-to-2.0.md).
 
 ---
 

--- a/docs/migrating-to-2.0.md
+++ b/docs/migrating-to-2.0.md
@@ -1,0 +1,272 @@
+# Migrating to 2.0
+
+**2.0 changes the shapes values arrive in.** A variant becomes the value it
+holds, a string-keyed dict becomes a plain object, and 64-bit integers become
+`bigint`. Nothing else about the API moves.
+
+It is the release people have been asking for since
+[#3](https://github.com/sidorares/dbus-native/issues/3) in 2013, and it is the
+one that breaks the most code, because these shapes are what every `invoke`
+callback in your program reads.
+
+**The whole of it can be done before you upgrade.** Every change below is
+available today, per connection, behind an option. You can migrate one file at
+a time on a released version, verify it against your real bus, and arrive at
+2.0 with nothing left to do. Read [Doing it early](#doing-it-early) first if you
+read nothing else.
+
+---
+
+## What changes
+
+| D-Bus type       | 1.x                                | 2.0                 |
+| ---------------- | ---------------------------------- | ------------------- |
+| `v`              | `[parsedSignatureTree, [value]]`   | the value           |
+| `a{sv}`, `a{ss}` | array of `[key, value]` pairs      | a plain object      |
+| `x`, `t`         | lossy `number`, or long.js objects | **`bigint`**        |
+| `ay`             | `Buffer`                           | `Buffer`, unchanged |
+
+`ay` stays a `Buffer` deliberately. `Buffer` is a `Uint8Array` subclass, so
+anything that accepts the latter already accepts the former, while
+`buf.toString('utf8')` does not exist on a plain `Uint8Array`. Changing it
+would cost real code and buy nothing in a Node-only library.
+
+---
+
+## `bigint` is the sharp edge
+
+Take this one first. The other two changes make code that reads a value shape
+fail loudly at the read. This one makes code fail somewhere else entirely,
+often much later, in a line you did not think was about D-Bus at all.
+
+`bigint` is not a drop-in for `number`:
+
+```js
+size + 1; // TypeError: Cannot mix BigInt and other types
+size * 2; // TypeError, likewise
+Math.round(size); // TypeError: Cannot convert a BigInt to a number
+JSON.stringify({ size }); // TypeError: Do not know how to serialize a BigInt
+size > 100; // fine, comparisons work across types
+size === 100; // false! strict equality across types never holds
+size == 100; // true, loose equality does
+Number(size); // fine, with the precision loss you already had
+```
+
+The two that bite hardest are **arithmetic** and **`JSON.stringify`**. A
+metrics counter that adds a byte total, or an HTTP handler that serialises a
+device property, will throw at runtime on a value that used to work — and the
+stack trace points at your serialiser, not at the D-Bus call that produced it.
+
+So: find every 64-bit value your program actually reads, and decide for each
+one whether it wants the range or the arithmetic.
+
+```js
+// wants the range: a file size, a byte counter, a timestamp in microseconds
+const size = await iface.Size(); // keep it a bigint
+
+// wants the arithmetic: a value you know is small, feeding a percentage
+const pct = Number(await iface.Level()) / 100;
+```
+
+`Number()` at the boundary is not a defeat. It is the same precision you had in
+1.x, made visible in one place instead of applied silently to everything.
+
+For JSON, convert at the edge:
+
+```js
+JSON.stringify(payload, (key, value) =>
+  typeof value === 'bigint' ? value.toString() : value
+);
+```
+
+**Which of your values are 64-bit?** Look for `x` and `t` in the interface's
+introspection XML:
+
+```bash
+dbus-native introspect --service org.freedesktop.UPower \
+  --path /org/freedesktop/UPower/devices/DisplayDevice --system
+```
+
+or generate typings and let the type checker find them, which is less work:
+
+```bash
+dbus-native types --system --service org.freedesktop.UPower \
+  --path /org/freedesktop/UPower --target next --out upower.d.ts
+```
+
+`--target next` emits the 2.0 shapes, so `tsc` reports every place a `bigint`
+meets a `number` before you have run anything.
+
+---
+
+## Variants
+
+```js
+// 1.x -- the shape behind more issues than anything else in this project
+const value = result[1][0];
+
+// 2.0
+const value = result;
+```
+
+Nested in a dict, which is where it usually appears:
+
+```js
+// 1.x
+const udi = dict.find(([key]) => key === 'Udi')[1][1][0];
+
+// 2.0
+const { Udi } = dict;
+```
+
+**Write it once, for both**, using the accessor that shipped in 0.6:
+
+```js
+const { variantValue } = require('dbus-native');
+
+const value = variantValue(result); // identical before and after
+```
+
+`variantValue()` reads the 1.x wrapper and is the identity on a plain value, so
+a file converted to it is done — it needs no second pass at the flag day. This
+is what the accessors are for; see [DBUS_DEP0002](deprecations.md#dbus_dep0002).
+
+### The signature goes with it
+
+`[parsedSignatureTree, [value]]` carried the variant's type. The plain shape
+does not:
+
+```js
+variantSignature(result); // 's' in 1.x, undefined in 2.0
+```
+
+Almost nobody reads it — but if you do, say because you dispatch on the type of
+an `a{sv}` value, there is no replacement yet and you should
+[open an issue](https://github.com/sidorares/dbus-native/issues) describing the
+case. Writing variants is unaffected: `new Variant('u', 9)` and the
+`['u', 9]` pair both still work.
+
+---
+
+## Dicts
+
+```js
+// 1.x
+for (const [key, value] of dict) {
+  console.log(key, variantValue(value));
+}
+const name = dict.find(([key]) => key === 'Name')[1][1][0];
+
+// 2.0
+for (const [key, value] of Object.entries(dict)) {
+  console.log(key, value);
+}
+const { Name } = dict;
+```
+
+**Write it once, for both**, with `toPlain()`, which converts a whole reply
+recursively — pairs to objects, variants unwrapped — and is the identity on a
+2.0 value:
+
+```js
+const { toPlain } = require('dbus-native');
+
+const props = toPlain(await getAll()); // { Name: 'eth0', Mtu: 1500 }
+```
+
+Only dicts with string-like keys become objects — `s`, `o` and `g`. `a{is}`
+and friends stay arrays of pairs in both versions, because an integer key is
+not a JavaScript property name and a 64-bit one would lose precision on the way
+back. (`toPlain()` converts them anyway, stringifying the keys, if that is what
+you want — so a file using it sees objects where the parser hands out pairs.)
+And a dict is told from a struct array by the parser rather than by shape, so
+`a(ss)` is never mistaken for `a{ss}`.
+
+Writing a dict has accepted a plain object since 0.11.0, so code that sends
+`{ Name: 'eth0' }` needs no change. See
+[DBUS_DEP0003](deprecations.md#dbus_dep0003).
+
+---
+
+## Doing it early
+
+None of the above has to wait for 2.0. Both shapes are options today, per
+connection:
+
+```js
+const bus = dbus.sessionBus({ plainValues: true, returnBigInt: true });
+```
+
+That is the same code path 2.0 turns on by default — not a simulation of it.
+So the migration that actually works is:
+
+1. **Convert reads to `variantValue()` and `toPlain()`** on your current
+   version. Nothing changes behaviourally; every converted call site is one
+   that the flag day cannot break.
+
+2. **Find the rest with the linter.** Reading a variant is an index chain, and
+   nothing in the source says what is at the end of it, so there is no complete
+   codemod for this release — anyone promising one has not thought about it.
+   The linter narrows it to a reviewed list instead:
+
+   ```bash
+   npx dbus-native lint src/
+   src/net.js:42  DBUS_DEP0002  variant index chain `[1][1][0]`
+       -> variantValue(), or a plain property read after 2.0
+   ```
+
+   It exits non-zero when there are findings, so it can gate CI while you work
+   through them. Dict findings are marked `(possible)`: `for (const [k, v] of
+xs)` is also ordinary JavaScript, and a linter that cries wolf gets switched
+   off.
+
+3. **Turn the options on, one connection at a time.** Because they are per
+   connection, a large program can move a subsystem at a time against its real
+   bus rather than all at once.
+
+4. **Upgrade.** If steps 1–3 are done, 2.0 is a version bump.
+
+---
+
+## If you cannot migrate yet
+
+```js
+const { withClassicTypes } = require('dbus-native/compat');
+
+const bus = withClassicTypes(dbus.sessionBus());
+```
+
+1.x shapes on a 2.0 connection: variants wrapped, dicts as pairs, `x`/`t` as
+`number`. For code with `result[1][1][0]` in three hundred places and a reason
+to upgrade that is not this.
+
+It is available now, where it does nothing, so the import can land before the
+flag day rather than during it.
+
+Four things to know:
+
+- **It is scoped to the connection, not to the reference.** It configures the
+  bus you hand it and returns that same bus. There is one parser per socket, so
+  an independent 2.0 view of the same connection is not something that can
+  exist. Unrelated code with its own bus is unaffected.
+- **Call it before your first call goes out.** A reply that has already been
+  parsed is already the new shape, and nothing can reach back and change it.
+- **It restores the old lossiness too.** `x` and `t` come back as rounded
+  `number`s again — that is what "classic" means, and it is the right answer if
+  your code needs a Number, but do not reach for this merely to silence a
+  BigInt error. You will be reintroducing the precision bug that
+  [#248](https://github.com/sidorares/dbus-native/issues/248) is about.
+- **It is a holding position, not a destination.** Delete the wrapper and fix
+  what `dbus-native lint` and `tsc` then point at.
+
+---
+
+## Reference
+
+- [docs/deprecations.md](deprecations.md) — DBUS_DEP0001 (`ReturnLongjs`),
+  DBUS_DEP0002 (variants), DBUS_DEP0003 (dicts), with the runtime warnings and
+  what silences each one
+- [docs/api.md](api.md) — `variantValue`, `variantSignature`, `toPlain`,
+  `Variant`
+- [RELEASE_PLAN.md](../RELEASE_PLAN.md) — why these changes are grouped into
+  one major, and what comes after

--- a/index.d.ts
+++ b/index.d.ts
@@ -265,6 +265,16 @@ export interface DBusConnection extends EventEmitter {
    */
   message(msg: Message): boolean;
   end(): this;
+  /**
+   * Change the value shapes this connection's parser produces. Takes effect on
+   * the next message in; a reply already parsed keeps the shape it was read
+   * with. `dbus-native/compat`'s `withClassicTypes` is what this is for.
+   */
+  setValueShapes(shapes: {
+    plainValues?: boolean;
+    returnBigInt?: boolean;
+    ayBuffer?: boolean;
+  }): this;
 
   on(event: 'connect', listener: () => void): this;
   on(event: 'message', listener: (msg: Message) => void): this;

--- a/index.js
+++ b/index.js
@@ -208,6 +208,26 @@ function createConnection(opts) {
     return self;
   };
 
+  // The shapes the parser hands back, changeable after the connection is up.
+  //
+  // This exists for `dbus-native/compat`, and it is the only faithful way to
+  // build it: `plainValues` discards a variant's inner signature as it reads
+  // it, so no amount of post-processing downstream can reconstruct
+  // `[signatureTree, [value]]` -- it would have to invent the tree. Asking the
+  // parser is the difference between the real signature and a guess.
+  //
+  // A fresh DBusBuffer is built per message from this same options object, so a
+  // change takes effect on the next message in. Only the value-shape keys are
+  // writable: `maxMessageSize` and the transport options are read once during
+  // setup, and letting those be poked afterwards would do nothing visible
+  // except confuse whoever tried.
+  self.setValueShapes = shapes => {
+    for (const key of ['plainValues', 'returnBigInt', 'ayBuffer']) {
+      if (Object.hasOwn(shapes, key)) opts[key] = shapes[key];
+    }
+    return self;
+  };
+
   const handshake = opts.server ? serverHandshake : clientHandshake;
   handshake(stream, opts, (error, guid, identity) => {
     if (error) {

--- a/lib/compat.d.ts
+++ b/lib/compat.d.ts
@@ -1,8 +1,10 @@
 /**
- * Backwards-compatibility helpers for the 0.7 error change.
+ * Escape hatches for code that cannot be migrated yet.
  *
- * `import { toClassicError } from 'dbus-native/compat'`
+ * `import { toClassicError, withClassicTypes } from 'dbus-native/compat'`
  */
+
+import type { MessageBus } from '../index';
 
 /**
  * The pre-0.7 error value: the error reply's body, with the properties 0.6
@@ -23,3 +25,13 @@ export interface ClassicDBusError extends Array<unknown> {
  * unchanged.
  */
 export function toClassicError(err: unknown): ClassicDBusError | unknown;
+
+/**
+ * Read 1.x value shapes on a 2.0 connection: a variant as
+ * `[signatureTree, [value]]`, a string-keyed dict as an array of pairs, and
+ * `x`/`t` as a lossy `number`.
+ *
+ * Configures the connection it is given and returns the same bus. Call it
+ * before the first call goes out.
+ */
+export function withClassicTypes<T extends MessageBus>(bus: T): T;

--- a/lib/compat.js
+++ b/lib/compat.js
@@ -1,12 +1,11 @@
-// The 0.7 escape hatch: turn a DBusError back into the array that the
-// callback API delivered before 0.7.
+// Escape hatches for code that cannot be migrated yet.
 //
-// Deliberately a subpath (`dbus-native/compat`) rather than an option on the
-// client. An option would be a mode -- invisible at the call site, inherited
-// by code that never asked for it, and awkward to remove. An import is
-// greppable, obviously temporary, and deleting it is one line.
+// Deliberately a subpath (`dbus-native/compat`) rather than options on the
+// client. An option is invisible at the call site, inherited by code that never
+// asked for it, and awkward to remove. An import is greppable, obviously
+// temporary, and deleting it is one line.
 //
-// See docs/migrating-to-0.7.md.
+// See docs/migrating-to-0.7.md and docs/migrating-to-2.0.md.
 
 /**
  * Reconstruct the pre-0.7 error value.
@@ -48,4 +47,46 @@ function toClassicError(err) {
   return body;
 }
 
-module.exports = { toClassicError };
+// What 1.x handed back, spelled as options. `returnBigInt: false` is the lossy
+// path on purpose: a `t` above 2^53 came back rounded in 1.x, and code that
+// depends on getting a Number depends on that too.
+const CLASSIC_TYPES = { plainValues: false, returnBigInt: false };
+
+/**
+ * Read 1.x value shapes on a 2.0 connection.
+ *
+ *     const bus = withClassicTypes(dbus.sessionBus());
+ *
+ * A variant comes back as `[signatureTree, [value]]`, a string-keyed dict as an
+ * array of pairs, and `x`/`t` as a lossy `number` -- whatever the defaults have
+ * become. For code with `result[1][1][0]` in three hundred places and no
+ * appetite for touching all of them at once.
+ *
+ * **It configures the connection it is given and returns it**, rather than
+ * producing an independent view of the same bus. There is one parser per socket
+ * and the shape is decided as a message is read, so a second view with
+ * different shapes is not a thing that can exist. The scope is therefore the
+ * connection: unrelated code with its own bus is unaffected, which is the
+ * property that matters, but two references to *this* bus both see 1.x shapes.
+ *
+ * Call it before the first call goes out. A reply already parsed is already the
+ * wrong shape, and this cannot reach back and change it.
+ *
+ * Migrating away is deleting the wrapper and fixing what the type checker or
+ * `npx dbus-native lint` then points at. See docs/migrating-to-2.0.md.
+ *
+ * @param {object} bus a bus from sessionBus(), systemBus() or createClient()
+ * @returns {object} the same bus
+ */
+function withClassicTypes(bus) {
+  const connection = bus && bus.connection;
+  if (!connection || typeof connection.setValueShapes !== 'function') {
+    throw new TypeError(
+      'withClassicTypes expects a bus from sessionBus(), systemBus() or createClient()'
+    );
+  }
+  connection.setValueShapes(CLASSIC_TYPES);
+  return bus;
+}
+
+module.exports = { toClassicError, withClassicTypes };

--- a/test/integration/compat-classic-types.js
+++ b/test/integration/compat-classic-types.js
@@ -1,0 +1,154 @@
+// `withClassicTypes` from dbus-native/compat, exercised against a real daemon.
+//
+// The interesting run is `npm run test:integration:2.0`, where the connection
+// would otherwise read the 2.0 shapes: that is the only configuration in which
+// this helper does anything at all. In the default run it is a no-op and these
+// tests are still worth having, because they say what the shapes are either
+// way.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const { variantValue, variantSignature } = require('../../lib/values');
+const { withClassicTypes } = require('../../lib/compat');
+const { sessionBus, PLAIN_VALUES } = require('../utils/shape');
+
+const NO_BUS =
+  !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
+
+const SERVICE = 'com.github.sidorares.dbusnative.Classic';
+const OBJECT_PATH = '/com/github/sidorares/dbusnative/Classic';
+const IFACE = 'com.github.sidorares.dbusnative.ClassicIface';
+const PROPS = 'org.freedesktop.DBus.Properties';
+
+const ifaceDesc = {
+  name: IFACE,
+  methods: { Big: ['', 't', [], ['value']] },
+  signals: {},
+  properties: { Greeting: 's', Count: 'u' }
+};
+
+describe(
+  'integration: withClassicTypes',
+  { timeout: 10000, skip: NO_BUS },
+  () => {
+    let serviceBus, clientBus, modernBus;
+
+    const whenReady = bus =>
+      new Promise((resolve, reject) =>
+        bus.getId(err => (err ? reject(err) : resolve()))
+      );
+
+    before(async () => {
+      serviceBus = sessionBus();
+      // Wrapped before the first call goes out, which is the documented rule.
+      clientBus = withClassicTypes(sessionBus());
+      // A second bus, deliberately not wrapped, to show the scope.
+      modernBus = sessionBus();
+
+      const impl = Object.assign(Object.create(EventEmitter.prototype), {
+        Greeting: 'hello',
+        Count: 7,
+        Big: () => 9223372036854775807n
+      });
+      EventEmitter.call(impl);
+
+      await Promise.all([
+        whenReady(serviceBus),
+        whenReady(clientBus),
+        whenReady(modernBus)
+      ]);
+      await new Promise((resolve, reject) =>
+        serviceBus.requestName(SERVICE, 0, err => {
+          if (err) return reject(err);
+          serviceBus.exportInterface(impl, OBJECT_PATH, ifaceDesc);
+          resolve();
+        })
+      );
+    });
+
+    after(() => {
+      for (const bus of [serviceBus, clientBus, modernBus])
+        if (bus) bus.connection.end();
+    });
+
+    const get = (bus, property) =>
+      bus.invoke({
+        destination: SERVICE,
+        path: OBJECT_PATH,
+        interface: PROPS,
+        member: 'Get',
+        signature: 'ss',
+        body: [IFACE, property]
+      });
+
+    const getAll = bus =>
+      bus.invoke({
+        destination: SERVICE,
+        path: OBJECT_PATH,
+        interface: PROPS,
+        member: 'GetAll',
+        signature: 's',
+        body: [IFACE]
+      });
+
+    it('hands back a variant as [signatureTree, [value]]', async () => {
+      const value = await get(clientBus, 'Greeting');
+      assert.ok(Array.isArray(value), 'expected the classic wrapper');
+      // The index chain 1.x code is full of, working verbatim.
+      assert.strictEqual(value[1][0], 'hello');
+      // And the real signature, not one inferred from the value -- which is why
+      // this asks the parser rather than converting after the fact.
+      assert.strictEqual(variantSignature(value), 's');
+    });
+
+    it('hands back a{sv} as an array of pairs', async () => {
+      const all = await getAll(clientBus);
+      assert.ok(Array.isArray(all), 'expected pairs, not an object');
+      assert.deepStrictEqual(
+        all.map(([key]) => key).sort(),
+        ['Count', 'Greeting'].sort()
+      );
+      const greeting = all.find(([key]) => key === 'Greeting');
+      assert.strictEqual(greeting[1][1][0], 'hello');
+    });
+
+    it("hands back 't' as a lossy number, as 1.x did", async () => {
+      const value = await clientBus.invoke({
+        destination: SERVICE,
+        path: OBJECT_PATH,
+        interface: IFACE,
+        member: 'Big'
+      });
+      assert.strictEqual(typeof value, 'number');
+      // Restoring the old shape restores the old rounding. Documented, not a
+      // regression: code that wants a Number is asking for this.
+      assert.notStrictEqual(BigInt(value), 9223372036854775807n);
+    });
+
+    it('leaves an unwrapped bus on this run’s own shapes', async () => {
+      const value = await get(modernBus, 'Greeting');
+      if (PLAIN_VALUES) {
+        assert.strictEqual(value, 'hello', 'the wrapper leaked to another bus');
+      } else {
+        assert.strictEqual(value[1][0], 'hello');
+      }
+    });
+
+    it('is what variantValue reads either way', async () => {
+      assert.strictEqual(
+        variantValue(await get(clientBus, 'Greeting')),
+        'hello'
+      );
+      assert.strictEqual(
+        variantValue(await get(modernBus, 'Greeting')),
+        'hello'
+      );
+    });
+
+    it('rejects something that is not a bus', () => {
+      assert.throws(() => withClassicTypes({}), /expects a bus/);
+      assert.throws(() => withClassicTypes(undefined), /expects a bus/);
+    });
+  }
+);


### PR DESCRIPTION
Follows #359, which added the gate this is verified against.

RELEASE_PLAN §2.0 lists three migration mechanisms. The 0.6 accessors shipped, the lint rule shipped; the third — `dbus-native/compat` — was a code sample. `lib/compat.js` contained only `toClassicError`. The bigint guide page the plan says the change "deserves" did not exist either.

```js
const { withClassicTypes } = require('dbus-native/compat');
const bus = withClassicTypes(dbus.sessionBus());
```

1.x shapes on a 2.0 connection: variants wrapped, dicts as pairs, `x`/`t` as `number`. For code with `result[1][1][0]` in three hundred places and a reason to upgrade that is not this one. **It ships now, where it is a no-op**, so the import can land before the flag day rather than during it.

## It is not the implementation the plan described

The plan said "a wrapper, not a mode. It cannot leak into unrelated code." That turned out not to be buildable, so **the plan is corrected rather than the code**.

`plainValues` discards a variant's inner signature as it reads it. Nothing downstream can rebuild `[signatureTree, [value]]` without inventing the tree — and a fabricated signature is worse than none, because `result[0][0].type` would then confidently return a guess. So it asks the parser instead, through a new `connection.setValueShapes()`, restricted to the three value-shape keys: `maxMessageSize` and the transport options are read once during setup, and letting those be poked afterwards would do nothing visible except confuse whoever tried.

The consequence is that it configures the bus it is given and returns it — scoped to the **connection**, not to the reference. There is one parser per socket, so an independent 2.0 view of the same connection is not a thing that can exist.

`test/integration/compat-classic-types.js` demonstrates the real scope rather than asserting the intention: a wrapped and an unwrapped bus run side by side in one process, and under `DBUS_TEST_SHAPE=2.0` one gives `[tree, ['hello']]` while the other gives `'hello'`.

It also **restores the old lossiness** along with the old shapes — `x`/`t` come back rounded. Right for code that needs a Number, and a trap for anyone reaching for this to silence a BigInt error, so it is said plainly in the JSDoc, the guide and the plan.

## docs/migrating-to-2.0.md

Leads with `bigint`, per the plan, because it is the only one of the three changes that breaks code *far away from the D-Bus call*: a metrics counter or an HTTP handler throws with a stack pointing at the serialiser, not at the call that produced the value. The variant and dict changes fail loudly at the read; this one does not.

The guide's spine is that **none of it has to wait for the release** — both shapes are options today, per connection, so a large program can migrate a subsystem at a time against its real bus and arrive at 2.0 with nothing to do.

Every sample in it was executed rather than written from memory. That caught two things I had wrong:

- plain-object dict writing landed in **0.11.0**, not 0.9 — #335 is after the 0.10.0 release commit
- "string-keyed" means `s`, `o` **and** `g`, per `STRING_KEYS` in `lib/dbus-buffer.js`

and confirmed the rest: every `TypeError` in the bigint section, the linter's exit codes (1 with findings, 0 with `--exit-zero`, 0 when clean), and that `--target next` really does emit `bigint` and `Record<string, unknown>`.

## Verification

| | dbus-daemon | broker |
|---|---|---|
| classic | 161/161 | 161/161 |
| `DBUS_TEST_SHAPE=2.0` | 161/161 | 161/161 |

`npm test` (809 unit tests, lint, format, tsc) green.
