### PR TITLE
feat: variants: 'wrap', so a variant can carry its type without the tree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,14 +83,19 @@ tests never touch (or depend on) the user's real session bus.
 ### The 2.0 shape gate
 
 ```sh
-npm run test:integration:2.0          # against dbus-daemon
-npm run test:integration:2.0:broker   # against lib/broker.js
+npm run test:integration:2.0               # against dbus-daemon
+npm run test:integration:2.0:broker        # against lib/broker.js
+npm run test:integration:2.0-wrap          # variants: 'wrap' as well
+npm run test:integration:2.0-wrap:broker
 ```
 
 Same suite, run with the value shapes 2.0 makes the default: a variant reads as
 its value, a string-keyed `a{sv}` as a plain object, and `x`/`t` as `bigint`.
-`DBUS_TEST_SHAPE=2.0` turns them on through `test/utils/shape.js`, which every
-integration file gets its connections from.
+`DBUS_TEST_SHAPE` turns them on through `test/utils/shape.js`, which every
+integration file gets its connections from. It takes `classic` (the default),
+`2.0`, or `2.0-wrap` — the last being the same shapes but with variants read as
+`Variant` instances, which is what a caller opts into when it needs the type
+back. All three must pass.
 
 **This is the gate for the major.** Flipping those defaults is the largest
 break in RELEASE_PLAN, and until this passed there was no way to find out what

--- a/BIG_FUTURE_PLANS.md
+++ b/BIG_FUTURE_PLANS.md
@@ -86,7 +86,7 @@ discipline. That is the whole thesis.
 
 ## 2. What building it proved wrong
 
-### 2.1 The parse tree was never the right "typed" shape — `Variant` is
+### 2.1 The parse tree was never the right "typed" shape — `Variant` is ✅
 
 The original §3 said a variant reads as "the value, or `Variant` when asked".
 Shipping `plainValues` showed **there is no way to ask**, and that this is not
@@ -125,6 +125,18 @@ legacy shape belongs.
 
 **This is the highest-value correction in this document.** It turns a known gap
 into a better API than the one being replaced.
+
+**Shipped.** `variants: 'tree' | 'plain' | 'wrap'`, defaulting to whatever
+`plainValues` implied so it is purely additive. The whole integration suite runs
+under it (`npm run test:integration:2.0-wrap`) and found **no place in the
+library that indexes into a variant** — only the tests written to assert a
+specific shape, plus one real bug: `withClassicTypes` had to pin
+`variants: 'tree'` as well, or a caller who opted into `'wrap'` kept their
+Variants through it.
+
+`dbus-native call` is the proof it earns its keep. It used to pin
+`plainValues: false` purely to keep printing `variant u 501`; it now runs on the
+full 2.0 shapes with `variants: 'wrap'` and prints byte-identical output.
 
 ### 2.2 `ay` stays a `Buffer` — the two documents disagreed
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -104,6 +104,7 @@ socket other processes can reach.
 | `maxMessageSize` | `number`                  | 128 MiB                                         | reject a message declaring more than this                      |
 | `returnBigInt`   | `boolean`                 | `false`                                         | read `x`/`t` as native `bigint`, exactly — the 2.0 default     |
 | `plainValues`    | `boolean`                 | `false`                                         | read variants and dicts in the 2.0 shapes — see below          |
+| `variants`       | `'tree'\|'plain'\|'wrap'` | follows `plainValues`                           | how a `v` comes back; `'wrap'` keeps the signature — see below |
 | `ReturnLongjs`   | `boolean`                 | `false`                                         | **deprecated** (`DBUS_DEP0001`) — 64-bit as Long.js            |
 
 Address forms understood by `busAddress`: `unix:path=…`, `unix:abstract=…`,
@@ -669,15 +670,56 @@ always a string, so `a{us}` read as an object would turn the key `1` into `'1'`,
 and with `returnBigInt` a 64-bit key would stringify and lose precision on the
 way back. Quiet corruption is worse than an inconvenient shape.
 
-**Reading a variant this way discards its signature**, which is the point of the
-shape — `variantSignature()` returns `undefined` for it. Use `Variant` when
-writing if you need to control the type.
+**Reading a variant this way discards its signature** — `variantSignature()`
+returns `undefined` for it. That is usually what you want, and when it is not,
+see `variants` below.
 
 Both sides of a conversation should agree: a service reads its own method
 arguments through the same parser, so set it there too.
 
 `variantValue()` and `toPlain()` read either shape and become the identity under
 this one, so code written against them needs no change when the default flips.
