### PR TITLE
feat: bus.objects(), a live view of a service's object tree

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -545,8 +545,63 @@ them: there is no value to report and the spec says to leave it out.
 last interface goes stops existing rather than lingering as a path with nothing
 on it.
 
-Reading the reply is the usual `a{oa{sa{sv}}}` — three levels deep, so
-`toPlain()` is worth reaching for:
+### Watching one: `bus.objects()`
+
+The client side. `GetManagedObjects` returns `a{oa{sa{sv}}}` — three levels of
+dict with variants at the bottom — and then you have to keep it current from
+three different signals, matched against the right service. Everyone using
+BlueZ or NetworkManager writes this, and writes it slightly wrong.
+
+```js
+const bluez = await bus.objects('org.bluez', '/');
+
+bluez.filter('org.bluez.Device1');
+// { '/org/bluez/hci0/dev_AA': { Alias: 'Headphones', Connected: false } }
+
+bluez.on('added', (path, interfaces) => {});
+bluez.on('removed', (path, interfaceNames) => {});
+bluez.on('changed', (path, iface, changed, invalidated) => {});
+
+await bluez.close();
+```
+
+| member                       |                                                        |
+| ---------------------------- | ------------------------------------------------------ |
+| `view.objects`               | `{ path: { interface: { property: value } } }`         |
+| `view.paths()`               | every managed path                                     |
+| `view.get(path)`             | one object's interfaces, or `undefined`                |
+| `view.filter(interfaceName)` | `{ path: properties }` for objects implementing it     |
+| `view.owner`                 | the unique name currently owning the service           |
+| `view.close()`               | remove the match rules and stop listening — idempotent |
+
+It also implements `Symbol.asyncDispose`, so the match rules — the resource
+people forget — can be scoped rather than released by hand:
+
+```js
+await using bluez = await bus.objects('org.bluez', '/');
+```
+
+**Values are plain in every connection shape.** A view whose contents depended
+on `plainValues` would be useless to write against.
+
+**It subscribes before it fetches.** Fetching first leaves a window where an
+object appears, its `InterfacesAdded` goes nowhere, and the view is permanently
+missing it. Signals arriving during startup are buffered and replayed onto the
+snapshot.
+
+**`PropertiesChanged` is tracked too**, so a value stays current and not just
+the set of objects. Pass `{ properties: false }` to skip it and the match rule
+it costs. An invalidated property is _dropped_ from the view rather than left
+at its old value — keeping a value the service has disowned is how a view
+starts lying; re-read it with `Properties.Get`.
+
+**A `'stale'` event fires if the service is replaced or goes away.** The view
+does not resynchronise itself: re-fetching would race whatever the caller is
+doing with it, and a half-updated tree is worse than a stale one that says so.
+Make a new view.
+
+If you only want the snapshot, the raw call is fine — just reach for
+`toPlain()`, because three levels of pairs is not readable:
 
 ```js
 const objects = toPlain(await bus.invoke({/* GetManagedObjects */}));

--- a/index.d.ts
+++ b/index.d.ts
@@ -505,6 +505,63 @@ export interface DBusService {
 // The bus
 // ---------------------------------------------------------------------------
 
+/** `{ path: { interfaceName: { property: value } } }`, in plain values. */
+export type ManagedObjectTree = Record<
+  string,
+  Record<string, Record<string, unknown>>
+>;
+
+/**
+ * A live view of a service's object tree, from `bus.objects()`.
+ *
+ * Values are plain in every connection shape — a view whose contents depended
+ * on how the connection was configured would be useless to write against.
+ */
+export interface ManagedObjects extends EventEmitter {
+  /** The bus name being watched, and the manager's path. */
+  readonly service: string;
+  readonly path: string;
+  /** The unique name currently owning `service`. */
+  readonly owner: string;
+  readonly closed: boolean;
+
+  /** The whole tree. Mutated in place as signals arrive; do not hold slices. */
+  readonly objects: ManagedObjectTree;
+
+  paths(): string[];
+  get(path: string): Record<string, Record<string, unknown>> | undefined;
+  /** The objects implementing an interface, as `{ path: properties }`. */
+  filter(interfaceName: string): Record<string, Record<string, unknown>>;
+
+  /** Remove the match rules and stop listening. Idempotent. */
+  close(): Promise<void>;
+  [Symbol.asyncDispose](): Promise<void>;
+
+  on(
+    event: 'added',
+    listener: (
+      path: string,
+      interfaces: Record<string, Record<string, unknown>>
+    ) => void
+  ): this;
+  on(
+    event: 'removed',
+    listener: (path: string, interfaceNames: string[]) => void
+  ): this;
+  on(
+    event: 'changed',
+    listener: (
+      path: string,
+      interfaceName: string,
+      changed: Record<string, unknown>,
+      invalidated: string[]
+    ) => void
+  ): this;
+  /** The service was replaced or went away; this view is watching nothing. */
+  on(event: 'stale', listener: (newOwner: string) => void): this;
+  on(event: string, listener: (...args: any[]) => void): this;
+}
+
 export interface MessageBus {
   connection: DBusConnection;
   serial: number;
@@ -580,6 +637,25 @@ export interface MessageBus {
 
   /** Paths serving `org.freedesktop.DBus.ObjectManager`. */
   objectManagers: Set<string>;
+
+  /**
+   * A live view of the objects a service manages below `path`.
+   *
+   * One round trip for the whole tree, then kept current from
+   * `InterfacesAdded`, `InterfacesRemoved` and `PropertiesChanged`.
+   *
+   * ```js
+   * const bluez = await bus.objects('org.bluez', '/');
+   * const devices = bluez.filter('org.bluez.Device1');
+   * bluez.on('added', (path, interfaces) => { ... });
+   * await bluez.close();
+   * ```
+   */
+  objects(
+    service: string,
+    path: string,
+    options?: { properties?: boolean }
+  ): Promise<ManagedObjects>;
 
   /**
    * Emit org.freedesktop.DBus.Properties.PropertiesChanged for an exported

--- a/lib/broker.js
+++ b/lib/broker.js
@@ -243,6 +243,31 @@ function createBroker(opts = {}) {
       body: [text]
     });
 
+  /**
+   * A rule matches this message, with `sender` resolved.
+   *
+   * A signal always carries the sender's *unique* name, so a rule saying
+   * `sender='org.bluez'` would never fire if it were compared literally --
+   * which is what this used to do. dbus-daemon reads a well-known name there
+   * as "whoever owns it now", and re-evaluates as the name changes hands, so a
+   * rule written before the service started still works once it does.
+   *
+   * Found by the ObjectManager client, which is the first thing in the tree to
+   * watch a service by its well-known name: every signal-driven test passed
+   * against dbus-daemon and none against the broker.
+   */
+  function ruleMatches(parsed, msg) {
+    const wanted = parsed.sender;
+    // BUS_NAME is well-known but owned by nothing -- the bus is not a client,
+    // so it has no entry to resolve and is compared as written.
+    if (wanted === undefined || wanted.startsWith(':') || wanted === BUS_NAME) {
+      return matches(parsed, msg);
+    }
+    const owner = ownerOf(wanted);
+    if (!owner || owner.name !== msg.sender) return false;
+    return matches({ ...parsed, sender: undefined }, msg);
+  }
+
   /** Deliver a signal to every client whose rules ask for it. */
   function broadcast(signal) {
     const msg = {
@@ -254,7 +279,7 @@ function createBroker(opts = {}) {
       if (!client.name) continue;
       // A client sees its own broadcast if it asked for it -- checked against
       // dbus-daemon, which delivers to the sender too.
-      if (client.rules.some(rule => matches(rule.parsed, msg))) {
+      if (client.rules.some(rule => ruleMatches(rule.parsed, msg))) {
         send(client, msg);
       }
     }

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -573,6 +573,29 @@ module.exports = function bus(conn, opts) {
     return self;
   };
 
+  /**
+   * A live view of the objects a service manages below `path`.
+   *
+   * One round trip for the whole tree, then kept current from
+   * InterfacesAdded, InterfacesRemoved and PropertiesChanged. Values are plain
+   * whatever shape this connection reads in.
+   *
+   *     const bluez = await bus.objects('org.bluez', '/');
+   *     const devices = bluez.filter('org.bluez.Device1');
+   *     bluez.on('added', (path, interfaces) => { ... });
+   *     await bluez.close();
+   *
+   * @param {string} service the bus name to watch
+   * @param {string} path the manager's object path
+   * @param {{properties?: boolean}} [options] `properties: false` to skip
+   *   tracking PropertiesChanged, and the match rule that costs
+   * @returns {Promise<import('./managed-objects').ManagedObjects>}
+   */
+  this.objects = function (service, path, options) {
+    const { ManagedObjects } = require('./managed-objects');
+    return new ManagedObjects(self, service, path, options || {}).start();
+  };
+
   /** InterfacesAdded, if any manager is responsible for this path. */
   this.emitInterfacesAdded = function (path, interfaceNames) {
     const manager = objectManager.managerFor(self.objectManagers, path);

--- a/lib/managed-objects.js
+++ b/lib/managed-objects.js
@@ -1,0 +1,225 @@
+// The client side of org.freedesktop.DBus.ObjectManager: a live view of a
+// service's object tree.
+//
+// This is the half that removes the hand-decoding. `GetManagedObjects` returns
+// `a{oa{sa{sv}}}` -- three levels of dict with variants at the bottom -- and
+// then you have to keep it up to date from InterfacesAdded, InterfacesRemoved
+// and PropertiesChanged, all of which arrive as separate signals that have to
+// be matched against the right service. Everyone using BlueZ or NetworkManager
+// writes this, and writes it slightly wrong.
+
+const { EventEmitter } = require('events');
+const { toPlain } = require('./values');
+const { OBJECT_MANAGER } = require('./object-manager');
+
+const PROPERTIES = 'org.freedesktop.DBus.Properties';
+const DBUS = 'org.freedesktop.DBus';
+
+/**
+ * A live view of the objects a service manages below one path.
+ *
+ * Values are plain -- `{ path: { interface: { property: value } } }` -- in
+ * every connection shape, because a view whose contents depended on how the
+ * connection was configured would be useless to write against.
+ *
+ * @fires ManagedObjects#added   (path, interfaces)
+ * @fires ManagedObjects#removed (path, interfaceNames)
+ * @fires ManagedObjects#changed (path, interfaceName, changed, invalidated)
+ * @fires ManagedObjects#stale   (newOwner) -- the service was replaced
+ */
+class ManagedObjects extends EventEmitter {
+  constructor(bus, service, path, options) {
+    super();
+    this.bus = bus;
+    this.service = service;
+    this.path = path;
+    this.objects = {};
+    this.owner = undefined;
+    this.closed = false;
+
+    this._trackProperties = options.properties !== false;
+    this._rules = [];
+    // Signals that arrive between subscribing and the GetManagedObjects reply
+    // are held here rather than dropped. See start().
+    this._pending = [];
+    this._buffering = true;
+    this._onMessage = msg => this._handle(msg);
+  }
+
+  /** Every managed object path. */
+  paths() {
+    return Object.keys(this.objects);
+  }
+
+  /** One object's interfaces, or undefined. */
+  get(path) {
+    return this.objects[path];
+  }
+
+  /**
+   * The objects implementing an interface, as `{ path: properties }`.
+   *
+   * The interface name is already known to the caller, so returning it again
+   * in the value would only be something to index past.
+   */
+  filter(interfaceName) {
+    const out = {};
+    for (const [path, interfaces] of Object.entries(this.objects)) {
+      if (Object.hasOwn(interfaces, interfaceName)) {
+        out[path] = interfaces[interfaceName];
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Subscribe, then fetch.
+   *
+   * The order matters and is the bug this class exists to not have. Fetching
+   * first leaves a window in which an object appears, its InterfacesAdded goes
+   * nowhere, and the view is permanently missing it. Subscribing first means
+   * signals can arrive describing objects the snapshot has not delivered yet,
+   * so they are buffered and replayed once it has.
+   */
+  async start() {
+    // Signals carry the sender's unique name, never the well-known one, so
+    // matching on `service` directly would never fire.
+    this.owner = this.service.startsWith(':')
+      ? this.service
+      : await this.bus.getNameOwner(this.service);
+
+    this.bus.connection.on('message', this._onMessage);
+
+    const sender = `sender='${this.service}'`;
+    await this._watch(
+      `type='signal',${sender},path='${this.path}',interface='${OBJECT_MANAGER}'`
+    );
+    if (this._trackProperties) {
+      // path_namespace rather than path: the properties belong to the managed
+      // objects below this one, not to the manager.
+      await this._watch(
+        `type='signal',${sender},interface='${PROPERTIES}',member='PropertiesChanged',path_namespace='${this.path}'`
+      );
+    }
+    // Not scoped to the service: the argument *is* the name, and a
+    // NameOwnerChanged is sent by the daemon rather than by the service.
+    await this._watch(
+      `type='signal',sender='${DBUS}',interface='${DBUS}',member='NameOwnerChanged',arg0='${this.service}'`
+    );
+
+    const reply = await this.bus.invoke({
+      destination: this.service,
+      path: this.path,
+      interface: OBJECT_MANAGER,
+      member: 'GetManagedObjects'
+    });
+    this.objects = toPlain(reply);
+
+    // Replay. A signal for an object already in the snapshot is idempotent:
+    // InterfacesAdded overwrites with the same values, and a removal that the
+    // snapshot already reflects finds nothing to delete.
+    this._buffering = false;
+    const pending = this._pending;
+    this._pending = [];
+    for (const msg of pending) this._apply(msg);
+
+    return this;
+  }
+
+  async _watch(rule) {
+    await this.bus.addMatch(rule);
+    this._rules.push(rule);
+  }
+
+  _handle(msg) {
+    if (this.closed) return;
+    if (msg.sender !== this.owner && msg.sender !== DBUS) return;
+    if (this._buffering) {
+      this._pending.push(msg);
+      return;
+    }
+    this._apply(msg);
+  }
+
+  _apply(msg) {
+    if (msg['interface'] === OBJECT_MANAGER && msg.path === this.path) {
+      if (msg.member === 'InterfacesAdded') {
+        const [path, interfaces] = msg.body;
+        const added = toPlain(interfaces);
+        this.objects[path] = { ...this.objects[path], ...added };
+        this.emit('added', path, added);
+      } else if (msg.member === 'InterfacesRemoved') {
+        const [path, names] = msg.body;
+        const object = this.objects[path];
+        if (!object) return;
+        for (const name of names) delete object[name];
+        // An object with no interfaces left is gone, which is how the spec
+        // says a client should read it.
+        if (Object.keys(object).length === 0) delete this.objects[path];
+        this.emit('removed', path, names);
+      }
+      return;
+    }
+
+    if (
+      this._trackProperties &&
+      msg['interface'] === PROPERTIES &&
+      msg.member === 'PropertiesChanged'
+    ) {
+      const [interfaceName, changedRaw, invalidated = []] = msg.body;
+      const object = this.objects[msg.path];
+      // A PropertiesChanged for something we are not tracking -- a path below
+      // the manager that it never reported -- is not ours to apply.
+      if (!object || !object[interfaceName]) return;
+      const changed = toPlain(changedRaw);
+      Object.assign(object[interfaceName], changed);
+      // Invalidated means "changed, value not sent". Dropping the key is
+      // honest: keeping a value the service has disowned is how a view starts
+      // lying. Re-read with Properties.Get if you need it.
+      for (const name of invalidated) delete object[interfaceName][name];
+      this.emit('changed', msg.path, interfaceName, changed, invalidated);
+      return;
+    }
+
+    if (
+      msg['interface'] === DBUS &&
+      msg.member === 'NameOwnerChanged' &&
+      msg.body &&
+      msg.body[0] === this.service
+    ) {
+      const newOwner = msg.body[2];
+      if (newOwner === this.owner) return;
+      // Not resynchronised automatically: re-fetching would race with whatever
+      // the caller is doing with the view, and a half-updated tree is worse
+      // than a stale one that says so. The alternative -- staying quiet -- is
+      // how a view silently stops working after a service restart.
+      this.emit('stale', newOwner);
+    }
+  }
+
+  /** Remove the match rules and stop listening. Idempotent. */
+  async close() {
+    if (this.closed) return;
+    this.closed = true;
+    this.bus.connection.removeListener('message', this._onMessage);
+    const rules = this._rules;
+    this._rules = [];
+    for (const rule of rules) {
+      try {
+        await this.bus.removeMatch(rule);
+      } catch {
+        // The connection may already be going away, which is the common case
+        // for a view being closed. Nothing useful to do, and throwing here
+        // would mask whatever is actually shutting down.
+      }
+    }
+  }
+
+  // Lets a view be scoped rather than closed by hand -- the match rules are
+  // exactly the resource people forget to release.
+  async [Symbol.asyncDispose]() {
+    await this.close();
+  }
+}
+
+module.exports = { ManagedObjects };

--- a/lib/match-rule.js
+++ b/lib/match-rule.js
@@ -185,11 +185,11 @@ function matches(rule, msg) {
   if (parsed.type !== undefined && msg.type !== MESSAGE_TYPES[parsed.type]) {
     return false;
   }
-  // `sender` and `destination` are matched as written. The daemon resolves a
-  // well-known name to its owner before comparing, which it can do because it
-  // owns the name table; here there is nothing to resolve against, so a rule
-  // naming a well-known sender is compared against whatever the message says.
-  // lib/broker.js passes an already-resolved message.
+  // `sender` and `destination` are matched as written. Resolving a well-known
+  // name to its owner needs the name table, which lives in the bus rather than
+  // here -- so a caller that has one resolves first and passes `sender`
+  // already matching, or drops it and checks separately. lib/broker.js does
+  // the latter, in ruleMatches().
   for (const key of ['sender', 'destination', 'interface', 'member', 'path']) {
     if (parsed[key] !== undefined && msg[key] !== parsed[key]) return false;
   }

--- a/test/broker.js
+++ b/test/broker.js
@@ -653,6 +653,64 @@ describe('broker', { timeout: 20000 }, () => {
       assert.strictEqual(seen[0].sender, sender.name);
     });
 
+    it("resolves a well-known sender='' to whoever owns it", async () => {
+      // A signal carries the sender's *unique* name, so comparing a
+      // well-known one literally never matches and the rule silently never
+      // fires. dbus-daemon resolves it; this did not, which made every
+      // signal-driven ObjectManager test pass against the daemon and fail here.
+      const sender = await client();
+      await request(sender, 'com.example.Named');
+      const listener = await client();
+      const seen = await watch(
+        listener,
+        "type='signal',sender='com.example.Named',interface='com.example.ByName'",
+        msg => msg['interface'] === 'com.example.ByName'
+      );
+      sender.sendSignal('/o', 'com.example.ByName', 'Fired', 's', ['payload']);
+      await settle();
+      assert.strictEqual(seen.length, 1);
+      // Delivered under the unique name, as the spec requires.
+      assert.strictEqual(seen[0].sender, sender.name);
+    });
+
+    it('does not deliver from a different owner of the same shape', async () => {
+      const named = await client();
+      await request(named, 'com.example.Owner');
+      const other = await client();
+      const listener = await client();
+      const seen = await watch(
+        listener,
+        "type='signal',sender='com.example.Owner',interface='com.example.Scoped'",
+        msg => msg['interface'] === 'com.example.Scoped'
+      );
+      // Same signal, from a connection that does not own the name.
+      other.sendSignal('/o', 'com.example.Scoped', 'Fired', 's', ['nope']);
+      await settle();
+      assert.deepStrictEqual(seen, []);
+
+      named.sendSignal('/o', 'com.example.Scoped', 'Fired', 's', ['yes']);
+      await settle();
+      assert.strictEqual(seen.length, 1);
+      assert.deepStrictEqual(seen[0].body, ['yes']);
+    });
+
+    it('follows the name when it changes hands', async () => {
+      // The rule is written once; ownership moves afterwards. dbus-daemon
+      // re-evaluates, so a rule added before a service starts works once it
+      // does -- which is the normal case for anything watching a system service.
+      const listener = await client();
+      const seen = await watch(
+        listener,
+        "type='signal',sender='com.example.Moving',interface='com.example.Moved'",
+        msg => msg['interface'] === 'com.example.Moved'
+      );
+      const later = await client();
+      await request(later, 'com.example.Moving');
+      later.sendSignal('/o', 'com.example.Moved', 'Fired', 's', ['after']);
+      await settle();
+      assert.strictEqual(seen.length, 1);
+    });
+
     it('does not deliver one nobody asked for', async () => {
       const sender = await client();
       const listener = await client();

--- a/test/integration/managed-objects.js
+++ b/test/integration/managed-objects.js
@@ -1,0 +1,287 @@
+// bus.objects(): the client-side live view of a service's object tree.
+//
+// Exercised against our own ObjectManager implementation, which is the only
+// way to drive the interesting transitions on demand -- BlueZ will not add a
+// device because a test asked it to.
+
+const { describe, it, before, after, beforeEach } = require('node:test');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const { sessionBus } = require('../utils/shape');
+
+const NO_BUS =
+  !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
+
+const SERVICE = 'com.github.sidorares.dbusnative.Tree';
+const ROOT = '/com/github/sidorares/dbusnative/Tree';
+const DEVICE = 'com.github.sidorares.dbusnative.TreeDevice';
+const EXTRA = 'com.github.sidorares.dbusnative.TreeExtra';
+
+const deviceIface = {
+  name: DEVICE,
+  methods: {},
+  signals: {},
+  properties: { Name: 's', Rssi: 'n', Secret: { type: 's', access: 'write' } }
+};
+
+const extraIface = {
+  name: EXTRA,
+  methods: {},
+  signals: {},
+  properties: { Tag: 's' }
+};
+
+const impl = fields => {
+  const o = Object.assign(Object.create(EventEmitter.prototype), fields);
+  EventEmitter.call(o);
+  return o;
+};
+
+const settle = () => new Promise(resolve => setTimeout(resolve, 120));
+
+describe('integration: bus.objects', { timeout: 15000, skip: NO_BUS }, () => {
+  let serviceBus, clientBus, view;
+
+  const whenReady = bus =>
+    new Promise((resolve, reject) =>
+      bus.getId(err => (err ? reject(err) : resolve()))
+    );
+
+  before(async () => {
+    serviceBus = sessionBus();
+    clientBus = sessionBus();
+    await Promise.all([whenReady(serviceBus), whenReady(clientBus)]);
+    await new Promise((resolve, reject) =>
+      serviceBus.requestName(SERVICE, 0, err => (err ? reject(err) : resolve()))
+    );
+    serviceBus.exportObjectManager(ROOT);
+  });
+
+  after(async () => {
+    if (view) await view.close();
+    for (const bus of [serviceBus, clientBus]) if (bus) bus.connection.end();
+  });
+
+  // A fresh tree and a fresh view per test, so ordering between them cannot
+  // matter -- these mutate the very thing they observe.
+  beforeEach(async () => {
+    if (view) await view.close();
+    for (const path of Object.keys(serviceBus.exportedObjects)) {
+      if (path.startsWith(`${ROOT}/`)) serviceBus.unexportInterface(path);
+    }
+    serviceBus.exportInterface(
+      impl({ Name: 'hci0', Rssi: -40, Secret: 'shh' }),
+      `${ROOT}/dev0`,
+      deviceIface
+    );
+    view = await clientBus.objects(SERVICE, ROOT);
+  });
+
+  describe('the snapshot', () => {
+    it('is the whole tree, in plain values', () => {
+      assert.deepStrictEqual(view.objects, {
+        [`${ROOT}/dev0`]: { [DEVICE]: { Name: 'hci0', Rssi: -40 } }
+      });
+    });
+
+    it('answers paths(), get() and filter()', () => {
+      assert.deepStrictEqual(view.paths(), [`${ROOT}/dev0`]);
+      assert.deepStrictEqual(view.get(`${ROOT}/dev0`), {
+        [DEVICE]: { Name: 'hci0', Rssi: -40 }
+      });
+      assert.strictEqual(view.get('/nope'), undefined);
+      // filter() drops the interface name -- the caller just supplied it.
+      assert.deepStrictEqual(view.filter(DEVICE), {
+        [`${ROOT}/dev0`]: { Name: 'hci0', Rssi: -40 }
+      });
+      assert.deepStrictEqual(view.filter('com.example.Absent'), {});
+    });
+
+    it('resolves the well-known name to its owner', () => {
+      assert.match(view.owner, /^:\d+\.\d+$/);
+    });
+  });
+
+  describe('InterfacesAdded', () => {
+    it('adds the object and emits', async () => {
+      const seen = [];
+      view.on('added', (path, interfaces) => seen.push([path, interfaces]));
+
+      serviceBus.exportInterface(
+        impl({ Name: 'hci1', Rssi: -70, Secret: 'x' }),
+        `${ROOT}/dev1`,
+        deviceIface
+      );
+      await settle();
+
+      assert.deepStrictEqual(seen, [
+        [`${ROOT}/dev1`, { [DEVICE]: { Name: 'hci1', Rssi: -70 } }]
+      ]);
+      assert.deepStrictEqual(view.filter(DEVICE), {
+        [`${ROOT}/dev0`]: { Name: 'hci0', Rssi: -40 },
+        [`${ROOT}/dev1`]: { Name: 'hci1', Rssi: -70 }
+      });
+    });
+
+    it('merges a second interface onto an object it already has', async () => {
+      serviceBus.exportInterface(
+        impl({ Tag: 'blue' }),
+        `${ROOT}/dev0`,
+        extraIface
+      );
+      await settle();
+
+      assert.deepStrictEqual(view.get(`${ROOT}/dev0`), {
+        [DEVICE]: { Name: 'hci0', Rssi: -40 },
+        [EXTRA]: { Tag: 'blue' }
+      });
+    });
+  });
+
+  describe('InterfacesRemoved', () => {
+    it('drops the object and emits', async () => {
+      const seen = [];
+      view.on('removed', (path, names) => seen.push([path, names]));
+
+      serviceBus.unexportInterface(`${ROOT}/dev0`);
+      await settle();
+
+      assert.deepStrictEqual(seen, [[`${ROOT}/dev0`, [DEVICE]]]);
+      assert.deepStrictEqual(view.objects, {});
+    });
+
+    it('keeps the object while another interface remains', async () => {
+      serviceBus.exportInterface(
+        impl({ Tag: 'blue' }),
+        `${ROOT}/dev0`,
+        extraIface
+      );
+      await settle();
+      serviceBus.unexportInterface(`${ROOT}/dev0`, EXTRA);
+      await settle();
+
+      assert.deepStrictEqual(view.get(`${ROOT}/dev0`), {
+        [DEVICE]: { Name: 'hci0', Rssi: -40 }
+      });
+    });
+  });
+
+  describe('PropertiesChanged', () => {
+    it('updates the value in place and emits', async () => {
+      const seen = [];
+      view.on('changed', (path, iface, changed) =>
+        seen.push([path, iface, changed])
+      );
+
+      serviceBus.emitPropertiesChanged(`${ROOT}/dev0`, DEVICE, { Rssi: -55 });
+      await settle();
+
+      assert.deepStrictEqual(seen, [[`${ROOT}/dev0`, DEVICE, { Rssi: -55 }]]);
+      assert.deepStrictEqual(view.get(`${ROOT}/dev0`)[DEVICE], {
+        Name: 'hci0',
+        Rssi: -55
+      });
+    });
+
+    it('drops an invalidated property rather than keeping a stale value', async () => {
+      serviceBus.emitPropertiesChanged(`${ROOT}/dev0`, DEVICE, {}, ['Rssi']);
+      await settle();
+
+      assert.deepStrictEqual(view.get(`${ROOT}/dev0`)[DEVICE], {
+        Name: 'hci0'
+      });
+    });
+
+    it('can be switched off, and then the value goes stale', async () => {
+      await view.close();
+      view = await clientBus.objects(SERVICE, ROOT, { properties: false });
+
+      serviceBus.emitPropertiesChanged(`${ROOT}/dev0`, DEVICE, { Rssi: -99 });
+      await settle();
+
+      assert.strictEqual(view.get(`${ROOT}/dev0`)[DEVICE].Rssi, -40);
+    });
+  });
+
+  describe('lifetime', () => {
+    it('stops updating once closed', async () => {
+      await view.close();
+      serviceBus.exportInterface(
+        impl({ Name: 'after', Rssi: 0, Secret: '' }),
+        `${ROOT}/dev9`,
+        deviceIface
+      );
+      await settle();
+      assert.ok(!(`${ROOT}/dev9` in view.objects));
+    });
+
+    it('closes twice without complaint', async () => {
+      await view.close();
+      await view.close();
+    });
+
+    it('releases through Symbol.asyncDispose', async () => {
+      const scoped = await clientBus.objects(SERVICE, ROOT);
+      assert.strictEqual(typeof scoped[Symbol.asyncDispose], 'function');
+      await scoped[Symbol.asyncDispose]();
+      assert.strictEqual(scoped.closed, true);
+    });
+
+    it('says so when the service goes away, rather than going quietly stale', async () => {
+      // A view whose service restarts under a new owner is not just out of
+      // date, it is watching a name nobody answers on. Staying silent about
+      // that is how a program stops working with no symptom to chase.
+      const stale = new Promise(resolve => view.once('stale', resolve));
+      await new Promise((resolve, reject) =>
+        serviceBus.releaseName(SERVICE, err => (err ? reject(err) : resolve()))
+      );
+      assert.strictEqual(await stale, '', 'no new owner');
+
+      // Put it back for the tests that follow.
+      await new Promise((resolve, reject) =>
+        serviceBus.requestName(SERVICE, 0, err =>
+          err ? reject(err) : resolve()
+        )
+      );
+    });
+  });
+
+  describe('the subscribe-then-fetch order', () => {
+    // The bug this class exists to not have: fetch the snapshot first and
+    // there is a window where an object appears, its InterfacesAdded goes
+    // nowhere because nothing is subscribed yet, and the view is permanently
+    // missing it.
+    //
+    // Timing that window from outside does not work -- an export issued right
+    // after calling objects() lands while the *name lookup* is still in
+    // flight, so it is in the snapshot and the test passes either way.
+    // Verified: with the order deliberately reversed, that version stayed
+    // green. So the service exports at the one moment that is provably inside
+    // the window, on seeing the GetManagedObjects call itself.
+    it('does not lose an object that appears while it is starting', async () => {
+      await view.close();
+
+      const exportOnFetch = msg => {
+        if (msg.member !== 'GetManagedObjects') return;
+        serviceBus.connection.removeListener('message', exportOnFetch);
+        // The bus's own handler is registered first and has already written
+        // the reply, so this is strictly after the snapshot was taken.
+        serviceBus.exportInterface(
+          impl({ Name: 'racy', Rssi: -1, Secret: '' }),
+          `${ROOT}/racy`,
+          deviceIface
+        );
+      };
+      serviceBus.connection.on('message', exportOnFetch);
+
+      view = await clientBus.objects(SERVICE, ROOT);
+      await settle();
+
+      serviceBus.connection.removeListener('message', exportOnFetch);
+      assert.ok(
+        `${ROOT}/racy` in view.objects,
+        'an object added during startup must not be lost'
+      );
+    });
+  });
+});


### PR DESCRIPTION
Follows #364 with the client half — the one that actually removes the hand-decoding.

`GetManagedObjects` returns `a{oa{sa{sv}}}`, three levels of dict with variants at the bottom, and then it has to be kept current from `InterfacesAdded`, `InterfacesRemoved` and `PropertiesChanged`, each matched against the right service. Everyone using BlueZ or NetworkManager writes this, and writes it slightly wrong.

```js
const bluez = await bus.objects('org.bluez', '/');

