### PR TITLE
feat: serve org.freedesktop.DBus.ObjectManager

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -500,6 +500,59 @@ Lower-level pieces, if you are not using `exportInterface`:
 | `bus.sendError(msg, errorName, errorText)`                            | error-reply to a method call |
 | `bus.setMethodCallHandler(path, iface, member, [handler, signature])` | handle one member            |
 
+### Publishing a tree: ObjectManager
+
+`org.freedesktop.DBus.ObjectManager` is how a service with many objects lets a
+client fetch all of them, with their properties, in one round trip — and get
+told when they come and go. BlueZ, NetworkManager, systemd and UDisks all use
+it, so it is how "list the devices" is spelled on a real bus.
+
+```js
+bus.exportObjectManager('/com/example');
+
+bus.exportInterface(hci0, '/com/example/dev0', deviceIface); // InterfacesAdded
+bus.exportInterface(hci1, '/com/example/dev1', deviceIface); // InterfacesAdded
+
+bus.unexportInterface('/com/example/dev1'); // InterfacesRemoved
+```
+
+That is the whole API. `GetManagedObjects` is answered for you, the interface
+appears in the introspection XML at the manager path, and the two signals are
+emitted as objects are exported and unexported.
+
+| method                                         |                                         |
+| ---------------------------------------------- | --------------------------------------- |
+| `bus.exportObjectManager(path)`                | serve ObjectManager at `path`           |
+| `bus.unexportInterface(path[, interfaceName])` | stop serving an object or one interface |
+
+Four things worth knowing:
+
+- **A manager reports what is strictly below it**, never itself. This is why
+  BlueZ's manager is at `/` and reports `/org/bluez/hci0`.
+- **Opt-in.** A path only manages a tree if you say so — a client has no way to
+  know it can call `GetManagedObjects` unless the interface is advertised, and
+  answering everywhere would claim a tree at any path someone asked about.
+- **Managers may nest.** The deepest one containing an object is the one that
+  announces it, so `/` and `/com/example` can both be managers without every
+  signal arriving twice at the root.
+- **`InterfacesAdded` announces only what appeared.** Re-exporting one interface
+  on an object that already had three is not news about the other three.
+
+Write-only properties are omitted from the reply, exactly as `GetAll` omits
+them: there is no value to report and the spec says to leave it out.
+
+`unexportInterface` returns whether anything was removed, and an object whose
+last interface goes stops existing rather than lingering as a path with nothing
+on it.
+
+Reading the reply is the usual `a{oa{sa{sv}}}` — three levels deep, so
+`toPlain()` is worth reaching for:
+
+```js
+const objects = toPlain(await bus.invoke({/* GetManagedObjects */}));
+// { '/com/example/dev0': { 'com.example.Device': { Name: 'hci0' } } }
+```
+
 ---
 
 ## Connection (low-level)

