### PR TITLE
docs: re-evaluate the clean-slate design at v0.12.0

### DIFF
--- a/BIG_FUTURE_PLANS.md
+++ b/BIG_FUTURE_PLANS.md
@@ -1,695 +1,63 @@
 # BIG_FUTURE_PLANS.md
 
-What `dbus-native` could look like if it were designed today, with backwards
+What `dbus-native` would look like if it were designed today, with backwards
 compatibility off the table.
 
-Written 2026-07-28, after the 0.5.0 wire-layer work. This is a **design sketch
-for review, not a commitment and not implemented** — none of the code below
-runs. Where a proposal has a real problem I have said so rather than glossed
-over it; see §14 for the parts I would cut.
+**Revised 2026-07-30, at v0.12.0.** The first draft was written 2026-07-28,
+before 0.6 through 0.12 shipped. Roughly half of it is now in the package, so a
+straight re-read would be misleading. This revision does three things: records
+what landed, records **where building it proved the design wrong**, and states
+what perfect DX looks like from here.
 
-Two things ground it, so it is not a wishlist:
+The corrections in §2 are the point of this document. They are not second
+thoughts — each one is something that only became visible by shipping the thing
+next to it.
 
-- **The issue tracker.** Nearly every proposal here closes issues that have
-  been open for years. They are cited inline.
-- **What actually shipped in JavaScript.** Feature availability was checked on
-  Node 26 rather than assumed, and §13 records what is genuinely available
-  versus what still needs a transpiler.
-
----
-
-## 0. What is actually wrong today
-
-Not opinions — these are the recurring themes in the tracker.
-
-**Reading a value means walking the parser's internal tree.** From
-[#67](https://github.com/sidorares/dbus-native/issues/67), the answer a user
-was given for extracting one string out of an `a{sv}`:
-
-```js
-const dict = [
-  ['Udi', [[{ type: 's', child: [] }], ['/sys/devices/.../wlan0']]]
-];
-const value = dict.find(([key]) => key === 'Udi')[1][1][0];
-//                                              ^^^^^^^^^ parsed signature, then value, then unwrap
-```
-
-Same complaint in [#3](https://github.com/sidorares/dbus-native/issues/3),
-[#132](https://github.com/sidorares/dbus-native/issues/132),
-[#147](https://github.com/sidorares/dbus-native/issues/147),
-[#52](https://github.com/sidorares/dbus-native/issues/52),
-[#104](https://github.com/sidorares/dbus-native/issues/104). It is the single
-most-reported problem in the project's history.
-
-**Errors are not Errors.** From
-[#207](https://github.com/sidorares/dbus-native/issues/207) — a failed call
-hands the callback an _array of strings_:
-
-```js
-bus.invoke(msg, (err, result) => {
-  // err === [ 'The name net.connman was not provided by any .service files' ]
-  // no stack, no .name, no way to switch on the error, sometimes just []
-});
-```
-
-[#178](https://github.com/sidorares/dbus-native/issues/178) is the same thing
-with an empty body, where `err` is `[]` — falsy-adjacent and easy to miss.
-
-**Everything is a callback.** [#9](https://github.com/sidorares/dbus-native/issues/9)
-was opened in 2013 and is still open.
-[#10](https://github.com/sidorares/dbus-native/pull/10) and
-[#295](https://github.com/sidorares/dbus-native/pull/295) are both unmerged
-promise PRs, thirteen and three years old.
-
-**No types.** [#276](https://github.com/sidorares/dbus-native/issues/276).
-
-**No timeouts, no cancellation.** [#137](https://github.com/sidorares/dbus-native/issues/137).
-A call whose reply never arrives leaks its entry in `bus.cookies` forever.
-
-**Nothing is cleaned up.** Match rules, owned names and the connection itself
-all have to be released by hand, and
-[#20](https://github.com/sidorares/dbus-native/issues/20) shows that even
-closing the connection at the wrong moment throws.
-
-**Boilerplate before you can do anything.** The README's own opening example is
-three levels of nesting before the first method call.
+Everything marked ✅ has code and tests. Everything else is a proposal.
+Feature availability was re-checked on Node 26 (§4), not assumed.
 
 ---
 
-## 1. `await using` connections
+## 0. Where the sketch was right
 
-**Closes:** [#20](https://github.com/sidorares/dbus-native/issues/20).
+The original §0 listed what was wrong with the library. Most of it is fixed.
 
-A bus connection owns a socket, pending replies, match rules and possibly a
-well-known name. Today you release all of that by hand, in the right order, and
-`connection.end()` at the wrong moment throws.
+| the complaint                      | then                           | now                                                          |
+| ---------------------------------- | ------------------------------ | ------------------------------------------------------------ |
+| errors are not `Error`s            | `err` is an array of strings   | ✅ `DBusError` with `dbusName`, `body`, a real stack (0.7)   |
+| everything is a callback           | #9 open since 2013             | ✅ promises everywhere, callbacks still supported            |
+| no timeouts, no cancellation       | `bus.cookies` leaked forever   | ✅ `timeout`, `AbortSignal`, entries removed on settle       |
+| no types                           | #276                           | ✅ hand-written `index.d.ts` + `dbus-native types` codegen   |
+| reading a value walks a parse tree | `dict.find(…)[1][1][0]`        | ✅ `variantValue()`/`toPlain()`; `plainValues` opt-in        |
+| 64-bit is lossy                    | `number`, or a long.js object  | ✅ `returnBigInt` opt-in; default in 2.0                     |
+| nothing is inspectable             | "I sent something and it hung" | ✅ `diagnostics_channel`, `dbus-dissect`, `dbus-native call` |
+| tests need a system daemon         | `brew install dbus`            | ✅ `createBroker()` — in-process bus, 161 tests run on it    |
+| the server side is a stub          | hardcoded 2014 GUID            | ✅ real SASL, three mechanisms, match rules, routing         |
+| properties are all `readwrite`     | #89                            | ✅ `access` declared, enforced, and in the introspection XML |
+| a bad name produced a dead message | #309                           | ✅ validated on export and send                              |
 
-Explicit resource management makes the lifetime lexical:
+What is left from the original sketch: **`await using` (§1), proxies (§2), the
+value-shape flag day (§3), async-iterable signals (§5), `defineInterface` (§7),
+and ESM (§9).** That is the breaking window, and it is the subject of the rest
+of this document.
 
-```js
-import { sessionBus } from 'dbus-native';
-
-{
-  await using bus = await sessionBus();
-  const id = await bus.call({/* ... */});
-}
-// socket closed, pending calls rejected with a clear error, match rules
-// removed, owned names released -- in that order, and awaited
-```
-
-The library implements `[Symbol.asyncDispose]()`. Consumers on older Node that
-lack the `using` _syntax_ can still call `await bus.close()` — the protocol and
-the keyword are separable, so implementing it costs nothing.
-
-`DisposableStack` composes several resources, which is exactly the shape of a
-service that owns a name, exports objects and subscribes to signals:
-
-```js
-await using stack = new AsyncDisposableStack();
-const bus = stack.use(await sessionBus());
-stack.use(await bus.requestName('com.example.Greeter'));
-stack.use(await bus.export('/com/example/Greeter', greeter));
-stack.use(
-  await bus.watch("type='signal',interface='org.freedesktop.NetworkManager'")
-);
-
-await stack.defer(() => console.log('shutting down'));
-// everything unwinds in reverse order, whether we leave normally or throw
-```
-
-Today the equivalent is a `try/finally` pyramid that nobody writes, which is
-why processes leak match rules.
+The single most important thing the sketch got right, and it is worth
+restating because it constrains everything below: **the wire layer is good and
+must not be rewritten.** Marshalling, parsing and framing were measured and
+hardened across 0.5–0.12. All of the work here is above them.
 
 ---
 
-## 2. Proxies: the object _is_ the remote object
+## 1. The shape of a program
 
-**Closes:** [#88](https://github.com/sidorares/dbus-native/issues/88),
-[#141](https://github.com/sidorares/dbus-native/issues/141),
-and the core of [#104](https://github.com/sidorares/dbus-native/issues/104) —
-where this exact design was discussed in 2016 and rejected because
-"older node versions would require `--harmony-proxies`". That objection expired
-years ago.
-
-Today:
+Before the corrections, here is the target, so the corrections have something
+to attach to.
 
 ```js
-sessionBus
-  .getService('org.freedesktop.Notifications')
-  .getInterface(
-    '/org/freedesktop/Notifications',
-    'org.freedesktop.Notifications',
-    (err, notifications) => {
-      if (err) throw err;
-      notifications.Notify(
-        'app',
-        0,
-        '',
-        'summary',
-        'body',
-        [],
-        [],
-        5000,
-        (err, id) => {
-          /* ... */
-        }
-      );
-    }
-  );
-```
-
-Proposed:
-
-```js
-const notifications = await bus.proxy(
-  'org.freedesktop.Notifications',
-  '/org/freedesktop/Notifications'
-);
-
-const id = await notifications.Notify(
-  'app',
-  0,
-  '',
-  'summary',
-  'body',
-  [],
-  {},
-  5000
-);
-```
-
-`proxy()` introspects once, caches the result per (service, path), and returns
-a `Proxy` whose `get` trap resolves a member name against the interfaces found
-there. Method arguments are marshalled against the _introspected_ signature,
-which is what lets callers pass plain JS — the type information comes from the
-bus, not from the caller.
-
-Where a member name is ambiguous across two interfaces on the same object, the
-trap throws with both candidates named, and you disambiguate explicitly:
-
-```js
-const player = await bus.proxy(
-  'org.mpris.MediaPlayer2.vlc',
-  '/org/mpris/MediaPlayer2',
-  {
-    interface: 'org.mpris.MediaPlayer2.Player'
-  }
-);
-```
-
-Properties read as if they were properties, because a `get` trap can return a
-promise and `await` does the rest:
-
-```js
-const metadata = await player.props.Metadata; // a{sv} -> plain object
-const { Devices } = await nm.props.$all; // GetAll in one round trip
-```
-
-Writes cannot use assignment — `obj.x = v` evaluates to `v`, not to a promise,
-so there is nothing to await and a failed write would be silently lost. Rather
-than pretend, writes are explicit:
-
-```js
-await player.props.$set('Volume', 0.5);
-await player.props.$set({ Volume: 0.5, Shuffle: true }); // batched
-```
-
-This is the one place I would accept slight asymmetry over a footgun.
-
----
-
-## 3. Variants and the type system
-
-**Closes:** [#3](https://github.com/sidorares/dbus-native/issues/3),
-[#67](https://github.com/sidorares/dbus-native/issues/67),
-[#91](https://github.com/sidorares/dbus-native/issues/91),
-[#114](https://github.com/sidorares/dbus-native/issues/114),
-[#132](https://github.com/sidorares/dbus-native/issues/132),
-[#147](https://github.com/sidorares/dbus-native/issues/147).
-Supersedes [#143](https://github.com/sidorares/dbus-native/pull/143).
-
-The rule: **D-Bus types map to the closest JS type, and the parser's internal
-tree never escapes.**
-
-| D-Bus               | today                                | proposed                           |
-| ------------------- | ------------------------------------ | ---------------------------------- |
-| `s` `o` `g`         | string                               | string                             |
-| `y` `n` `q` `i` `u` | number                               | number                             |
-| `x` `t`             | `number` (lossy) or a Long.js object | **`bigint`**                       |
-| `d`                 | number                               | number                             |
-| `b`                 | boolean                              | boolean                            |
-| `ay`                | Buffer                               | `Uint8Array`                       |
-| `a{sv}`             | array of `[key, [tree, [value]]]`    | **plain object**                   |
-| `a{ss}`             | array of pairs                       | plain object                       |
-| `as`                | array                                | array                              |
-| `(...)`             | array                                | array (tuple)                      |
-| `v`                 | `[tree, [value]]`                    | the value, or `Variant` when asked |
-
-So [#67](https://github.com/sidorares/dbus-native/issues/67) becomes:
-
-```js
-const { Udi } = await device.props.$all;
-```
-
-Type information is not lost, it just stops being mandatory. When a value is
-genuinely ambiguous — writing a `v`, or a numeric type the signature does not
-pin down — there is an explicit wrapper:
-
-```js
-import { Variant } from 'dbus-native';
-
-await notifications.Notify(
-  'app',
-  0,
-  '',
-  'summary',
-  'body',
-  [],
-  {
-    urgency: new Variant('y', 1),
-    'sound-name': 'message-new-instant' // plain string infers 's'
-  },
-  5000
-);
-```
-
-and reading can ask for it back:
-
-```js
-const raw = await player.props.$variant('Metadata');
-raw.signature; // 'a{sv}'
-raw.value; // the plain object
-```
-
-`Variant` implements `util.inspect.custom`, so `console.log` shows
-`Variant('y', 1)` rather than a wall of parse-tree objects — a small thing that
-makes the debugging loop enormously better.
-
-**64-bit becomes `bigint`.** This is [ROADMAP §3.2](./ROADMAP.md) and
-[#248](https://github.com/sidorares/dbus-native/issues/248), and it also
-removes the last non-trivial runtime dependency along with the `long.js` ARMv6
-crash that forced the Homebridge fork to vendor its own copy.
-
-```js
-const bytes = await disk.props.Size; // 2000398934016n
-```
-
-**Marshalling a plain object** as `a{sv}` closes the `// TODO: serialise JS
-objects as a{sv}` that has been in `marshall.js` for a decade, and the disabled
-test in `test/js-types.js` that has been waiting for it just as long.
-
----
-
-## 4. Errors that are Errors
-
-**Closes:** [#178](https://github.com/sidorares/dbus-native/issues/178),
-[#207](https://github.com/sidorares/dbus-native/issues/207),
-[#208](https://github.com/sidorares/dbus-native/issues/208),
-[#39](https://github.com/sidorares/dbus-native/issues/39).
-
-I verified during the audit that `getInterface` on a missing interface still
-calls back `(null, undefined)` today — no error at all, which is
-[#39](https://github.com/sidorares/dbus-native/issues/39) and
-[#208](https://github.com/sidorares/dbus-native/issues/208) exactly.
-
-```js
-class DBusError extends Error {
-  name = 'DBusError';
-  dbusName; // 'org.freedesktop.DBus.Error.ServiceUnknown'
-  body; // the raw arguments, for the rare caller that wants them
-  reply; // the full message
-}
-```
-
-Which makes the natural thing work:
-
-```js
-try {
-  await notifications.Notify(/* ... */);
-} catch (err) {
-  if (err.dbusName === 'org.freedesktop.DBus.Error.ServiceUnknown') {
-    // start it, fall back, whatever
-  }
-  throw err; // with a real stack, and .cause set where we wrapped something
-}
-```
-
-Named subclasses for the errors people actually branch on —
-`ServiceUnknownError`, `NoReplyError`, `AccessDeniedError`, `TimeoutError` —
-so `err instanceof NoReplyError` works without string comparison.
-
-**Locatable stack traces are the real prize.** Today a failed call gives you a
-stack rooted in the socket read handler, with no trace of your own code.
-
-Worth correcting an assumption in an earlier draft: promises do **not** fix
-this for free. V8 stitches async frames only along an unbroken await chain, and
-a reply arriving on a socket is a fresh I/O callback with no link back to the
-caller. The frames have to be captured deliberately at call time and attached
-to the rejection — which is what `lib/promisify.js` now does, measured at
-1.95 µs against an 85.8 µs round trip, so about 2% of a call.
-
----
-
-## 5. Signals as async iterables
-
-**Closes:** [#75](https://github.com/sidorares/dbus-native/issues/75),
-[#117](https://github.com/sidorares/dbus-native/issues/117),
-[#136](https://github.com/sidorares/dbus-native/issues/136),
-[#138](https://github.com/sidorares/dbus-native/issues/138).
-
-Two shapes, because both are legitimate.
-
-**Callback, with a disposable subscription** — the match rule is removed when
-the scope exits, which is the bug nobody remembers to fix by hand:
-
-```js
-using sub = await nm.on('StateChanged', state => console.log(state));
-```
-
-**Async iteration**, which composes with everything else:
-
-```js
-for await (const [state] of nm.signal('StateChanged')) {
-  if (state === NM_STATE_CONNECTED_GLOBAL) break; // <- removes the match rule
-}
-```
-
-Breaking out of a `for await` calls the iterator's `return()`, so the
-subscription is torn down by the language rather than by discipline. Combined
-with `AbortSignal`:
-
-```js
-const changes = nm.signal('PropertiesChanged', {
-  signal: AbortSignal.timeout(30_000)
-});
-for await (const [iface, changed] of changes) {
-  console.log(changed); // plain object, per §3
-}
-```
-
-Note the honest caveat: **async iterator helpers are not in Node yet** (checked
-on 26), so `.map()`/`.filter()`/`.take()` on these streams are not available
-without a helper library. Async _generators_ are, so composing by hand works
-fine.
-
-A `queueing` option decides what happens when the consumer is slower than the
-bus — drop, buffer to a bound, or apply backpressure. Silently unbounded
-buffering is how this design usually goes wrong.
-
----
-
-## 6. Cancellation and timeouts
-
-**Closes:** [#137](https://github.com/sidorares/dbus-native/issues/137).
-Supersedes [#213](https://github.com/sidorares/dbus-native/pull/213).
-
-Every call takes an `AbortSignal`, and there is a default timeout:
-
-```js
-const bus = await sessionBus({ timeout: 25_000 }); // default for all calls
-
-await slowThing.DoIt({ signal: AbortSignal.timeout(5_000) });
-
-const ac = new AbortController();
-process.on('SIGINT', () => ac.abort());
-await longRunning.Watch({ signal: ac.signal });
-```
-
-Aborting rejects with `AbortError` **and removes the pending-reply entry**,
-which is the actual leak today: `bus.cookies` grows forever for any call whose
-reply never arrives. A long-lived daemon leaks in proportion to how often its
-peers misbehave.
-
-Combined with `Promise.withResolvers()` (available now), the internal
-pending-call table gets much simpler than the current cookie-plus-callback
-scheme.
-
----
-
-## 7. Defining a service
-
-**Closes:** [#81](https://github.com/sidorares/dbus-native/issues/81),
-[#89](https://github.com/sidorares/dbus-native/issues/89),
-[#230](https://github.com/sidorares/dbus-native/issues/230),
-[#309](https://github.com/sidorares/dbus-native/issues/309).
-
-The current descriptor format is positional arrays — `Echo: ['s', 's',
-['input'], ['output']]` — where the meaning of each slot has to be memorised,
-and there is no way to declare that a property is read-only
-([#89](https://github.com/sidorares/dbus-native/issues/89)).
-
-**No build step required:**
-
-```js
-import { defineInterface, signal } from 'dbus-native';
-
-const greeter = defineInterface({
-  name: 'com.example.Greeter',
-  methods: {
-    Hello: {
-      in: { name: 's' },
-      out: { greeting: 's' },
-      handler: ({ name }, { sender }) => `Hello, ${name}, from ${sender}`
-    }
-  },
-  properties: {
-    Language: { type: 's', access: 'read', get: () => currentLanguage },
-    Volume: {
-      type: 'd',
-      access: 'readwrite',
-      get: () => volume,
-      set: v => {
-        volume = v;
-      } // PropertiesChanged emitted automatically
-    }
-  },
-  signals: {
-    Greeted: { args: { who: 's' } }
-  }
-});
-
-await using registration = await bus.export('/com/example/Greeter', greeter);
-greeter.emit.Greeted('world');
-```
-
-Three things fall out of this that are currently missing or broken:
-
-- `access: 'read'` is _enforced_, and reaches the introspection XML instead of
-  the hardcoded `access="readwrite"` that everything gets today.
-- `PropertiesChanged` is emitted on write, which is
-  [#81](https://github.com/sidorares/dbus-native/issues/81) and
-  [#117](https://github.com/sidorares/dbus-native/issues/117).
-- Handlers receive a **context** with `sender`, `path` and an `AbortSignal`, so
-  [#230](https://github.com/sidorares/dbus-native/issues/230) is a named
-  parameter rather than a documented accident of argument order.
-
-Interface and member names are validated on export
-([#309](https://github.com/sidorares/dbus-native/issues/309)).
-
-**Decorators, for TypeScript users only.** This reads better:
-
-```ts
-@iface('com.example.Greeter')
-class Greeter {
-  @method({ in: { name: 's' }, out: { greeting: 's' } })
-  Hello(name: string) {
-    return `Hello, ${name}`;
-  }
-
-  @property({ type: 'd', access: 'readwrite' })
-  accessor volume = 0.5;
-}
-```
-
-but **decorators are still not native** — I checked on Node 26 and the syntax
-is a `SyntaxError`. Shipping this as the primary API would force a build step
-on every consumer, which contradicts the no-build-step property this package is
-valued for. So: `defineInterface` is the API, decorators are an optional export
-for people who already have a TypeScript pipeline.
-
----
-
-## 8. Types without a build step
-
-**Closes:** [#276](https://github.com/sidorares/dbus-native/issues/276).
-
-Three layers, in increasing order of magic.
-
-**A hand-written `index.d.ts`** for the library itself. Table stakes, and the
-thing most likely to be driving users to `dbus-next`.
-
-**A codegen CLI** — the modern replacement for `dbus2js`, which currently
-generates ES5 string-concatenated code:
-
-```
-$ npx dbus-native types --system \
-    --service org.freedesktop.NetworkManager \
-    --path /org/freedesktop/NetworkManager \
-    > src/generated/network-manager.d.ts
-```
-
-```ts
-import type { NetworkManager } from './generated/network-manager.js';
-
-const nm = await bus.proxy<NetworkManager>(
-  'org.freedesktop.NetworkManager',
-  '/org/freedesktop/NetworkManager'
-);
-await nm.GetDeviceByIpIface('eth0'); // fully typed, checked at compile time
-```
-
-**A module customization hook**, for the case where the introspection XML is
-checked into the repo. `module.register()` is available now:
-
-```js
-// register once, in the app entry point
-import { register } from 'node:module';
-register('dbus-native/loader', import.meta.url);
-```
-
-```js
-// then an XML file imports as a typed client factory
-import connectNetworkManager from './network-manager.xml' with { type: 'dbus' };
-
-await using nm = await connectNetworkManager(bus);
-```
-
-I want to be straight about this last one: it is the most fashionable idea here
-and the least useful. It saves one codegen step, costs a loader registration in
-every consumer, breaks bundlers, and confuses every tool that does not know
-about import attributes. **I would build the first two and prototype the third
-behind a flag**, and drop it if it does not earn its keep. It is in this
-document because you asked what is possible, not because I think it is wise.
-
----
-
-## 9. ESM, and the shape of the package
-
-Native ESM, with a real `exports` map:
-
-```json
-{
-  "type": "module",
-  "exports": {
-    ".": "./lib/index.js",
-    "./next": "./lib/next/index.js",
-    "./classic": "./lib/classic/index.js",
-    "./compat": "./lib/compat.js",
-    "./variant": "./lib/variant.js",
-    "./testing": "./lib/testing.js"
-  }
-}
-```
-
-Three deliberate choices:
-
-- **This API ships as `dbus-native/next`** while it is being built, alongside
-  the existing surface, and becomes the default only once it has real users.
-  One package, one repo, one test suite — see
-  [RELEASE_PLAN.md](./RELEASE_PLAN.md) for the sequencing.
-- **ESM-only, not dual**, at the point the default flips. Dual packages cause
-  the "two copies of the same class" problem, which for a library exporting a
-  `Variant` that people `instanceof` is a genuine hazard, not a theoretical
-  one.
-- **`./compat` holds the migration shims**, in a subpath rather than as options
-  on the core, so they are greppable, obviously temporary, and deletable in one
-  commit.
-
-**No Node 24 floor is required.** I said otherwise in an earlier draft and it
-was wrong: the library implements `Symbol.asyncDispose` on any Node that has
-the symbol (20.9+), and only _consumer_ code writing the `using` keyword needs 24. That is the user's choice, not a floor we impose — which matters for a
-library whose users skew embedded and Raspberry Pi.
-
----
-
-## 10. Observability
-
-A protocol library is a natural place for `diagnostics_channel`, which costs
-nothing when nobody subscribes:
-
-```js
-import diagnostics_channel from 'node:diagnostics_channel';
-
-diagnostics_channel.subscribe('dbus:call:start', ({ destination, member }) => {
-  console.log('->', destination, member);
-});
-```
-
-That gives OpenTelemetry integration, a `dbus-monitor` equivalent, and
-per-call timing without a debug-logging API of our own. Given how many issues
-in this tracker are "I sent something and nothing happened"
-([#115](https://github.com/sidorares/dbus-native/issues/115),
-[#136](https://github.com/sidorares/dbus-native/issues/136),
-[#138](https://github.com/sidorares/dbus-native/issues/138),
-[#229](https://github.com/sidorares/dbus-native/issues/229)), making traffic
-inspectable is probably worth more than any single API improvement here.
-
----
-
-## 11. Testing DX
-
-The integration harness added in 0.5.0 already starts a private `dbus-daemon`.
-The missing piece is an **in-process bus**, which would make tests hermetic and
-remove the `brew install dbus` step for contributors:
-
-```js
-import { test } from 'node:test';
-import { testBus } from 'dbus-native/testing';
-
-test('greets', async t => {
-  await using bus = await testBus(); // in-process, no daemon
-  await using _ = await bus.export('/com/example/Greeter', greeter);
-
-  const client = await bus.proxy('com.example.Greeter', '/com/example/Greeter');
-  t.assert.strictEqual(await client.Hello('world'), 'Hello, world');
-});
-```
-
-This is [ROADMAP §4.5](./ROADMAP.md) — `lib/server.js` is currently a stub
-whose handshake replies with a GUID hardcoded from someone's 2014 session.
-Finishing it pays off twice: contributors stop needing a system dependency, and
-the server side stops being a liability.
-
----
-
-## 12. Putting it together
-
-The README's opening example, today versus proposed:
-
-```js
-// today
-var dbus = require('dbus-native');
-var sessionBus = dbus.sessionBus();
-sessionBus
-  .getService('org.freedesktop.Notifications')
-  .getInterface(
-    '/org/freedesktop/Notifications',
-    'org.freedesktop.Notifications',
-    function (err, notifications) {
-      if (err) throw err;
-      notifications.on('ActionInvoked', function () {
-        console.log('ActionInvoked', arguments);
-      });
-      notifications.Notify(
-        'exampl',
-        0,
-        '',
-        'summary 3',
-        'new message text',
-        ['xxx yyy', 'test2'],
-        [],
-        5,
-        function (err, id) {}
-      );
-    }
-  );
-```
-
-```js
-// proposed
-import { sessionBus } from 'dbus-native';
+import { sessionBus, Variant } from 'dbus-native';
 
 await using bus = await sessionBus();
+
 const notifications = await bus.proxy(
   'org.freedesktop.Notifications',
   '/org/freedesktop/Notifications'
@@ -700,130 +68,418 @@ const id = await notifications.Notify(
   0,
   '',
   'summary',
-  'new message text',
+  'body',
   ['default', 'Open'],
   { urgency: new Variant('y', 1) },
   5_000
 );
 
-for await (const [closedId, reason] of notifications.signal(
-  'NotificationClosed'
-)) {
-  if (closedId === id) break;
+using sub = notifications.on('NotificationClosed', ([closed, reason]) => {
+  if (closed === id) console.log('closed:', reason);
+});
+```
+
+Every resource in that snippet is released by the language rather than by
+discipline. That is the whole thesis.
+
+---
+
+## 2. What building it proved wrong
+
+### 2.1 The parse tree was never the right "typed" shape — `Variant` is
+
+The original §3 said a variant reads as "the value, or `Variant` when asked".
+Shipping `plainValues` showed **there is no way to ask**, and that this is not
+a small omission: two real consumers hit it inside a week.
+
+- `dbus-native call` prints `variant u 501`. That `u` exists only in the parse
+  tree, so the CLI had to pin `plainValues: false` to keep printing types.
+- A service receiving `a{sv}` cannot discover what types its caller sent. The
+  integration test for it has a branch that asserts `undefined` and explains
+  why, which is the shape of a gap, not a test.
+
+The fix is not a third read mode. It is noticing that **the parse tree was
+always the wrong carrier** — it leaked the parser's internals, it is unreadable
+in a debugger, and it cannot be sent back. `Variant` already exists, already
+carries `signature` and `value`, already has a custom `inspect`, and the
+marshaller already accepts it on the write path.
+
+So 2.0 has **two** read shapes, not three:
+
+```js
+// default: the value
+const level = await dev.props.Percentage; // 87
+
+// opt in per connection, or per call where it matters
+const bus = await sessionBus({ variants: 'wrap' });
+const v = await dev.props.Percentage; // Variant('d', 87)
+v.signature; // 'd'
+v.value; // 87
+variantValue(v); // 87 -- the accessor already handles it
+```
+
+`variants: 'wrap'` is strictly better than the classic tree at the one job the
+tree had, and it round-trips: a value read in `wrap` mode can be sent straight
+back out. The tree survives only inside `withClassicTypes`, which is where a
+legacy shape belongs.
+
+**This is the highest-value correction in this document.** It turns a known gap
+into a better API than the one being replaced.
+
+### 2.2 `ay` stays a `Buffer` — the two documents disagreed
+
+The original §3 table said `ay` → `Uint8Array` on web-standards grounds.
+`RELEASE_PLAN.md` §2.0 later argued the opposite and is right: `Buffer` **is** a
+`Uint8Array` subclass, so every consumer of the latter already accepts the
+former, while `buf.toString('utf8')` — used constantly — does not exist on a
+plain `Uint8Array`. Breaking it costs real code and buys nothing in a Node-only
+library.
+
+The table in this document is now corrected. `ay` is a `Buffer`, unchanged.
+
+### 2.3 A member-name proxy hangs on `await` unless `then` is guarded
+
+The original §2 described a `get` trap that resolves any member name. Awaiting
+such a proxy — directly, or by returning one from an `async` function — makes
+`await` look up `.then`, find a function, call it with `(resolve, reject)`, and
+wait forever. Demonstrated, not theorised:
+
+```js
+const naive = new Proxy(
+  {},
+  {
+    get:
+      (t, k) =>
+      (...a) =>
+        `called ${String(k)}`
+  }
+);
+await naive; // hangs. Permanently.
+```
+
+Any proxy design must return `undefined` for `then`, and should also pass
+through `Symbol.toStringTag`, `util.inspect.custom`, `constructor` and
+`Symbol.iterator` rather than manufacturing methods for them. This is a
+one-line fix and a multi-hour debugging session for whoever hits it, which is
+exactly the kind of thing a design document should carry.
+
+Two consequences for the design:
+
+- `bus.proxy()` returns a **promise of** a proxy, and the proxy itself is never
+  a thenable. Introspection happens in `proxy()`, not lazily in the trap.
+- The `$`-prefixed members (`props.$all`, `props.$set`) are worth keeping, and
+  for a better reason than the original gave: a D-Bus member name matches
+  `[A-Za-z_][A-Za-z0-9_]*`, so `$` is a **guaranteed-collision-free** namespace
+  rather than merely an unlikely one.
+
+### 2.4 Signals: the callback form is primary, not the iterable
+
+The original §5 led with `for await`. That emphasis is wrong, for two reasons
+that only became clear with the async-iterator-helper check.
+
+**Async iterator helpers are still not in Node** (re-verified on 26 — §4). So
+`.map()`, `.filter()`, `.take()` do not exist on these streams, which removes
+most of what made the iterable form attractive. Composing by hand with an async
+generator works, but that is a worse API than a callback.
+
+**More fundamentally, an async iterator is a queue and a signal is a
+broadcast.** If the consumer is slower than the bus, something has to give, and
+the original buried that decision in a `queueing` option. Perfect DX does not
+make silent unbounded buffering reachable at all:
+
+```js
+// primary: a callback, with a subscription the language releases
+using sub = nm.on('StateChanged', ([state]) => {
+  /* ... */
+});
+
+// convenience: iteration, when you genuinely want to consume in sequence
+for await (const [state] of nm.signal('StateChanged', { queue: 64 })) {
+  if (state === CONNECTED) break; // removes the match rule
 }
 ```
 
-Nine lines instead of sixteen, no callbacks, no `arguments`, errors that throw,
-and every resource released on the way out.
+`queue` is required to be a bound or the literal `'latest'`. There is no
+unbounded option, because a long-lived daemon with an unbounded signal queue is
+a memory leak with a countdown, and this library's users skew toward long-lived
+daemons.
+
+### 2.5 The value-shape gate is the precondition, and it now exists
+
+Not a correction so much as a change in what is possible. `npm run
+test:integration:2.0` runs the whole suite with the 2.0 defaults on, against
+both `dbus-daemon` and the in-process broker. Before it existed, the flag day
+was unverifiable; the measurement that motivated it found 9 failures, **all of
+them in tests asserting old shapes rather than in the library**.
+
+The practical consequence for everything below: a breaking value change can now
+be proven green before it is released, so the sequencing can be more aggressive
+than the original assumed.
 
 ---
 
-## 13. Feature availability, checked
+## 3. What the sketch missed entirely
 
-Verified on Node 26 rather than assumed, because a plan built on a feature that
-does not exist is worse than no plan:
+### 3.1 `ObjectManager` — the biggest real-world gap
 
-| feature                                    | status                                | used for           |
-| ------------------------------------------ | ------------------------------------- | ------------------ |
-| `using` / `Symbol.dispose`                 | ✅ native (syntax: Node 24+)          | §1, §5, §7         |
-| `DisposableStack` / `AsyncDisposableStack` | ✅ native                             | §1                 |
-| `Promise.withResolvers()`                  | ✅ native                             | §6                 |
-| `Array.fromAsync()`                        | ✅ native                             | §5                 |
-| Sync iterator helpers                      | ✅ native                             | §5                 |
-| `AbortSignal.timeout()`                    | ✅ native                             | §6                 |
-| `Error.cause`                              | ✅ native                             | §4                 |
-| `module.register()` hooks                  | ✅ native                             | §8                 |
-| Proxy                                      | ✅ native since forever               | §2                 |
-| BigInt                                     | ✅ native                             | §3                 |
-| **Async iterator helpers**                 | ❌ **not available**                  | would have been §5 |
-| **Decorators**                             | ❌ **not native, needs a transpiler** | §7, opt-in only    |
+Not mentioned anywhere in the original document, and it is how you enumerate
+anything on a modern bus. BlueZ, NetworkManager, systemd and UDisks all expose
+their object trees through `org.freedesktop.DBus.ObjectManager`. Today the
+library has a `// TODO: emit ObjectManager's InterfaceAdded` in `lib/bus.js` and
+no client-side support at all, so "list the Bluetooth devices" — the single most
+common thing anyone wants — means hand-decoding `a{oa{sa{sv}}}`.
+
+Both halves are needed.
+
+**Consuming:**
+
+```js
+const bluez = await bus.objects('org.bluez', '/');
+
+const devices = bluez.filter('org.bluez.Device1'); // { path: { iface: props } }
+
+using sub = bluez.on('added', (path, interfaces) => {
+  /* ... */
+});
+using gone = bluez.on('removed', (path, interfaces) => {
+  /* ... */
+});
+```
+
+`bus.objects()` calls `GetManagedObjects` once, subscribes to
+`InterfacesAdded`/`InterfacesRemoved`, and keeps a live view. That is the thing
+people write by hand today, badly, and it composes with §2.1: the properties
+arrive as plain objects.
+
+**Exporting:** a service that exports objects under a path should be able to
+answer `GetManagedObjects` and emit the signals without writing any of it:
+
+```js
+await using tree = await bus.exportTree('/com/example');
+await tree.add('/com/example/Thing1', thing); // InterfacesAdded emitted
+```
+
+This closes a whole category of tracker questions and is, in my judgement, worth
+more per line than proxies.
+
+### 3.2 Reconnection
+
+A daemon that loses the bus currently has no story at all. For an audience that
+skews toward Raspberry Pi and Homebridge — where ~41k weekly downloads sit on a
+fork of this package — that is a real gap. It does not have to be automatic, but
+it has to be _possible_ and documented:
+
+```js
+const bus = await sessionBus({
+  reconnect: { retries: Infinity, backoff: 'exponential' }
+});
+bus.on('reconnected', () => {
+  /* names re-requested, match rules re-added */
+});
+```
+
+The hard part is not the socket, it is that a reconnect invalidates the unique
+name, every match rule and every owned name. Whatever ships must re-establish
+those or say loudly that it does not.
+
+### 3.3 The file-descriptor transport seam — the one breaking thing that must land now
+
+`ROADMAP.md` §2.8 scoped UNIX_FD on 2026-07-29 and concluded that the feature is
+**not buildable today** (no Node ancillary-data API; the one viable addon needs
+a compiler on every install) but is **additive when it becomes possible**.
+
+The part that matters here: carrying descriptors means a message is
+`{ bytes, fds }` rather than a `Buffer`, in both directions. That touches
+`connection.message()`, the cork/uncork write batching, `unmarshalMessages()`,
+and `opts.stream` — the seam a caller supplies their own transport through.
+
+**So the feature is a minor, but the seam is a major.** If the breaking window
+closes without it, UNIX_FD costs another major later. Defining
+`stream.writeWithFds?` / `stream.on('fds')` as an optional capability now, with
+nothing behind it, is cheap insurance and belongs in this release train.
 
 ---
 
-## 14. Risks, and what I would cut
+## 4. The platform moved — re-checked on Node 26
 
-**What I would cut.**
+Two of these change decisions the original made.
 
-- **The `dbus:` import specifier and the XML loader** (§8). Fashionable,
-  fragile, breaks bundlers. Prototype behind a flag, drop if it does not earn
-  its keep.
-- **Decorators as the primary service API** (§7). Not native. Forcing a build
-  step on consumers contradicts the property this package is valued for.
-- **Auto-inferring signatures from plain JS on the write path** where no
-  introspected signature is available. `{ a: 1 }` could be `a{sy}`, `a{si}`,
-  `a{su}`, `a{sd}`, `a{sv}` — this is exactly the data-loss argument from
-  [#52](https://github.com/sidorares/dbus-native/issues/52), and it was right
-  then. Infer only where the signature is known; require `Variant` otherwise.
+| feature                                | status on Node 26          | consequence                               |
+| -------------------------------------- | -------------------------- | ----------------------------------------- |
+| `await using` / `Symbol.asyncDispose`  | ✅ native, syntax included | §1 is unblocked                           |
+| `AsyncDisposableStack`                 | ✅ native                  | §1                                        |
+| `Promise.withResolvers()`              | ✅ native                  | simplifies the cookie table               |
+| `AbortSignal.timeout()`, `Error.cause` | ✅ native                  | shipped already                           |
+| **`require()` of an ESM module**       | ✅ **unflagged** (22.12+)  | **weakens the ESM-only objection**        |
+| **TypeScript type stripping**          | ✅ **unflagged**           | changes the codegen story, not decorators |
+| Sync iterator helpers                  | ✅ native                  | —                                         |
+| **Async iterator helpers**             | ❌ still absent            | §2.4 — callbacks lead                     |
+| **Decorators**                         | ❌ still a `SyntaxError`   | §7 stays `defineInterface`                |
 
-**Real risks.**
+**`require(esm)` is the significant one.** The original argued for ESM-only on
+the grounds that a dual package ships two copies of `Variant` and breaks
+`instanceof`. That argument still holds. But the _cost_ of ESM-only has dropped
+sharply: a CJS consumer can now `require()` an ESM `dbus-native` directly —
+**provided the entry point has no top-level await**, which otherwise fails with
+`ERR_REQUIRE_ASYNC_MODULE`. Verified both ways.
 
-- **This is a rewrite of the public API, not a refactor.** The wire layer
-  (marshaller, parser, framing) is now good and should be kept as-is — the work
-  is all above it. Rewriting the parts that were just measured and hardened
-  would be the way to turn a 2× improvement into a regression.
-- **Two live packages** is how `dbus-next` and this package both ended up
-  half-maintained. Whatever ships must be _this_ package, not a third one.
-  [#263](https://github.com/sidorares/dbus-native/issues/263) is the cautionary
-  tale.
-- **~7.4k weekly downloads depend on the current API**, plus ~41k on the
-  Homebridge fork which tracks it closely. A clean break has to come with a
-  codemod or a genuinely good migration guide, or it forks the ecosystem again.
-- **Scope.** Everything here is maybe six months of evenings. The sequencing
-  below front-loads the parts that stand alone.
+That makes ESM-only tractable much earlier than the original assumed, and turns
+"no top-level await in any entry point" into a hard architectural rule worth
+writing down now.
 
-**Suggested order** — superseded by [RELEASE_PLAN.md](./RELEASE_PLAN.md),
-which turns this into a dated release train with migration tooling. Kept here
-because the reasoning about value-per-unit-of-risk still holds:
+**Type stripping does not help decorators** — verified: a decorator is still a
+`SyntaxError` under it, because decorators are a runtime feature and not an
+erasable type. The original's conclusion stands unchanged: `defineInterface` is
+the API, decorators are an optional export for people who already have a
+TypeScript pipeline.
 
-1. **Promises** (§4 errors, §6 timeouts) — additive, unblocks everything else,
-   and [#295](https://github.com/sidorares/dbus-native/pull/295) is a
-   +15/−3 starting point.
-2. **`bigint` for 64-bit** (§3) — drops the last real dependency.
-3. **Plain-JS variants** (§3) — the biggest single ergonomic win, and closes
-   the most issues.
-4. **Proxies** (§2) and **async-iterable signals** (§5).
-5. **`await using`** (§1) and the new service API (§7).
-6. **Types** (§8), then ESM (§9).
-
-Steps 1–3 could ship as `1.0` under the existing API shape. Steps 4–6 are the
-break.
+**Node 20 reached end of life on 2026-04-30.** The current floor of 20.8.0 is
+now a dead LTS line. A major is the moment to raise it; Node 22 is the
+conservative choice and 24 buys `await using` in our own source. I would raise
+to 22 and use `Symbol.asyncDispose` without the syntax internally, because the
+embedded audience upgrades slowly and the syntax is a convenience for us, not a
+capability.
 
 ---
 
-## Appendix: issues this would close
+## 5. Revised type mapping
 
-Directly, if all of it landed: [#3](https://github.com/sidorares/dbus-native/issues/3),
-[#9](https://github.com/sidorares/dbus-native/issues/9),
-[#20](https://github.com/sidorares/dbus-native/issues/20),
-[#39](https://github.com/sidorares/dbus-native/issues/39),
-[#67](https://github.com/sidorares/dbus-native/issues/67),
-[#72](https://github.com/sidorares/dbus-native/issues/72),
-[#75](https://github.com/sidorares/dbus-native/issues/75),
-[#81](https://github.com/sidorares/dbus-native/issues/81),
-[#88](https://github.com/sidorares/dbus-native/issues/88),
-[#89](https://github.com/sidorares/dbus-native/issues/89),
-[#91](https://github.com/sidorares/dbus-native/issues/91),
-[#114](https://github.com/sidorares/dbus-native/issues/114),
-[#117](https://github.com/sidorares/dbus-native/issues/117),
-[#132](https://github.com/sidorares/dbus-native/issues/132),
-[#137](https://github.com/sidorares/dbus-native/issues/137),
-[#141](https://github.com/sidorares/dbus-native/issues/141),
-[#147](https://github.com/sidorares/dbus-native/issues/147),
-[#178](https://github.com/sidorares/dbus-native/issues/178),
-[#207](https://github.com/sidorares/dbus-native/issues/207),
-[#208](https://github.com/sidorares/dbus-native/issues/208),
-[#230](https://github.com/sidorares/dbus-native/issues/230),
-[#236](https://github.com/sidorares/dbus-native/issues/236),
-[#248](https://github.com/sidorares/dbus-native/issues/248),
-[#276](https://github.com/sidorares/dbus-native/issues/276),
-[#309](https://github.com/sidorares/dbus-native/issues/309).
+Superseding the original §3 table, with §2.1 and §2.2 folded in.
 
-Plus the open PRs it supersedes or absorbs:
-[#10](https://github.com/sidorares/dbus-native/pull/10),
-[#143](https://github.com/sidorares/dbus-native/pull/143),
-[#213](https://github.com/sidorares/dbus-native/pull/213),
-[#251](https://github.com/sidorares/dbus-native/pull/251),
-[#252](https://github.com/sidorares/dbus-native/pull/252),
-[#295](https://github.com/sidorares/dbus-native/pull/295).
+| D-Bus               | 1.x                                 | 2.0                                                  |
+| ------------------- | ----------------------------------- | ---------------------------------------------------- |
+| `s` `o` `g`         | string                              | string                                               |
+| `y` `n` `q` `i` `u` | number                              | number                                               |
+| `x` `t`             | lossy `number`, or a long.js object | **`bigint`**                                         |
+| `d`                 | number                              | number                                               |
+| `b`                 | boolean                             | boolean                                              |
+| `ay`                | `Buffer`                            | **`Buffer`** — corrected, see §2.2                   |
+| `a{sv}` `a{ss}`     | array of `[key, [tree, [value]]]`   | plain object                                         |
+| `a{iv}` etc.        | array of pairs                      | array of pairs — a key must be a string              |
+| `as`                | array                               | array                                                |
+| `(...)`             | array                               | array (tuple)                                        |
+| `v`                 | `[tree, [value]]`                   | the value, or **`Variant`** under `variants: 'wrap'` |
+| `h`                 | throws                              | throws, with the seam defined — §3.3                 |
 
-That is over half the open tracker, which is the real argument for doing it.
+---
+
+## 6. What is actually breaking, and what is not
+
+The useful cut, now that the gate exists to verify it.
+
+**Breaking, needs the major:**
+
+- the value shapes becoming the default (§5)
+- the `{ bytes, fds }` message seam (§3.3) — the feature is additive, the seam
+  is not
+- ESM-only, with the no-top-level-await rule (§4)
+- the Node floor (§4)
+- dropping `long`, `ReturnLongjs`, `dbus2js`, and `lib/address-x11.js` — which
+  is published in `lib/` and throws `Cannot find module 'x11'` on require
+- `defineInterface` replacing the positional descriptor arrays (§7 of the
+  original, unchanged and still right)
+
+**Additive, ships whenever it is ready:**
+
+- `await using` / `Symbol.asyncDispose` — implementing the protocol breaks
+  nothing
+- `bus.proxy()` — a new method beside `getService()`
+- `bus.objects()` and `exportTree()` (§3.1)
+- signal subscriptions and the iterable form (§2.4)
+- `variants: 'wrap'` (§2.1) — an option today, meaningful after the flip
+- reconnection (§3.2)
+- UNIX_FD itself, once a transport exists
+
+That split is more favourable than the original assumed, and it suggests the
+order: **land the additive ergonomics first, on 0.x, where they can be used and
+corrected by real consumers — then flip the defaults once.** The flag day should
+be the last thing that happens, not the first, and by then the gate will have
+been green for months.
+
+---
+
+## 7. What I would still cut
+
+Unchanged from the original, and re-confirmed:
+
+- **The `dbus:` import specifier and the XML loader.** Fashionable, fragile,
+  breaks bundlers, costs a loader registration in every consumer. Native type
+  stripping makes the codegen path _better_, which weakens the case further.
+- **Decorators as the primary service API.** Still not native.
+- **Auto-inferring signatures from plain JS where no introspected signature is
+  available.** `{ a: 1 }` could be `a{sy}`, `a{si}`, `a{su}`, `a{sd}` or
+  `a{sv}`. Infer only where the signature is known; require `Variant` otherwise.
+
+And one addition:
+
+- **A third variant read mode.** §2.1 replaces the parse tree rather than
+  joining it. If `variants: 'wrap'` cannot do a job, that is a bug in `Variant`,
+  not an argument for exposing the parser's internals again.
+
+And one thing worth doing _before_ any of it:
+
+- **Answer [#263](https://github.com/sidorares/dbus-native/issues/263).** It
+  asks whether this package should be deprecated in favour of `dbus-next`. Every
+  proposal here is an argument that the answer is no, and none of them are worth
+  building if the answer is yes. It is the cheapest issue on the list to close
+  and the one that changes the most.
+
+---
+
+## 8. Risks
+
+Mostly unchanged, with one downgraded and one added.
+
+- **This is an API rewrite, not a refactor** — but less of one than it was. Half
+  the sketch shipped without breaking anyone, which is evidence the incremental
+  path works better than expected. _Downgraded._
+- **Two live surfaces is how `dbus-next` and this package both ended up
+  half-maintained.** Whatever ships must be this package. Still the top risk.
+- **9.3k weekly downloads on the current API**, plus 37k on the Homebridge
+  fork that tracks it closely (npm, week ending 2026-07-28). The
+  migration tooling now exists — lint rule, codemod, `withClassicTypes`,
+  `docs/migrating-to-2.0.md` — which is the difference between a break and a
+  fork.
+- **New: the integration flake is mitigated, not explained.** The suite runs
+  serially because concurrent runs failed roughly 1 in 5, always a service
+  answering `UnknownObject` for something it had exported. One captured instance
+  had a connection with an empty `exportedObjects` receiving a call addressed to
+  a name it did not own, which should not be possible with unicast routing.
+  Rewriting the dispatch layer on top of an unexplained dispatch bug is how a
+  known-flaky suite becomes a mysteriously-broken one. **Root-cause it before
+  the proxy and service work lands**, not after.
+
+---
+
+## Appendix: the tracker, checked
+
+The original closed with "over half the open tracker", which was true when it
+was written and is now the wrong argument entirely — **the tracker is down to 11
+open issues.** Checked 2026-07-30, because inheriting a stale list is how a
+design document starts justifying itself with issues that were fixed two
+releases ago. Ten of the fourteen this document originally listed as open are
+closed.
+
+Of the 11, these are the ones the remaining work touches:
+
+| issue                                                       | what it needs                                                                                         |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| [#3](https://github.com/sidorares/dbus-native/issues/3)     | the value-shape flip (§5) — the oldest one                                                            |
+| [#248](https://github.com/sidorares/dbus-native/issues/248) | `bigint` becoming the default (§5)                                                                    |
+| [#141](https://github.com/sidorares/dbus-native/issues/141) | proxies (§1)                                                                                          |
+| [#104](https://github.com/sidorares/dbus-native/issues/104) | the gap against python-dbus ergonomics                                                                |
+| [#228](https://github.com/sidorares/dbus-native/issues/228) | a BlueZ user hunting for `GattService` — the shape of problem `ObjectManager` (§3.1) exists to remove |
+| [#263](https://github.com/sidorares/dbus-native/issues/263) | positioning: whether this package is the one to use                                                   |
+
+The rest are usage questions and connection-environment problems
+([#96](https://github.com/sidorares/dbus-native/issues/96),
+[#158](https://github.com/sidorares/dbus-native/issues/158),
+[#115](https://github.com/sidorares/dbus-native/issues/115),
+[#85](https://github.com/sidorares/dbus-native/issues/85),
+[#297](https://github.com/sidorares/dbus-native/issues/297)), several of which
+are themselves DX arguments: nobody opens "callback never received" against a
+library whose traffic is inspectable by default.
+
+So the case for this work is no longer "it closes half the tracker". It is that
+the tracker is nearly empty and the remaining complaints are about **shape**,
+not defects — which is exactly when a library gets to think about ergonomics.


### PR DESCRIPTION
`BIG_FUTURE_PLANS.md` was written two days and seven releases ago, and roughly half of it shipped in the meantime. Reading it straight is now misleading about what is left, so this re-baselines it at v0.12.0.

The accounting is the boring part. **The point is §2 — the four places where building the design proved it wrong.**

### The parse tree was never the right typed shape; `Variant` is

The sketch said a variant reads as "the value, or `Variant` when asked". Shipping `plainValues` showed **there is no way to ask**, and two consumers hit it inside a week: `dbus-native call` had to pin `plainValues: false` to keep printing `variant u 501`, and a service receiving `a{sv}` still cannot discover what types its caller sent.

The fix is not a third read mode. It is that `Variant` already does the tree's one job better — it carries `signature` and `value`, prints readably, and round-trips onto the wire, none of which the tree does. So 2.0 gets two read shapes, not three, and the tree survives only inside `withClassicTypes`. **This turns a known gap into a better API than the one being replaced.**

### `ay` stays a `Buffer`

The sketch's table said `Uint8Array`; RELEASE_PLAN §2.0 later argued the opposite and is right. Two design documents disagreeing about a breaking change is worse than either answer, so the table is corrected here.

### A member-name proxy hangs forever on `await`

Demonstrated rather than theorised:

```js
const naive = new Proxy({}, { get: (t, k) => (...a) => `called ${String(k)}` });
await naive; // hangs. Permanently.
```

`await` finds `.then`, calls it, and waits. One line to guard, a long evening to diagnose.

### Signals: callbacks lead, iteration follows

Async iterator helpers are **still** absent on Node 26 (re-verified), so `.map`/`.filter`/`.take` don't exist on these streams and the iterable form loses most of its appeal. And an async iterator is a queue over a broadcast — the sketch buried that in a `queueing` option. There is now no unbounded option, because a long-lived daemon with an unbounded signal queue is a memory leak with a countdown.

## Three things the sketch missed entirely

- **`ObjectManager`** — how you enumerate anything on BlueZ, NetworkManager, systemd or UDisks. Not mentioned once in the original; today there is a `// TODO` in `lib/bus.js` and no client support, so "list the devices" means hand-decoding `a{oa{sa{sv}}}`. Worth more per line than proxies.
- **Reconnection** — no story at all, for an audience that skews Raspberry Pi and Homebridge.
- **The `{ bytes, fds }` transport seam** — ROADMAP §2.8 established UNIX_FD is additive and unbuildable today, but the *message shape* is breaking. The feature is a minor; the seam is a major. If this window closes without it, UNIX_FD costs another one.

## Re-checked on Node 26, not inherited

`require(esm)` is unflagged, which sharply lowers the cost of ESM-only — provided no entry point uses top-level await (`ERR_REQUIRE_ASYNC_MODULE`, verified). Type stripping does **not** enable decorators. Node 20 went EOL 2026-04-30, so the 20.8 floor is a dead LTS line.

## The appendix was wrong

Rebuilt against the real tracker, which caught the document justifying itself with issues fixed two releases ago: **ten of the fourteen it listed as open are closed**, and there are 11 open issues in total. "It closes half the tracker" is no longer the argument. The argument is that the tracker is nearly empty and what remains is about shape rather than defects — which is exactly when a library gets to think about ergonomics.

## What this implies for sequencing

The breaking/additive split (§6) is more favourable than the original assumed. Most of the ergonomics — `await using`, `bus.proxy()`, `ObjectManager`, signal subscriptions, `variants: 'wrap'` — are **additive** and can ship on 0.x where real consumers correct them. Only the default flip, the fd seam, ESM, the Node floor and `defineInterface` need the major.

So: land the ergonomics first, flip the defaults last, with the gate green for months beforehand.

One thing worth settling before any of it: **#263** asks whether this package should be deprecated in favour of `dbus-next`. Every proposal here argues the answer is no, and none are worth building if it is yes.