bluez.filter('org.bluez.Device1');
// { '/org/bluez/hci0/dev_AA': { Alias: 'Headphones', Connected: false } }

bluez.on('added', (path, interfaces) => { … });
await bluez.close();
```

Values are plain in **every** connection shape — a view whose contents depended on how the connection was configured would be useless to write against.

## Three decisions with consequences

**It subscribes before it fetches.** Fetching first leaves a window where an object appears, its `InterfacesAdded` goes nowhere, and the view is permanently missing it. Signals arriving during startup are buffered and replayed onto the snapshot.

**`PropertiesChanged` is tracked too**, so a *value* stays current and not just the set of objects. An invalidated property is dropped rather than left at its old value — keeping one the service has disowned is how a view starts lying. `{ properties: false }` skips it and the match rule it costs.

**A `'stale'` event fires if the service is replaced**, rather than the view silently watching a name nobody answers on. It deliberately does not resynchronise: re-fetching would race whatever the caller is doing with the view, and a half-updated tree is worse than a stale one that says so.

It implements `Symbol.asyncDispose`, so the match rules — the resource people forget — can be scoped rather than released by hand. That is the first bit of [BIG_FUTURE_PLANS §1](https://github.com/sidorares/dbus-native/blob/master/BIG_FUTURE_PLANS.md) to land anywhere:

```js
await using bluez = await bus.objects('org.bluez', '/');
```

## It found a real broker bug

A signal carries the sender's **unique** name, so a match rule saying `sender='org.bluez'` never fired — the broker compared it literally. dbus-daemon resolves a well-known name to its current owner, and re-evaluates as the name changes hands, so a rule written before a service starts works once it does.

Every signal-driven test here passed against `dbus-daemon` and failed against the broker. That is exactly what running both is for, and it is the first time the two have actually disagreed. Three unit tests in `test/broker.js` cover it — resolution, scoping to the real owner, and following the name when it moves — and all three fail without the fix.

## The race test needed a second attempt

Worth recording, because the first version was worthless and looked fine. The obvious test — export an object right after calling `objects()` — **passed even with the ordering deliberately reversed**, because the export lands while the *name lookup* is still in flight and so ends up in the snapshot either way.

It now exports on seeing the `GetManagedObjects` call itself, which is provably inside the window. Verified both directions: green with subscribe-then-fetch, red with it reversed.

## Verification

| | dbus-daemon | broker |
|---|---|---|
| classic | 189/189 | 189/189 |
| `2.0` | 189/189 | 189/189 |
| `2.0-wrap` | 189/189 | 189/189 |

`npm test` — 840 unit tests, lint, format, tsc — green.