+
+### Getting the type back: `variants`
+
+Sometimes the value is not enough. A tool that prints a reply has to say
+`variant u 501` rather than `501`, and a service handed an `a{sv}` may need to
+know what its caller actually sent. Both used to mean reading the parser's
+internal tree, which is the thing 2.0 exists to stop.
+
+`variants` decides how a `v` comes back, independently of the dict shape:
+
+| value     | a `v` reads as             | `variantSignature()` |
+| --------- | -------------------------- | -------------------- |
+| `'tree'`  | `[signatureTree, [value]]` | the signature        |
+| `'plain'` | `value`                    | `undefined`          |
+| `'wrap'`  | `Variant(sig, value)`      | the signature        |
+
+It defaults to `'plain'` when `plainValues` is set and `'tree'` otherwise, so
+existing code is unaffected either way.
+
+```js
+const bus = dbus.sessionBus({ plainValues: true, variants: 'wrap' });
+
+const props = await iface.$readProp('Metadata');
+props.Volume.signature; // 'd'
+props.Volume.value; // 0.5
+variantValue(props.Volume); // 0.5 -- the accessors understand it
+```
+
+That combination — plain dicts whose values still carry their types — is what
+`dbus-native call` uses, and it is the recommended shape for anything that
+inspects or forwards values rather than just consuming them.
+
+A `Variant` is a better carrier than the tree in three ways: it prints as
+`Variant('u', 501)` instead of a wall of parse-tree objects, `variantValue()`
+and `toPlain()` already read it, and **the marshaller accepts it**, so a value
+read this way can be sent straight back out without unwrapping. The tree could
+do none of those.
+
+The signature is the one the sender wrote, never one re-derived from the value:
+`y`, `n`, `q`, `i`, `u` and `d` all arrive as a JavaScript number, so inferring
+it back would be a guess presented as type information.
 
 ---
 