--- a/index.d.ts
+++ b/index.d.ts
@@ -548,6 +548,40 @@ export interface MessageBus {
   exportInterface(obj: unknown, path: string, iface: InterfaceDescriptor): void;
 
   /**
+   * Stop serving an object, or one interface of it.
+   *
+   * Emits `InterfacesRemoved` if a manager is responsible for the path. An
+   * object whose last interface is removed stops existing entirely, rather
+   * than lingering as a path with nothing on it.
+   *
+   * @returns whether anything was actually removed
+   */
+  unexportInterface(path: string, interfaceName?: string): boolean;
+
+  /**
+   * Serve `org.freedesktop.DBus.ObjectManager` at `path`.
+   *
+   * It reports every object exported **strictly below** `path` — which is why
+   * BlueZ puts one at `/` and reports `/org/bluez/hci0` — and emits
+   * `InterfacesAdded`/`InterfacesRemoved` as objects come and go. Managers may
+   * nest; the deepest one containing an object announces it, so no object is
+   * announced twice.
+   *
+   * Opt-in rather than automatic: the interface has to appear in the
+   * introspection XML for a client to know it can call `GetManagedObjects`.
+   */
+  exportObjectManager(path: string): this;
+
+  /** Announce interfaces at `path`; `exportInterface` calls this for you. */
+  emitInterfacesAdded(path: string, interfaceNames: string[]): void;
+
+  /** Announce their removal; `unexportInterface` calls this for you. */
+  emitInterfacesRemoved(path: string, interfaceNames: string[]): void;
+
+  /** Paths serving `org.freedesktop.DBus.ObjectManager`. */
+  objectManagers: Set<string>;
+
+  /**
    * Emit org.freedesktop.DBus.Properties.PropertiesChanged for an exported
    * interface.
    *

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -17,6 +17,7 @@ const {
   declaration: propertyDeclaration,
   changedSignal: propertiesChangedSignal
 } = require('./properties');
+const objectManager = require('./object-manager');
 
 module.exports = function bus(conn, opts) {
   if (!(this instanceof bus)) {
@@ -33,6 +34,8 @@ module.exports = function bus(conn, opts) {
   this.methodCallHandlers = {};
   this.signals = new EventEmitter();
   this.exportedObjects = {};
+  // Paths serving org.freedesktop.DBus.ObjectManager, in export order.
+  this.objectManagers = new Set();
 
   /**
    * Take the next message serial.
@@ -513,7 +516,88 @@ module.exports = function bus(conn, opts) {
         oldEmit.apply(obj, args);
       };
     }
-    // TODO: emit ObjectManager's InterfaceAdded
+
+    // Tell anyone watching a manager above this path. Only the new interface
+    // is announced, not everything at the path: re-exporting one interface on
+    // an object that already had three is not news about the other three.
+    self.emitInterfacesAdded(path, [iface.name]);
+  };
+
+  /**
+   * Stop serving an object, or one interface of it.
+   *
+   * Needed for InterfacesRemoved to mean anything -- a manager that can only
+   * ever report objects appearing is half an implementation, and a service
+   * whose devices come and go is the normal case rather than the exotic one.
+   *
+   * @param {string} path the object path
+   * @param {string} [interfaceName] only this interface; otherwise the object
+   * @returns {boolean} whether anything was actually removed
+   */
+  this.unexportInterface = function (path, interfaceName) {
+    const entry = self.exportedObjects[path];
+    if (!entry) return false;
+
+    let removed;
+    if (interfaceName === undefined) {
+      removed = Object.keys(entry);
+      delete self.exportedObjects[path];
+    } else {
+      if (!Object.hasOwn(entry, interfaceName)) return false;
+      removed = [interfaceName];
+      delete entry[interfaceName];
+      // An object with no interfaces left is not an object. Leaving the empty
+      // entry would keep it in Introspect and in GetManagedObjects as a path
+      // with nothing on it.
+      if (Object.keys(entry).length === 0) delete self.exportedObjects[path];
+    }
+
+    self.emitInterfacesRemoved(path, removed);
+    return true;
+  };
+
+  /**
+   * Serve org.freedesktop.DBus.ObjectManager at `path`.
+   *
+   * It reports every object exported **strictly below** `path`, which is why
+   * BlueZ puts one at '/' and reports '/org/bluez/hci0'. Managers may nest;
+   * the deepest one containing an object is the one that announces it.
+   *
+   * Opt-in rather than automatic: the interface has to appear in the
+   * introspection XML for a client to know to use it, and a service that has
+   * not thought about its object tree should not claim to manage one.
+   */
+  this.exportObjectManager = function (path) {
+    assertValidName('object path', path);
+    self.objectManagers.add(path);
+    return self;
+  };
+
+  /** InterfacesAdded, if any manager is responsible for this path. */
+  this.emitInterfacesAdded = function (path, interfaceNames) {
+    const manager = objectManager.managerFor(self.objectManagers, path);
+    if (manager === undefined) return;
+    const interfaces = objectManager.interfacesAndProperties(
+      self.exportedObjects[path],
+      interfaceNames
+    );
+    self.connection.message(
+      objectManager.addedSignal(self.nextSerial(), manager, path, interfaces)
+    );
+  };
+
+  /** InterfacesRemoved, if any manager is responsible for this path. */
+  this.emitInterfacesRemoved = function (path, interfaceNames) {
+    const manager = objectManager.managerFor(self.objectManagers, path);
+    if (manager === undefined || interfaceNames.length === 0) return;
+    self.connection.message(
+      objectManager.removedSignal(
+        self.nextSerial(),
+        manager,
+        path,
+        interfaceNames
+      )
+    );
   };
 
   // register name

--- a/lib/cli/call.js
+++ b/lib/cli/call.js
@@ -108,7 +108,7 @@ function describe(value, depth) {
     const looksLikeDict = value.every(
       entry => Array.isArray(entry) && entry.length === 2
     );
-    if (looksLikeDict) return dict(value, pad);
+    if (looksLikeDict) return dict(value, depth);
     return `${pad}[\n${value.map(item => describe(item, depth + 1)).join('\n')}\n${pad}]`;
   }
   if (value === null || value === undefined) return `${pad}${value}`;
@@ -116,19 +116,27 @@ function describe(value, depth) {
   if (typeof value === 'string') return `${pad}"${value}"`;
   // A string-keyed dict under `plainValues`. Printed the same as the pair form
   // above, so the output does not depend on which shape the tool asked for.
-  if (isPlainObject(value)) return dict(Object.entries(value), pad);
+  if (isPlainObject(value)) return dict(Object.entries(value), depth);
   if (typeof value === 'object') {
     return `${pad}${JSON.stringify(value, (k, v) => (typeof v === 'bigint' ? v.toString() : v))}`;
   }
   return `${pad}${value}`;
 }
 
-/** `{ "key" -> value, ... }`, from entries in either shape. */
-function dict(entries, pad) {
+/**
+ * `{ "key" -> value, ... }`, from entries in either dict shape.
+ *
+ * The value is rendered one level deeper and only its *first* line unindented,
+ * so a nested container lines up under its key instead of starting back at
+ * column zero. `a{oa{sa{sv}}}` from GetManagedObjects is three deep and was
+ * unreadable without this.
+ */
+function dict(entries, depth) {
+  const pad = '  '.repeat(depth);
   const body = entries
     .map(
       ([key, item]) =>
-        `${pad}  ${describe(key, 0).trim()} -> ${describe(item, 0).trim()}`
+        `${pad}  ${describe(key, 0).trim()} -> ${describe(item, depth + 1).trimStart()}`
     )
     .join('\n');
   return `${pad}{\n${body}\n${pad}}`;

--- a/lib/object-manager.js
+++ b/lib/object-manager.js
@@ -1,0 +1,149 @@
+// org.freedesktop.DBus.ObjectManager -- how a service publishes a tree of
+// objects, and how a client enumerates one in a single round trip.
+//
+// BlueZ, NetworkManager, systemd and UDisks all expose their objects this way,
+// so "list the devices" is `GetManagedObjects` on every real bus. Until now
+// this library had a `// TODO: emit ObjectManager's InterfaceAdded` and nothing
+// else, which left callers hand-decoding `a{oa{sa{sv}}}`.
+//
+// A manager reports the objects **strictly below** its own path, which is why
+// BlueZ puts one at '/' and reports '/org/bluez/hci0'. The manager object
+// itself is never in its own reply.
+
+const constants = require('./constants');
+const properties = require('./properties');
+
+const OBJECT_MANAGER = 'org.freedesktop.DBus.ObjectManager';
+
+/**
+ * Is `path` strictly below `root`?
+ *
+ * '/' is special: every path is below it, but the trailing-slash arithmetic
+ * that works for '/org/bluez' would ask whether a path starts with '//'.
+ */
+function isBelow(root, path) {
+  if (path === root) return false;
+  return root === '/' ? path.startsWith('/') : path.startsWith(`${root}/`);
+}
+
+/**
+ * The readable properties of one interface, as `a{sv}` body values.
+ *
+ * Write-only properties are omitted rather than guessed at, which is what the
+ * spec asks for and what Properties.GetAll already does.
+ *
+ * @throws if a declaration is malformed -- the service's bug, surfaced to
+ *   whoever is waiting on the reply
+ */
+function readableProperties(ifaceDesc, impl) {
+  const out = [];
+  for (const name of properties.names(ifaceDesc)) {
+    const decl = properties.declaration(ifaceDesc, name);
+    if (!properties.isReadable(decl.access)) continue;
+    out.push([name, [decl.type, impl[name]]]);
+  }
+  return out;
+}
+
+/**
+ * One object's interfaces and their properties: the `a{sa{sv}}` that both
+ * GetManagedObjects and InterfacesAdded carry.
+ *
+ * `only` restricts the result to those interface names, which is what an
+ * InterfacesAdded for a single newly-exported interface needs.
+ */
+function interfacesAndProperties(exported, only) {
+  const out = [];
+  for (const interfaceName of Object.keys(exported || {})) {
+    if (only && !only.includes(interfaceName)) continue;
+    const [ifaceDesc, impl] = exported[interfaceName];
+    out.push([interfaceName, readableProperties(ifaceDesc, impl)]);
+  }
+  return out;
+}
+
+/**
+ * Everything below `root`, as the `a{oa{sa{sv}}}` GetManagedObjects returns.
+ *
+ * Paths come out in export order. The spec does not require an order and no
+ * implementation sorts, so imposing one would only invite someone to depend on
+ * it.
+ */
+function managedObjects(exportedObjects, root) {
+  const out = [];
+  for (const path of Object.keys(exportedObjects)) {
+    if (!isBelow(root, path)) continue;
+    out.push([path, interfacesAndProperties(exportedObjects[path])]);
+  }
+  return out;
+}
+
+/** InterfacesAdded, announcing an object or a new interface on one. */
+function addedSignal(serial, managerPath, path, interfaces) {
+  return {
+    type: constants.messageType.signal,
+    serial,
+    path: managerPath,
+    interface: OBJECT_MANAGER,
+    member: 'InterfacesAdded',
+    signature: 'oa{sa{sv}}',
+    body: [path, interfaces]
+  };
+}
+
+/** InterfacesRemoved, naming the interfaces that went away. */
+function removedSignal(serial, managerPath, path, interfaceNames) {
+  return {
+    type: constants.messageType.signal,
+    serial,
+    path: managerPath,
+    interface: OBJECT_MANAGER,
+    member: 'InterfacesRemoved',
+    signature: 'oas',
+    body: [path, interfaceNames]
+  };
+}
+
+/**
+ * The manager responsible for `path`, or undefined.
+ *
+ * The deepest one wins, so a service may nest managers -- '/' reporting
+ * everything and '/org/example/devices' reporting a subtree -- and each object
+ * is announced by exactly one of them. Announcing to both would double every
+ * signal for anyone subscribed at the root.
+ */
+function managerFor(managerPaths, path) {
+  let best;
+  for (const manager of managerPaths) {
+    if (!isBelow(manager, path)) continue;
+    if (best === undefined || manager.length > best.length) best = manager;
+  }
+  return best;
+}
+
+const introspectionXML =
+  '  <interface name="org.freedesktop.DBus.ObjectManager">\n' +
+  '    <method name="GetManagedObjects">\n' +
+  '      <arg type="a{oa{sa{sv}}}" name="objects" direction="out"/>\n' +
+  '    </method>\n' +
+  '    <signal name="InterfacesAdded">\n' +
+  '      <arg type="o" name="object_path"/>\n' +
+  '      <arg type="a{sa{sv}}" name="interfaces_and_properties"/>\n' +
+  '    </signal>\n' +
+  '    <signal name="InterfacesRemoved">\n' +
+  '      <arg type="o" name="object_path"/>\n' +
+  '      <arg type="as" name="interfaces"/>\n' +
+  '    </signal>\n' +
+  '  </interface>';
+
+module.exports = {
+  OBJECT_MANAGER,
+  isBelow,
+  readableProperties,
+  interfacesAndProperties,
+  managedObjects,
+  addedSignal,
+  removedSignal,
+  managerFor,
+  introspectionXML
+};

--- a/lib/stdifaces.js
+++ b/lib/stdifaces.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const constants = require('./constants');
 const parseSignature = require('./signature');
 const properties = require('./properties');
+const objectManager = require('./object-manager');
 const { variantValue } = require('./values');
 
 // org.freedesktop.DBus.Peer.GetMachineId must return the same 32-char hex id
@@ -87,7 +88,14 @@ module.exports = function (msg, bus) {
       if (name) children.add(name);
     }
 
-    if (!exported && children.size === 0) {
+    // The lone '/' became '' above, but that is a quirk of the prefix
+    // arithmetic and not how the path was declared.
+    const declaredPath = msg.path === '' ? '/' : msg.path;
+    const isManager = Boolean(
+      bus.objectManagers && bus.objectManagers.has(declaredPath)
+    );
+
+    if (!exported && children.size === 0 && !isManager) {
       resultXml.push('<node/>');
     } else {
       resultXml.push('<node>');
@@ -97,6 +105,10 @@ module.exports = function (msg, bus) {
         }
         resultXml.push(stdIfaces);
       }
+      // Advertised even at a path with no interfaces of its own: a manager
+      // that only groups other objects is the normal case, and a client has no
+      // other way to discover it can call GetManagedObjects here.
+      if (isManager) resultXml.push(objectManager.introspectionXML);
       for (const name of children) {
         resultXml.push(`  <node name="${attr(name)}"/>`);
       }
@@ -221,6 +233,37 @@ module.exports = function (msg, bus) {
       propertiesReply.body = [props];
     }
     bus.connection.message(propertiesReply);
+    return 1;
+  } else if (msg['interface'] === objectManager.OBJECT_MANAGER) {
+    if (msg.member !== 'GetManagedObjects') return 0;
+    // Only paths the service declared with exportObjectManager(). Answering
+    // everywhere would advertise a tree at any path a caller happened to ask
+    // about, including ones with nothing below them.
+    if (!bus.objectManagers || !bus.objectManagers.has(msg.path)) {
+      bus.sendError(
+        msg,
+        'org.freedesktop.DBus.Error.UnknownInterface',
+        `No such interface "${objectManager.OBJECT_MANAGER}" at object path "${msg.path}"`
+      );
+      return 1;
+    }
+    let objects;
+    try {
+      objects = objectManager.managedObjects(bus.exportedObjects, msg.path);
+    } catch (e) {
+      // A malformed property declaration somewhere in the tree. The service's
+      // bug, but the caller is the one waiting.
+      bus.sendError(msg, 'org.freedesktop.DBus.Error.Failed', e.message);
+      return 1;
+    }
+    bus.connection.message({
+      type: constants.messageType.methodReturn,
+      serial: bus.serial++,
+      replySerial: msg.serial,
+      destination: msg.sender,
+      signature: 'a{oa{sa{sv}}}',
+      body: [objects]
+    });
     return 1;
   } else if (msg['interface'] === 'org.freedesktop.DBus.Peer') {
     // TODO: implement bus.replyTo(srcMsg, signature, body) method

--- a/test/cli-shape.js
+++ b/test/cli-shape.js
@@ -56,6 +56,27 @@ describe('cli value shapes', () => {
     );
   });
 
+  it('indents a nested dict under its key', () => {
+    // GetManagedObjects returns a{oa{sa{sv}}}, three deep. Rendered flat --
+    // every level starting at column zero -- it is unreadable.
+    const body = [
+      { '/dev0': { 'com.example.D': { Name: new Variant('s', 'hci0') } } }
+    ];
+    const [objects] = read('a{oa{sa{sv}}}', body, SHAPE);
+    assert.strictEqual(
+      render(objects, 0),
+      [
+        '{',
+        '  "/dev0" -> {',
+        '    "com.example.D" -> {',
+        '      "Name" -> variant s "hci0"',
+        '    }',
+        '  }',
+        '}'
+      ].join('\n')
+    );
+  });
+
   it('does not round a 64-bit value on the way to the terminal', () => {
     const [value] = read('t', [18446744073709551615n], SHAPE);
     assert.strictEqual(render(value, 0), '18446744073709551615');

--- a/test/integration/object-manager.js
+++ b/test/integration/object-manager.js
@@ -1,0 +1,235 @@
+// org.freedesktop.DBus.ObjectManager, served over a real bus.
+//
+// This is how BlueZ, NetworkManager, systemd and UDisks publish their object
+// trees, so "list the devices" is GetManagedObjects everywhere. Exercised end
+// to end because the interesting parts are the ones that span the whole path:
+// the declaration, the introspection XML, the reply body, and the two signals
+// actually arriving at a subscriber.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const { toPlain } = require('../../lib/values');
+const { sessionBus } = require('../utils/shape');
+
+const NO_BUS =
+  !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
+
+const SERVICE = 'com.github.sidorares.dbusnative.Manager';
+const ROOT = '/com/github/sidorares/dbusnative/Manager';
+const IFACE = 'com.github.sidorares.dbusnative.Device';
+const OM = 'org.freedesktop.DBus.ObjectManager';
+
+const ifaceDesc = {
+  name: IFACE,
+  methods: {},
+  signals: {},
+  properties: {
+    Name: 's',
+    Address: { type: 's', access: 'read' },
+    Pin: { type: 's', access: 'write' }
+  }
+};
+
+const device = fields => {
+  const impl = Object.assign(Object.create(EventEmitter.prototype), fields);
+  EventEmitter.call(impl);
+  return impl;
+};
+
+describe('integration: ObjectManager', { timeout: 10000, skip: NO_BUS }, () => {
+  let serviceBus, clientBus;
+
+  const whenReady = bus =>
+    new Promise((resolve, reject) =>
+      bus.getId(err => (err ? reject(err) : resolve()))
+    );
+
+  const call = (member, signature, body, path = ROOT) =>
+    clientBus.invoke({
+      destination: SERVICE,
+      path,
+      interface: OM,
+      member,
+      ...(signature ? { signature, body } : {})
+    });
+
+  // Resolves with the next signal of this member, as plain values.
+  const nextSignal = member =>
+    new Promise(resolve => {
+      const key = clientBus.mangle(ROOT, OM, member);
+      clientBus.signals.once(key, body => resolve(body));
+    });
+
+  before(async () => {
+    serviceBus = sessionBus();
+    clientBus = sessionBus();
+
+    await Promise.all([whenReady(serviceBus), whenReady(clientBus)]);
+    await new Promise((resolve, reject) =>
+      serviceBus.requestName(SERVICE, 0, err => {
+        if (err) return reject(err);
+        serviceBus.exportObjectManager(ROOT);
+        serviceBus.exportInterface(
+          device({ Name: 'hci0', Address: '00:11:22', Pin: '0000' }),
+          `${ROOT}/dev0`,
+          ifaceDesc
+        );
+        resolve();
+      })
+    );
+    await clientBus.addMatch(`type='signal',path='${ROOT}',interface='${OM}'`);
+  });
+
+  after(() => {
+    for (const bus of [serviceBus, clientBus]) if (bus) bus.connection.end();
+  });
+
+  describe('GetManagedObjects', () => {
+    it('reports the objects below the manager', async () => {
+      const objects = toPlain(await call('GetManagedObjects'));
+      assert.deepStrictEqual(objects, {
+        [`${ROOT}/dev0`]: {
+          [IFACE]: { Name: 'hci0', Address: '00:11:22' }
+        }
+      });
+    });
+
+    it('omits write-only properties, as GetAll does', async () => {
+      const objects = toPlain(await call('GetManagedObjects'));
+      assert.ok(
+        !('Pin' in objects[`${ROOT}/dev0`][IFACE]),
+        'a write-only property has no value to report'
+      );
+    });
+
+    it('does not include the manager object itself', async () => {
+      // The manager is not below itself. A service that exported an
+      // interface at ROOT would still not see it here.
+      const objects = toPlain(await call('GetManagedObjects'));
+      assert.ok(!(ROOT in objects));
+    });
+
+    it('is refused at a path that did not declare it', async () => {
+      await assert.rejects(
+        () => call('GetManagedObjects', undefined, undefined, `${ROOT}/dev0`),
+        { dbusName: 'org.freedesktop.DBus.Error.UnknownInterface' }
+      );
+    });
+  });
+
+  describe('introspection', () => {
+    const introspect = path =>
+      clientBus.invoke({
+        destination: SERVICE,
+        path,
+        interface: 'org.freedesktop.DBus.Introspectable',
+        member: 'Introspect'
+      });
+
+    it('advertises the interface at the manager path', async () => {
+      const xml = await introspect(ROOT);
+      assert.match(
+        xml,
+        /<interface name="org\.freedesktop\.DBus\.ObjectManager">/
+      );
+      assert.match(xml, /<method name="GetManagedObjects">/);
+      assert.match(xml, /<signal name="InterfacesAdded">/);
+      assert.match(xml, /<signal name="InterfacesRemoved">/);
+      // A manager that only groups other objects still lists its children.
+      assert.match(xml, /<node name="dev0"\/>/);
+    });
+
+    it('does not advertise it anywhere else', async () => {
+      const xml = await introspect(`${ROOT}/dev0`);
+      assert.ok(!xml.includes('ObjectManager'));
+    });
+  });
+
+  describe('InterfacesAdded', () => {
+    it('is emitted when an object is exported below the manager', async () => {
+      const signal = nextSignal('InterfacesAdded');
+      serviceBus.exportInterface(
+        device({ Name: 'hci1', Address: '33:44:55', Pin: '1111' }),
+        `${ROOT}/dev1`,
+        ifaceDesc
+      );
+      const [path, interfaces] = await signal;
+      assert.strictEqual(path, `${ROOT}/dev1`);
+      assert.deepStrictEqual(toPlain(interfaces), {
+        [IFACE]: { Name: 'hci1', Address: '33:44:55' }
+      });
+    });
+
+    it('announces only the interface that appeared', async () => {
+      const second = {
+        name: 'com.github.sidorares.dbusnative.Extra',
+        methods: {},
+        signals: {},
+        properties: { Extra: 's' }
+      };
+      const signal = nextSignal('InterfacesAdded');
+      serviceBus.exportInterface(
+        device({ Extra: 'more' }),
+        `${ROOT}/dev1`,
+        second
+      );
+      const [path, interfaces] = await signal;
+      assert.strictEqual(path, `${ROOT}/dev1`);
+      // Not news about the interface that was already there.
+      assert.deepStrictEqual(Object.keys(toPlain(interfaces)), [second.name]);
+    });
+
+    it('is not emitted for an object outside any manager', async () => {
+      let seen = false;
+      const key = clientBus.mangle(ROOT, OM, 'InterfacesAdded');
+      const watch = () => {
+        seen = true;
+      };
+      clientBus.signals.on(key, watch);
+      serviceBus.exportInterface(
+        device({ Name: 'elsewhere', Address: '', Pin: '' }),
+        '/com/github/sidorares/dbusnative/Unmanaged',
+        ifaceDesc
+      );
+      await new Promise(resolve => setTimeout(resolve, 150));
+      clientBus.signals.removeListener(key, watch);
+      assert.strictEqual(seen, false);
+    });
+  });
+
+  describe('InterfacesRemoved', () => {
+    it('is emitted when one interface is unexported', async () => {
+      const signal = nextSignal('InterfacesRemoved');
+      const removed = serviceBus.unexportInterface(`${ROOT}/dev1`, IFACE);
+      assert.strictEqual(removed, true);
+      const [path, interfaces] = await signal;
+      assert.strictEqual(path, `${ROOT}/dev1`);
+      assert.deepStrictEqual(interfaces, [IFACE]);
+    });
+
+    it('names every interface when the whole object goes', async () => {
+      const signal = nextSignal('InterfacesRemoved');
+      serviceBus.unexportInterface(`${ROOT}/dev1`);
+      const [path, interfaces] = await signal;
+      assert.strictEqual(path, `${ROOT}/dev1`);
+      assert.deepStrictEqual(interfaces, [
+        'com.github.sidorares.dbusnative.Extra'
+      ]);
+    });
+
+    it('leaves the object out of GetManagedObjects afterwards', async () => {
+      const objects = toPlain(await call('GetManagedObjects'));
+      assert.ok(!(`${ROOT}/dev1` in objects));
+      assert.ok(`${ROOT}/dev0` in objects, 'the others are untouched');
+    });
+
+    it('reports nothing removed for a path that was never exported', () => {
+      assert.strictEqual(serviceBus.unexportInterface(`${ROOT}/nope`), false);
+      assert.strictEqual(
+        serviceBus.unexportInterface(`${ROOT}/dev0`, 'com.example.Absent'),
+        false
+      );
+    });
+  });
+});

--- a/test/object-manager.js
+++ b/test/object-manager.js
@@ -1,0 +1,137 @@
+// The path arithmetic and body shapes behind org.freedesktop.DBus.ObjectManager.
+//
+// Kept separate from the end-to-end test because these are the parts with edge
+// cases -- '/' is not like any other path, and "below" has to exclude the
+// manager itself and near-misses like /a/bc under /a/b.
+
+const { describe, it } = require('node:test');
+const assert = require('assert');
+const om = require('../lib/object-manager');
+
+// Two objects' worth of exportedObjects, in the shape bus.js keeps.
+const exported = (properties, impl) => ({
+  'com.example.Thing': [{ name: 'com.example.Thing', properties }, impl]
+});
+
+describe('object manager: isBelow', () => {
+  it('excludes the manager itself', () => {
+    assert.strictEqual(om.isBelow('/a/b', '/a/b'), false);
+    assert.strictEqual(om.isBelow('/', '/'), false);
+  });
+
+  it('includes descendants at any depth', () => {
+    assert.strictEqual(om.isBelow('/a/b', '/a/b/c'), true);
+    assert.strictEqual(om.isBelow('/a/b', '/a/b/c/d'), true);
+  });
+
+  it("treats '/' as the parent of everything", () => {
+    // The case that breaks naive prefix arithmetic: `'/' + '/'` would ask
+    // whether the path starts with '//'.
+    assert.strictEqual(om.isBelow('/', '/a'), true);
+    assert.strictEqual(om.isBelow('/', '/org/bluez/hci0'), true);
+  });
+
+  it('does not mistake a sibling with a shared prefix for a child', () => {
+    assert.strictEqual(om.isBelow('/a/b', '/a/bc'), false);
+    assert.strictEqual(om.isBelow('/a/b', '/a/bc/d'), false);
+  });
+
+  it('excludes ancestors and unrelated paths', () => {
+    assert.strictEqual(om.isBelow('/a/b', '/a'), false);
+    assert.strictEqual(om.isBelow('/a/b', '/x/y'), false);
+  });
+});
+
+describe('object manager: managerFor', () => {
+  it('is undefined when nothing manages the path', () => {
+    assert.strictEqual(om.managerFor(new Set(['/a']), '/b/c'), undefined);
+    assert.strictEqual(om.managerFor(new Set(), '/b/c'), undefined);
+  });
+
+  it('picks the deepest manager, so an object is announced once', () => {
+    const managers = new Set(['/', '/a', '/a/b']);
+    assert.strictEqual(om.managerFor(managers, '/a/b/c'), '/a/b');
+    assert.strictEqual(om.managerFor(managers, '/a/x'), '/a');
+    assert.strictEqual(om.managerFor(managers, '/z'), '/');
+  });
+
+  it('does not let a manager announce itself', () => {
+    assert.strictEqual(om.managerFor(new Set(['/a']), '/a'), undefined);
+  });
+});
+
+describe('object manager: bodies', () => {
+  const impl = { Name: 'eth0', Secret: 'shh', Mtu: 1500 };
+  const props = {
+    Name: 's',
+    Mtu: { type: 'u', access: 'read' },
+    Secret: { type: 's', access: 'write' }
+  };
+
+  it('omits write-only properties, as GetAll does', () => {
+    assert.deepStrictEqual(om.readableProperties({ properties: props }, impl), [
+      ['Name', ['s', 'eth0']],
+      ['Mtu', ['u', 1500]]
+    ]);
+  });
+
+  it('reports every interface at a path', () => {
+    const obj = {
+      'com.example.A': [{ properties: { X: 's' } }, { X: '1' }],
+      'com.example.B': [{ properties: {} }, {}]
+    };
+    assert.deepStrictEqual(om.interfacesAndProperties(obj), [
+      ['com.example.A', [['X', ['s', '1']]]],
+      ['com.example.B', []]
+    ]);
+  });
+
+  it('can be narrowed to the interfaces that just appeared', () => {
+    const obj = {
+      'com.example.A': [{ properties: { X: 's' } }, { X: '1' }],
+      'com.example.B': [{ properties: {} }, {}]
+    };
+    assert.deepStrictEqual(om.interfacesAndProperties(obj, ['com.example.B']), [
+      ['com.example.B', []]
+    ]);
+  });
+
+  it('collects everything strictly below the manager', () => {
+    const objects = {
+      '/': exported({}, {}),
+      '/a': exported({ P: 's' }, { P: 'one' }),
+      '/a/b': exported({ P: 's' }, { P: 'two' })
+    };
+    assert.deepStrictEqual(om.managedObjects(objects, '/a'), [
+      ['/a/b', [['com.example.Thing', [['P', ['s', 'two']]]]]]
+    ]);
+    assert.deepStrictEqual(
+      om.managedObjects(objects, '/').map(([path]) => path),
+      ['/a', '/a/b']
+    );
+  });
+
+  it('surfaces a malformed declaration rather than emitting a bad body', () => {
+    assert.throws(
+      () =>
+        om.readableProperties({ properties: { X: { access: 'read' } } }, {}),
+      /must be declared as a signature string/
+    );
+  });
+});
+
+describe('object manager: signals', () => {
+  it('InterfacesAdded is oa{sa{sv}} from the manager path', () => {
+    const sig = om.addedSignal(7, '/', '/a', [['com.example.A', []]]);
+    assert.strictEqual(sig.path, '/');
+    assert.strictEqual(sig.member, 'InterfacesAdded');
+    assert.strictEqual(sig.signature, 'oa{sa{sv}}');
+    assert.deepStrictEqual(sig.body, ['/a', [['com.example.A', []]]]);
+  });
+
+  it('InterfacesRemoved is oas', () => {
+    const sig = om.removedSignal(8, '/', '/a', ['com.example.A']);
+    assert.strictEqual(sig.signature, 'oas');
+    assert.deepStrictEqual(sig.body, ['/a', ['com.example.A']]);
+  });
+});


### PR DESCRIPTION
[BIG_FUTURE_PLANS §3.1](https://github.com/sidorares/dbus-native/blob/master/BIG_FUTURE_PLANS.md) — the omission the re-evaluation rated worth more per line than proxies, and the one the original design sketch never mentioned at all.

BlueZ, NetworkManager, systemd and UDisks all publish their object trees through `org.freedesktop.DBus.ObjectManager`, so "list the devices" is `GetManagedObjects` on every real bus. This library had a `// TODO: emit ObjectManager's InterfaceAdded` in `lib/bus.js` and nothing else, which left callers hand-decoding `a{oa{sa{sv}}}` — see #228, a BlueZ user hunting for `GattService`.

This is the **server half**. The client-side live view is the next PR.

```js
bus.exportObjectManager('/com/example');

bus.exportInterface(hci0, '/com/example/dev0', deviceIface); // InterfacesAdded
bus.exportInterface(hci1, '/com/example/dev1', deviceIface); // InterfacesAdded

bus.unexportInterface('/com/example/dev1'); // InterfacesRemoved
```

That is the whole API. `GetManagedObjects` is answered, the interface reaches the introspection XML at the manager path, and both signals are emitted as objects come and go.

## Four decisions worth recording

**A manager reports what is strictly below it, never itself.** That is what the spec means by "beneath", and why BlueZ's manager sits at `/` and reports `/org/bluez/hci0`. `/` needs its own branch in the path arithmetic — naive prefix matching would ask whether a path starts with `//`. Also covered: `/a/bc` is not below `/a/b`.

**Opt-in, not automatic.** Answering everywhere would claim a tree at any path someone asked about, and a client cannot discover the interface unless it is advertised — so it has to be declared either way.

**Managers may nest, and the deepest one announces.** Otherwise a service with a manager at `/` and another at `/com/example` sends every signal twice to anyone subscribed at the root.

**`InterfacesAdded` announces only what appeared.** Re-exporting one interface on an object that already had three is not news about the other three.

## `unexportInterface` is new, and had to be

`InterfacesRemoved` cannot mean anything without it: a manager that can only ever report objects *appearing* is half an implementation, and devices coming and going is the normal case rather than the exotic one. An object whose last interface is removed stops existing rather than lingering as a path with nothing on it.

## Verified on the wire

The reply signature is `a{oa{sa{sv}}}` — matching what the [e2e Docker run recorded from NetworkManager](https://github.com/sidorares/dbus-native/blob/master/E2E_DOCKER_TESTING.md) — checked end to end through `dbus-native call` against a live service, and the introspection XML re-parsed with xml2js.

Write-only properties are omitted from the reply, exactly as `GetAll` omits them.

## Also: the CLI's nested-dict indentation

`a{oa{sa{sv}}}` is the first type deep enough to expose it — three levels all rendered at column zero. Before and after:

```
{                                    {
  "/com/example/dev0" -> {             "/com/example/dev0" -> {
  "com.example.Device" -> {              "com.example.Device" -> {
  "Name" -> variant s "hci0"               "Name" -> variant s "hci0"
}                                        }
}                                      }
}                                    }
```

## Verification

| | dbus-daemon | broker |
|---|---|---|
| classic | 174/174 | 174/174 |
| `2.0` | 174/174 | 174/174 |
| `2.0-wrap` | 174/174 | 174/174 |

`npm test` — 837 unit tests, lint, format, tsc — green. 15 unit tests cover the path arithmetic and body shapes; 13 integration tests cover the reply, the XML, both signals, and the negative cases.