--- a/docs/migrating-to-2.0.md
+++ b/docs/migrating-to-2.0.md
@@ -131,7 +131,7 @@ const value = variantValue(result); // identical before and after
 a file converted to it is done — it needs no second pass at the flag day. This
 is what the accessors are for; see [DBUS_DEP0002](deprecations.md#dbus_dep0002).
 
-### The signature goes with it
+### If you need the type, ask for a `Variant`
 
 `[parsedSignatureTree, [value]]` carried the variant's type. The plain shape
 does not:
@@ -140,10 +140,25 @@ does not:
 variantSignature(result); // 's' in 1.x, undefined in 2.0
 ```
 
-Almost nobody reads it — but if you do, say because you dispatch on the type of
-an `a{sv}` value, there is no replacement yet and you should
-[open an issue](https://github.com/sidorares/dbus-native/issues) describing the
-case. Writing variants is unaffected: `new Variant('u', 9)` and the
+Almost nobody reads it. If you do — a tool that prints what came back, or a
+service that dispatches on the type of an `a{sv}` value — ask for it:
+
+```js
+const bus = dbus.sessionBus({ variants: 'wrap' });
+
+const v = await iface.$readProp('Volume');
+v.signature; // 'd'
+v.value; // 0.5
+variantValue(v); // 0.5, same as every other shape
+```
+
+A `Variant` is what the tree should have been: it prints as `Variant('d', 0.5)`
+rather than a wall of parse-tree objects, and the marshaller accepts it, so a
+value read this way can be sent straight back out. **Do not migrate to
+`variants: 'tree'` to keep the signature** — it works, but it is the shape 2.0
+exists to remove, and `withClassicTypes` is the supported way to stay on it.
+
+Writing variants is unaffected either way: `new Variant('u', 9)` and the
 `['u', 9]` pair both still work.
 
 ---

--- a/index.d.ts
+++ b/index.d.ts
@@ -238,10 +238,29 @@ export interface ConnectionOptions {
    * JavaScript object key is always a string, so converting those would change
    * the key's type and, for 64-bit keys, lose precision.
    *
-   * Reading a variant this way discards its signature — use `Variant` when
-   * writing if you need to control the type.
+   * Reading a variant this way discards its signature — set
+   * `variants: 'wrap'` if you need it back.
    */
   plainValues?: boolean;
+  /**
+   * How a variant (`v`) comes back.
+   *
+   * - `'tree'` — `[parsedSignatureTree, [value]]`, what 1.x hands back
+   * - `'plain'` — the value, and the signature is gone
+   * - `'wrap'` — a {@link Variant}, carrying both
+   *
+   * Defaults to `'plain'` when `plainValues` is set and `'tree'` otherwise, so
+   * setting neither keeps 1.x behaviour and setting only `plainValues` keeps
+   * the behaviour it had before this option existed.
+   *
+   * `'wrap'` is how you ask for the type information without reading the
+   * parser's internal tree: a `Variant` prints readably, `variantValue()` and
+   * `toPlain()` understand it, and the marshaller accepts it, so a value read
+   * this way can be sent straight back out. Combining it with
+   * `plainValues: true` gives plain dicts whose values still carry their types
+   * — what `dbus-native call` uses to print `variant u 501`.
+   */
+  variants?: 'tree' | 'plain' | 'wrap';
   /**
    * @deprecated DBUS_DEP0001 -- 64-bit values become BigInt in 2.0; use
    * `returnBigInt`. Note the capital R: this one option predates the rest and
@@ -274,6 +293,7 @@ export interface DBusConnection extends EventEmitter {
     plainValues?: boolean;
     returnBigInt?: boolean;
     ayBuffer?: boolean;
+    variants?: 'tree' | 'plain' | 'wrap';
   }): this;
 
   on(event: 'connect', listener: () => void): this;

--- a/index.js
+++ b/index.js
@@ -222,7 +222,7 @@ function createConnection(opts) {
   // setup, and letting those be poked afterwards would do nothing visible
   // except confuse whoever tried.
   self.setValueShapes = shapes => {
-    for (const key of ['plainValues', 'returnBigInt', 'ayBuffer']) {
+    for (const key of ['plainValues', 'returnBigInt', 'ayBuffer', 'variants']) {
       if (Object.hasOwn(shapes, key)) opts[key] = shapes[key];
     }
     return self;

--- a/lib/cli/call.js
+++ b/lib/cli/call.js
@@ -7,26 +7,34 @@
 
 const dbus = require('../../index');
 const { parseArguments, parseArgument } = require('./dbus-args');
-const { variantValue, variantSignature, toPlain } = require('../values');
+const {
+  variantValue,
+  variantSignature,
+  toPlain,
+  isPlainObject
+} = require('../values');
 
 const PROPERTIES = 'org.freedesktop.DBus.Properties';
 
 /**
  * The value shapes this tool needs, stated rather than inherited.
  *
- * Both are pinned because printing a reply is not the same job as consuming
- * one, and the defaults are tuned for consuming.
+ * All three are pinned because printing a reply is not the same job as
+ * consuming one, and the defaults are tuned for consuming.
  *
  * `returnBigInt` because a tool whose job is to show you what came back must
  * not round it on the way: read as a Number,
  * uint64:18446744073709551615 comes out as 18446744073709552000.
  *
- * `plainValues: false` because `describe()` prints a variant as
- * `variant u 501`, and the only place that `u` exists is the parsed signature
- * tree that `plainValues` throws away. Left to follow the default, this
- * command would silently stop printing types the day 2.0 flips it.
+ * `variants: 'wrap'` because `describe()` prints a variant as `variant u 501`
+ * and needs the signature to do it. This used to be spelled
+ * `plainValues: false`, which got the signature by reading the parser's
+ * internal tree -- the only way to ask, before there was a way to ask. A
+ * Variant carries the same thing without the tree, so this command now runs on
+ * the 2.0 shapes rather than pinned away from them, which is the better
+ * advertisement for them.
  */
-const SHAPE = { returnBigInt: true, plainValues: false };
+const SHAPE = { returnBigInt: true, plainValues: true, variants: 'wrap' };
 
 /** Open the bus the flags asked for. */
 function connect(argv) {
@@ -94,28 +102,36 @@ function describe(value, depth) {
   if (Array.isArray(value)) {
     if (value.length === 0) return `${pad}[]`;
     // An array of pairs is almost always a dict; printing it as one is what a
-    // reader wants, and being wrong about it costs nothing but a shape.
+    // reader wants, and being wrong about it costs nothing but a shape. Still
+    // reached under `plainValues` by the dicts it does not convert -- `a{iv}`
+    // and friends, whose keys are not strings.
     const looksLikeDict = value.every(
       entry => Array.isArray(entry) && entry.length === 2
     );
-    if (looksLikeDict) {
-      const body = value
-        .map(
-          ([key, item]) =>
-            `${pad}  ${describe(key, 0).trim()} -> ${describe(item, 0).trim()}`
-        )
-        .join('\n');
-      return `${pad}{\n${body}\n${pad}}`;
-    }
+    if (looksLikeDict) return dict(value, pad);
     return `${pad}[\n${value.map(item => describe(item, depth + 1)).join('\n')}\n${pad}]`;
   }
   if (value === null || value === undefined) return `${pad}${value}`;
   if (typeof value === 'bigint') return `${pad}${value}`;
   if (typeof value === 'string') return `${pad}"${value}"`;
+  // A string-keyed dict under `plainValues`. Printed the same as the pair form
+  // above, so the output does not depend on which shape the tool asked for.
+  if (isPlainObject(value)) return dict(Object.entries(value), pad);
   if (typeof value === 'object') {
     return `${pad}${JSON.stringify(value, (k, v) => (typeof v === 'bigint' ? v.toString() : v))}`;
   }
   return `${pad}${value}`;
+}
+
+/** `{ "key" -> value, ... }`, from entries in either shape. */
+function dict(entries, pad) {
+  const body = entries
+    .map(
+      ([key, item]) =>
+        `${pad}  ${describe(key, 0).trim()} -> ${describe(item, 0).trim()}`
+    )
+    .join('\n');
+  return `${pad}{\n${body}\n${pad}}`;
 }
 
 /** A body from either the `type:value` shorthand or --signature plus --body. */

--- a/lib/compat.js
+++ b/lib/compat.js
@@ -50,7 +50,16 @@ function toClassicError(err) {
 // What 1.x handed back, spelled as options. `returnBigInt: false` is the lossy
 // path on purpose: a `t` above 2^53 came back rounded in 1.x, and code that
 // depends on getting a Number depends on that too.
-const CLASSIC_TYPES = { plainValues: false, returnBigInt: false };
+//
+// `variants: 'tree'` is stated rather than left to follow `plainValues`,
+// because a caller who opted into `variants: 'wrap'` would otherwise keep the
+// Variants -- and this function's whole promise is that nothing arrives in a
+// shape 1.x did not produce.
+const CLASSIC_TYPES = {
+  plainValues: false,
+  returnBigInt: false,
+  variants: 'tree'
+};
 
 /**
  * Read 1.x value shapes on a 2.0 connection.

--- a/lib/dbus-buffer.js
+++ b/lib/dbus-buffer.js
@@ -1,7 +1,7 @@
 const Long = require('long');
 const constants = require('./constants');
 const parseSignature = require('./signature');
-const { VARIANT, DICT, tag } = require('./values');
+const { VARIANT, DICT, tag, Variant } = require('./values');
 
 const DEFAULT_OPTIONS = {
   ayBuffer: true,
@@ -9,6 +9,23 @@ const DEFAULT_OPTIONS = {
   returnBigInt: false,
   plainValues: false
 };
+
+// How a `v` comes back.
+//
+//   'tree'  [parsedSignatureTree, [value]] -- what 1.x hands back
+//   'plain' the value, and the signature is gone
+//   'wrap'  a Variant, carrying both
+//
+// 'wrap' exists because 'plain' throws the type away and nothing downstream
+// can put it back: `dbus-native call` prints `variant u 501` and a service
+// receiving a{sv} may need to know what its caller sent. Both used to need the
+// tree, which meant reading the parser's internals to get at a signature.
+//
+// A Variant does that job better -- it prints readably, `variantValue()` and
+// `toPlain()` already understand it, and the marshaller already accepts it, so
+// a value read in this shape can be sent straight back out. See
+// BIG_FUTURE_PLANS 2.1.
+const VARIANT_SHAPES = new Set(['tree', 'plain', 'wrap']);
 
 // Dict key types that survive becoming JavaScript object keys.
 //
@@ -39,7 +56,21 @@ function DBusBuffer(buffer, startPos, options, endianness) {
     this.options.ayBuffer === undefined ? true : this.options.ayBuffer;
   // The 2.0 value shapes, available now so code can be migrated on a released
   // version rather than on a flag day. See RELEASE_PLAN.md.
+  //
+  // `plainValues` governs dicts; `variants` governs variants and defaults to
+  // whatever `plainValues` implied, so it is purely additive. Separating them
+  // is what lets a caller take the plain dicts and keep the type information
+  // on the values inside them, which is the combination both the CLI and a
+  // service inspecting a{sv} actually want.
   this.plainValues = this.options.plainValues === true;
+  const variants = this.options.variants;
+  if (variants !== undefined && !VARIANT_SHAPES.has(variants)) {
+    throw new TypeError(
+      `Unknown 'variants' option ${JSON.stringify(variants)}; expected 'tree', 'plain' or 'wrap'`
+    );
+  }
+  this.variants =
+    variants === undefined ? (this.plainValues ? 'plain' : 'tree') : variants;
   this.buffer = buffer;
   this.startPos = startPos ? startPos : 0;
   this.pos = 0;
@@ -150,10 +181,14 @@ DBusBuffer.prototype.readVariant = function readVariant() {
   const signature = this.readSimpleType('g');
   const tree = parseSignature(signature);
   const values = this.readStruct(tree);
-  // Under `plainValues` the wrapper is gone and the signature with it, which
-  // is the 2.0 shape. A variant holds exactly one complete type, so the
-  // length check is belt and braces -- it mirrors variantValue().
-  if (this.plainValues) return values.length === 1 ? values[0] : values;
+  // A variant holds exactly one complete type, so the length check is belt and
+  // braces -- it mirrors variantValue().
+  const value = values.length === 1 ? values[0] : values;
+  // The signature is the one the sender wrote, not one re-derived from the
+  // value: `u`, `i` and `d` all arrive as a JS number, so inferring it back
+  // would be a guess dressed up as type information.
+  if (this.variants === 'wrap') return new Variant(signature, value);
+  if (this.variants === 'plain') return value;
   // Tagged so variantValue()/toPlain() can recognise this without guessing
   // from shape. The tag is non-enumerable and invisible to consumers.
   return tag([tree, values], VARIANT);

--- a/package.json
+++ b/package.json
@@ -82,7 +82,9 @@
     "test:integration:raw": "node --test --test-concurrency=1 --test-reporter=spec test/integration/*.js",
     "test:integration:broker": "node scripts/with-broker.js -- npm run test:integration:raw",
     "test:integration:2.0": "DBUS_TEST_SHAPE=2.0 npm run test:integration",
+    "test:integration:2.0-wrap": "DBUS_TEST_SHAPE=2.0-wrap npm run test:integration",
     "test:integration:2.0:broker": "DBUS_TEST_SHAPE=2.0 npm run test:integration:broker",
+    "test:integration:2.0-wrap:broker": "DBUS_TEST_SHAPE=2.0-wrap npm run test:integration:broker",
     "dbus:session": "node scripts/dbus-session.js",
     "test:types": "tsc --noEmit"
   },

--- a/test/cli-shape.js
+++ b/test/cli-shape.js
@@ -1,42 +1,63 @@
 // The CLI pins the value shapes it reads, rather than following the defaults.
 //
-// `describe()` prints a variant as `variant u 501`. That `u` only exists in the
-// parsed signature tree, which `plainValues` discards -- so the day 2.0 flips
-// that default, a CLI that inherited it would quietly stop printing types.
-// These tests are here to fail if the pin is ever removed.
+// `describe()` prints a variant as `variant u 501`, and it needs the signature
+// to do that. `variants: 'wrap'` is how it asks. Before that option existed the
+// only way to ask was `plainValues: false`, which got the signature by reading
+// the parser's internal tree -- so the CLI was pinned away from the 2.0 shapes
+// to keep a feature it should not have had to trade for them.
+//
+// These tests are here to fail if the pin is ever dropped.
 
 const { describe, it } = require('node:test');
 const assert = require('assert');
 const DBusBuffer = require('../lib/dbus-buffer');
 const marshall = require('../lib/marshall');
+const { Variant } = require('../lib/values');
 const { SHAPE, describe: render } = require('../lib/cli/call');
 
-// A `v` holding a `u`, read back the way the given options would read it.
-const readVariant = options => {
-  const buffer = marshall('v', [['u', 501]]);
-  return new DBusBuffer(buffer, 0, options).read('v')[0];
-};
+// Read a value back the way the given options would read it.
+const read = (signature, body, options) =>
+  new DBusBuffer(marshall(signature, body), 0, options).read(signature);
 
 describe('cli value shapes', () => {
-  it('asks for the tree shape and for bigints', () => {
-    assert.deepStrictEqual(SHAPE, { returnBigInt: true, plainValues: false });
+  it('asks for the modern shapes, and for the type information', () => {
+    assert.deepStrictEqual(SHAPE, {
+      returnBigInt: true,
+      plainValues: true,
+      variants: 'wrap'
+    });
   });
 
-  it('prints a variant with its signature under the pinned shape', () => {
-    assert.strictEqual(render(readVariant(SHAPE), 0), 'variant u 501');
+  it('prints a variant with its signature', () => {
+    const [v] = read('v', [['u', 501]], SHAPE);
+    assert.ok(v instanceof Variant);
+    assert.strictEqual(render(v, 0), 'variant u 501');
   });
 
-  it('cannot print the signature once plainValues has discarded it', () => {
-    // Not a wish, a demonstration: this is what the output becomes if the pin
-    // goes away. 2.0 needs a way to ask for `Variant` wrappers before the CLI
-    // can use the modern shape at all.
-    const plain = readVariant({ ...SHAPE, plainValues: true });
-    assert.strictEqual(render(plain, 0), '501');
+  it('cannot print the signature under variants: plain', () => {
+    // Not a wish, a demonstration: this is what the output degrades to if the
+    // pin goes away, and the reason the option exists at all.
+    const [v] = read('v', [['u', 501]], { ...SHAPE, variants: 'plain' });
+    assert.strictEqual(render(v, 0), '501');
+  });
+
+  it('prints a string-keyed dict the same in either dict shape', () => {
+    const body = [{ Name: new Variant('s', 'eth0') }];
+    const [asObject] = read('a{sv}', body, SHAPE);
+    const [asPairs] = read('a{sv}', body, { ...SHAPE, plainValues: false });
+
+    assert.ok(!Array.isArray(asObject), 'plainValues should give an object');
+    assert.ok(Array.isArray(asPairs), 'without it, pairs');
+    // The whole point: the reader sees one format regardless.
+    assert.strictEqual(render(asObject, 0), render(asPairs, 0));
+    assert.strictEqual(
+      render(asObject, 0),
+      '{\n  "Name" -> variant s "eth0"\n}'
+    );
   });
 
   it('does not round a 64-bit value on the way to the terminal', () => {
-    const buffer = marshall('t', [18446744073709551615n]);
-    const [value] = new DBusBuffer(buffer, 0, SHAPE).read('t');
+    const [value] = read('t', [18446744073709551615n], SHAPE);
     assert.strictEqual(render(value, 0), '18446744073709551615');
   });
 });

--- a/test/integration/compat-classic-types.js
+++ b/test/integration/compat-classic-types.js
@@ -9,9 +9,9 @@
 const { describe, it, before, after } = require('node:test');
 const assert = require('assert');
 const { EventEmitter } = require('events');
-const { variantValue, variantSignature } = require('../../lib/values');
+const { variantValue, variantSignature, Variant } = require('../../lib/values');
 const { withClassicTypes } = require('../../lib/compat');
-const { sessionBus, PLAIN_VALUES } = require('../utils/shape');
+const { sessionBus, VARIANTS } = require('../utils/shape');
 
 const NO_BUS =
   !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
@@ -128,8 +128,12 @@ describe(
 
     it('leaves an unwrapped bus on this run’s own shapes', async () => {
       const value = await get(modernBus, 'Greeting');
-      if (PLAIN_VALUES) {
-        assert.strictEqual(value, 'hello', 'the wrapper leaked to another bus');
+      const leaked = 'the wrapper leaked to another bus';
+      if (VARIANTS === 'plain') {
+        assert.strictEqual(value, 'hello', leaked);
+      } else if (VARIANTS === 'wrap') {
+        assert.ok(value instanceof Variant, leaked);
+        assert.strictEqual(value.value, 'hello');
       } else {
         assert.strictEqual(value[1][0], 'hello');
       }

--- a/test/integration/dicts.js
+++ b/test/integration/dicts.js
@@ -8,7 +8,7 @@ const { describe, it, before, after } = require('node:test');
 const assert = require('assert');
 const { EventEmitter } = require('events');
 const { Variant, toPlain, variantSignature } = require('../../lib/values');
-const { sessionBus, PLAIN_VALUES } = require('../utils/shape');
+const { sessionBus, VARIANTS } = require('../utils/shape');
 
 const NO_BUS =
   !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
@@ -128,22 +128,25 @@ describe(
     });
 
     // A variant's signature is only recoverable from a shape that carries it.
-    // Under `plainValues` the parser has already discarded it and
-    // variantSignature() returns undefined -- there is no way for a service to
-    // ask what types an a{sv} argument arrived with. That is a real gap in the
-    // 2.0 plan, which promises `Variant` "when explicitly requested" without
-    // yet providing a way to request it. See ROADMAP 4.1.
-    it('the service sees the types too, in the shape that carries them', () => {
-      if (PLAIN_VALUES) {
+    // `variants: 'wrap'` is how a service asks for one: it is the only way to
+    // find out what types an a{sv} argument arrived with, and until it existed
+    // the answer was "read the parser's internal tree, or do without".
+    it(`the service sees the types too, under '${VARIANTS}'`, () => {
+      if (VARIANTS === 'plain') {
         assert.strictEqual(
           variantSignature(Object.values(received)[0]),
           undefined,
-          'plainValues discards signatures; nothing to assert here'
+          'this is the shape that trades the signature away'
         );
         return;
       }
+      // Pairs under 'tree', a plain object under 'wrap' -- the dict shape is
+      // governed by plainValues, not by this option.
+      const entries = Array.isArray(received)
+        ? received
+        : Object.entries(received);
       const signatures = {};
-      for (const [key, value] of received) {
+      for (const [key, value] of entries) {
         signatures[key] = variantSignature(value);
       }
       assert.deepStrictEqual(signatures, {

--- a/test/integration/forward-compat.js
+++ b/test/integration/forward-compat.js
@@ -5,7 +5,7 @@ const { describe, it, before, after } = require('node:test');
 const assert = require('assert');
 const { EventEmitter } = require('events');
 const dbus = require('../../index');
-const { sessionBus, PLAIN_VALUES } = require('../utils/shape');
+const { sessionBus, VARIANTS } = require('../utils/shape');
 const { Variant, variantValue, toPlain } = dbus;
 const { toClassicError } = require('../../lib/compat');
 
@@ -86,15 +86,17 @@ describe(
         body: [IFACE, 'Greeting']
       });
       assert.ifError(err);
-      // The shape people complain about -- and, under `plainValues`, the shape
-      // that replaces it. Asserted explicitly on both sides because the whole
-      // point of the next line is that it does not have to care.
-      if (PLAIN_VALUES) {
+      // The shape people complain about, and the two that replace it. Asserted
+      // explicitly for each because the whole point of the last line is that it
+      // does not have to care.
+      if (VARIANTS === 'plain') {
         assert.strictEqual(result, 'hello');
+      } else if (VARIANTS === 'wrap') {
+        assert.strictEqual(result.value, 'hello');
       } else {
         assert.strictEqual(result[1][0], 'hello');
       }
-      // the shape that survives 2.0
+      // the shape that survives all of them
       assert.strictEqual(variantValue(result), 'hello');
     });
 

--- a/test/integration/shape.js
+++ b/test/integration/shape.js
@@ -10,8 +10,8 @@
 const { describe, it, before, after } = require('node:test');
 const assert = require('assert');
 const { EventEmitter } = require('events');
-const { variantValue, variantSignature } = require('../../lib/values');
-const { sessionBus, PLAIN_VALUES, RETURN_BIGINT } = require('../utils/shape');
+const { variantValue, variantSignature, Variant } = require('../../lib/values');
+const { sessionBus, VARIANTS, RETURN_BIGINT } = require('../utils/shape');
 
 const NO_BUS =
   !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
@@ -73,11 +73,19 @@ describe(
         body: [IFACE, 'Greeting']
       });
 
-    it(`reads a variant in the ${PLAIN_VALUES ? '2.0' : 'classic'} shape`, async () => {
+    it(`reads a variant in the '${VARIANTS}' shape`, async () => {
       const value = await get();
-      if (PLAIN_VALUES) {
+      if (VARIANTS === 'plain') {
         assert.strictEqual(value, 'hello', 'plainValues did not take effect');
+        // The one thing this shape gives up.
         assert.strictEqual(variantSignature(value), undefined);
+      } else if (VARIANTS === 'wrap') {
+        assert.ok(
+          value instanceof Variant,
+          "variants:'wrap' did not take effect"
+        );
+        assert.strictEqual(value.signature, 's');
+        assert.strictEqual(value.value, 'hello');
       } else {
         assert.ok(Array.isArray(value), 'expected the classic [tree, [value]]');
         assert.strictEqual(variantSignature(value), 's');

--- a/test/utils/shape.js
+++ b/test/utils/shape.js
@@ -1,39 +1,73 @@
 // Lets the integration suite be run under the 2.0 value shapes, so the flag
 // day can be rehearsed on a released version instead of discovered after it.
 //
-// `DBUS_TEST_SHAPE=2.0` turns on the options that 2.0 makes the default
-// (RELEASE_PLAN.md): a variant reads as its value and a string-keyed dict as a
-// plain object, and 64-bit integers read as `bigint`. Everything in
-// test/integration should pass either way, because that is exactly the promise
-// the 0.6 accessors make to users -- code written against `variantValue()` and
-// `toPlain()` does not care which shape it is looking at.
+// `DBUS_TEST_SHAPE` selects the run:
+//
+//   unset       what 1.x hands back: a variant is [tree, [value]], a dict is
+//               pairs, and 64-bit is a lossy number
+//   2.0         what 2.0 makes the default: plain values and bigint
+//   2.0-wrap    the same, but a variant is a Variant -- the shape a caller
+//               opts into when it needs the type back (BIG_FUTURE_PLANS 2.1)
+//
+// Everything in test/integration should pass in all three, because that is
+// exactly the promise the 0.6 accessors make to users: code written against
+// `variantValue()` and `toPlain()` does not care which shape it is looking at.
 //
 // A test that reads a raw shape directly is a test *about* the shape. Those ask
-// which world they are in with PLAIN_VALUES / RETURN_BIGINT rather than
-// pretending to be agnostic.
+// which world they are in with VARIANTS / RETURN_BIGINT rather than pretending
+// to be agnostic.
 
 const dbus = require('../../index');
 
-const TWO_OH = process.env.DBUS_TEST_SHAPE === '2.0';
+const SHAPE = process.env.DBUS_TEST_SHAPE || 'classic';
 
-/** True when a variant reads as its value and an a{sv} as a plain object. */
+const KNOWN = new Set(['classic', '2.0', '2.0-wrap']);
+if (!KNOWN.has(SHAPE)) {
+  throw new Error(
+    `Unknown DBUS_TEST_SHAPE ${JSON.stringify(SHAPE)}; expected ${[...KNOWN].join(', ')}`
+  );
+}
+
+const TWO_OH = SHAPE !== 'classic';
+
+/** How a variant reads in this run: 'tree', 'plain' or 'wrap'. */
+const VARIANTS =
+  SHAPE === '2.0-wrap' ? 'wrap' : SHAPE === '2.0' ? 'plain' : 'tree';
+
+/** True when a string-keyed dict reads as a plain object. */
 const PLAIN_VALUES = TWO_OH;
 
 /** True when `x` and `t` read as `bigint` rather than a lossy `number`. */
 const RETURN_BIGINT = TWO_OH;
 
-const DEFAULTS = TWO_OH ? { plainValues: true, returnBigInt: true } : {};
+const DEFAULTS = TWO_OH
+  ? {
+      plainValues: true,
+      returnBigInt: true,
+      // Only stated for the wrap run. Leaving it unset in the '2.0' run is the
+      // point: `variants` has to keep defaulting to what `plainValues` implies,
+      // or every existing caller of `plainValues` changes behaviour.
+      ...(VARIANTS === 'wrap' ? { variants: 'wrap' } : {})
+    }
+  : {};
 
 /**
  * A session bus with the shape this run asked for.
  *
  * Caller options are layered *over* the defaults, not under them, because that
  * is what changing a default means: a test that states a shape explicitly --
- * `{ returnBigInt: false }` -- gets it in both runs, and keeps testing the
+ * `{ returnBigInt: false }` -- gets it in every run, and keeps testing the
  * thing it was written to test.
  */
 function sessionBus(opts) {
   return dbus.sessionBus({ ...DEFAULTS, ...opts });
 }
 
-module.exports = { sessionBus, PLAIN_VALUES, RETURN_BIGINT, TWO_OH };
+module.exports = {
+  sessionBus,
+  SHAPE,
+  VARIANTS,
+  PLAIN_VALUES,
+  RETURN_BIGINT,
+  TWO_OH
+};

--- a/test/variants-option.js
+++ b/test/variants-option.js
@@ -1,0 +1,116 @@
+// `variants: 'tree' | 'plain' | 'wrap'` -- how a `v` comes back.
+//
+// 'wrap' is the one that is new. It exists because 'plain' throws the
+// signature away and nothing downstream can put it back: reconstructing it
+// from the value is a guess, since `u`, `i` and `d` all arrive as a JS number.
+// See BIG_FUTURE_PLANS 2.1.
+
+const { describe, it } = require('node:test');
+const assert = require('assert');
+const DBusBuffer = require('../lib/dbus-buffer');
+const marshall = require('../lib/marshall');
+const {
+  Variant,
+  variantValue,
+  variantSignature,
+  toPlain
+} = require('../lib/values');
+
+const read = (signature, body, options) =>
+  new DBusBuffer(marshall(signature, body), 0, options).read(signature);
+
+const readVariant = options => read('v', [['u', 501]], options)[0];
+
+describe('variants option', () => {
+  it("defaults to 'tree', which is what 1.x hands back", () => {
+    const v = readVariant({});
+    assert.ok(Array.isArray(v));
+    assert.strictEqual(v[1][0], 501);
+  });
+
+  it('follows plainValues when it is not given', () => {
+    assert.strictEqual(readVariant({ plainValues: true }), 501);
+  });
+
+  it('wins over plainValues when it is given', () => {
+    const v = readVariant({ plainValues: true, variants: 'wrap' });
+    assert.ok(v instanceof Variant);
+    // The combination the CLI and a service inspecting a{sv} both want: plain
+    // dicts, with the types still on the values inside them.
+    assert.strictEqual(v.signature, 'u');
+    assert.strictEqual(v.value, 501);
+  });
+
+  it("'tree' overrides plainValues in the other direction", () => {
+    const v = readVariant({ plainValues: true, variants: 'tree' });
+    assert.ok(Array.isArray(v));
+    assert.strictEqual(v[1][0], 501);
+  });
+
+  it('rejects an unknown shape rather than silently picking one', () => {
+    assert.throws(
+      () => readVariant({ variants: 'plane' }),
+      /Unknown 'variants' option "plane"; expected 'tree', 'plain' or 'wrap'/
+    );
+  });
+
+  it('reports the signature the sender wrote, not one inferred', () => {
+    // All three arrive as a JS number, so a shape that re-derived the
+    // signature from the value could not tell them apart.
+    for (const signature of ['y', 'n', 'q', 'i', 'u', 'd']) {
+      const [v] = read('v', [[signature, 7]], { variants: 'wrap' });
+      assert.strictEqual(v.signature, signature);
+      assert.strictEqual(typeof v.value, 'number');
+    }
+  });
+
+  it('carries a container signature whole', () => {
+    const [v] = read('v', [['a{ss}', [['a', 'b']]]], { variants: 'wrap' });
+    assert.strictEqual(v.signature, 'a{ss}');
+  });
+
+  describe('the accessors read it', () => {
+    const shapes = ['tree', 'plain', 'wrap'];
+
+    it('variantValue() is the value in all three', () => {
+      for (const variants of shapes) {
+        assert.strictEqual(variantValue(readVariant({ variants })), 501);
+      }
+    });
+
+    it('variantSignature() is the signature wherever there is one', () => {
+      assert.strictEqual(
+        variantSignature(readVariant({ variants: 'tree' })),
+        'u'
+      );
+      assert.strictEqual(
+        variantSignature(readVariant({ variants: 'wrap' })),
+        'u'
+      );
+      // The one thing 'plain' trades away.
+      assert.strictEqual(
+        variantSignature(readVariant({ variants: 'plain' })),
+        undefined
+      );
+    });
+
+    it('toPlain() flattens all three the same', () => {
+      for (const variants of shapes) {
+        const [dict] = read('a{sv}', [{ Name: new Variant('s', 'eth0') }], {
+          variants,
+          plainValues: true
+        });
+        assert.deepStrictEqual(toPlain(dict), { Name: 'eth0' });
+      }
+    });
+  });
+
+  it('round-trips: a wrapped value can be sent straight back out', () => {
+    // The tree shape never had this property -- you had to unwrap it first.
+    // It is most of the argument for Variant being the better carrier.
+    const [v] = read('v', [['a{ss}', [['k', 'v']]]], { variants: 'wrap' });
+    const [back] = read('v', [v], { variants: 'wrap' });
+    assert.strictEqual(back.signature, 'a{ss}');
+    assert.deepStrictEqual(toPlain(back), { k: 'v' });
+  });
+});


### PR DESCRIPTION
First item from the re-evaluated plan (#361), [BIG_FUTURE_PLANS §2.1](https://github.com/sidorares/dbus-native/blob/master/BIG_FUTURE_PLANS.md) — the correction I rated highest-value, because it turns a known gap into a better API than the one being replaced.

## The gap

`plainValues` reads a variant as its value and drops the signature. Nothing downstream can put it back: `y`, `n`, `q`, `i`, `u` and `d` all arrive as a JavaScript number, so re-deriving the signature would be a guess presented as type information.

Two consumers hit that inside a week:

- **`dbus-native call`** has to print `variant u 501`. It pinned `plainValues: false` and got the `u` by reading the parser's internal tree — the shape 2.0 exists to remove.
- **A service handed an `a{sv}`** could not find out what its caller sent. `test/integration/dicts.js` had a branch asserting `undefined` and explaining why, which is the shape of a gap rather than a test.

## The fix is not a third read mode

It is that **the tree was always the wrong carrier**. A `Variant` does its one job better:

- prints as `Variant('u', 501)` rather than a wall of parse-tree objects
- `variantValue()`, `variantSignature()` and `toPlain()` already read it
- **the marshaller already accepts it**, so a value read this way can be sent straight back out — the tree could never do that

```js
variants: 'tree' | 'plain' | 'wrap'
```

Defaults to whatever `plainValues` implied, so it is **purely additive**: unset is `'tree'`, `plainValues: true` alone is still `'plain'`. It governs variants only — dicts stay with `plainValues`, and separating them is what makes the useful combination possible:

```js
const bus = dbus.sessionBus({ plainValues: true, variants: 'wrap' });
// plain dicts, whose values still carry their types
```

The signature is the one the sender wrote, never one re-derived from the value.

## Verified by running the suite under it

`npm run test:integration:2.0-wrap` (and the broker variant) runs all 161 tests with variants wrapped. That found **no place in the library that indexes into a variant** — the header-field path, `stdifaces`, `introspect` and the broker all go through `variantValue()` already.

It found six tests asserting a specific shape, now three-way, and **one real bug**: `withClassicTypes` had to pin `variants: 'tree'` as well, or a caller who opted into `'wrap'` kept their Variants through the one function whose entire promise is 1.x shapes.

## The CLI is the proof it earns its keep

It now runs on the full 2.0 shapes — `{ returnBigInt: true, plainValues: true, variants: 'wrap' }` — and prints byte-identical output:

```
reply a{sv}
{
  "ProcessID" -> variant u 51770
  "UnixUserID" -> variant u 501
}
```

`describe()` gained a plain-object branch so a dict renders the same in either dict shape, which `test/cli-shape.js` asserts directly.

## Verification

| | dbus-daemon | broker |
|---|---|---|
| classic | 161/161 | 161/161 |
| `2.0` | 161/161 | 161/161 |
| `2.0-wrap` | 161/161 | 161/161 |

`npm test` — 821 unit tests, lint, format, tsc — green. Also exercised the CLI end to end against a real daemon for `call`, `--json` and `list`.
