### PR TITLE
feat: bus.close(), bus.watch() and bus.ownName(), each disposable

### DIFF
--- a/BIG_FUTURE_PLANS.md
+++ b/BIG_FUTURE_PLANS.md
@@ -316,17 +316,18 @@ nothing behind it, is cheap insurance and belongs in this release train.
 
 Two of these change decisions the original made.
 
-| feature                                | status on Node 26          | consequence                               |
-| -------------------------------------- | -------------------------- | ----------------------------------------- |
-| `await using` / `Symbol.asyncDispose`  | ✅ native, syntax included | §1 is unblocked                           |
-| `AsyncDisposableStack`                 | ✅ native                  | §1                                        |
-| `Promise.withResolvers()`              | ✅ native                  | simplifies the cookie table               |
-| `AbortSignal.timeout()`, `Error.cause` | ✅ native                  | shipped already                           |
-| **`require()` of an ESM module**       | ✅ **unflagged** (22.12+)  | **weakens the ESM-only objection**        |
-| **TypeScript type stripping**          | ✅ **unflagged**           | changes the codegen story, not decorators |
-| Sync iterator helpers                  | ✅ native                  | —                                         |
-| **Async iterator helpers**             | ❌ still absent            | §2.4 — callbacks lead                     |
-| **Decorators**                         | ❌ still a `SyntaxError`   | §7 stays `defineInterface`                |
+| feature                                | status on Node 26         | consequence                               |
+| -------------------------------------- | ------------------------- | ----------------------------------------- |
+| `Symbol.asyncDispose`                  | ✅ from Node **20**       | §1 works across the whole supported range |
+| `await using` keyword                  | ✅ from Node **24**       | consumer's choice; unusable in our tests  |
+| `AsyncDisposableStack`                 | ✅ from Node **24**       | §1, feature-detected                      |
+| `Promise.withResolvers()`              | ✅ native                 | simplifies the cookie table               |
+| `AbortSignal.timeout()`, `Error.cause` | ✅ native                 | shipped already                           |
+| **`require()` of an ESM module**       | ✅ **unflagged** (22.12+) | **weakens the ESM-only objection**        |
+| **TypeScript type stripping**          | ✅ **unflagged**          | changes the codegen story, not decorators |
+| Sync iterator helpers                  | ✅ native                 | —                                         |
+| **Async iterator helpers**             | ❌ still absent           | §2.4 — callbacks lead                     |
+| **Decorators**                         | ❌ still a `SyntaxError`  | §7 stays `defineInterface`                |
 
 **`require(esm)` is the significant one.** The original argued for ESM-only on
 the grounds that a dual package ships two copies of `Variant` and breaks
@@ -393,8 +394,13 @@ The useful cut, now that the gate exists to verify it.
 
 **Additive, ships whenever it is ready:**
 
-- `await using` / `Symbol.asyncDispose` — implementing the protocol breaks
-  nothing
+- ~~`await using` / `Symbol.asyncDispose`~~ ✅ shipped. `bus.close()`,
+  `bus.watch()` and `bus.ownName()`, each disposable. Measured while building
+  it: `Symbol.asyncDispose` is available from Node 20 but `AsyncDisposableStack`
+  and the `using` keyword only from 24 — so the protocol works on the whole
+  supported range and the keyword stays the consumer's choice, exactly as this
+  document argued. The keyword cannot appear in our own tests at all: it is a
+  syntax error on 20 and 22, which fails the file before a skip could run.
 - `bus.proxy()` — a new method beside `getService()`
 - `bus.objects()` and `exportTree()` (§3.1)
 - signal subscriptions and the iterable form (§2.4)

--- a/docs/api.md
+++ b/docs/api.md
@@ -243,6 +243,60 @@ bus.signals.on(key, (body, signature) => console.log(body));
 The [proxy API](#proxy-api) wraps both steps — `iface.on('Pinged', handler)`
 adds the match rule for you.
 
+### Scoped resources
+
+A match rule is the thing people forget to remove. A process that adds them and
+never removes them has the bus deliver steadily more traffic to it, for signals
+nothing is still listening for. `bus.watch()` and `bus.ownName()` hand back
+something that releases itself:
+
+```js
+const sub = await bus.watch("type='signal',interface='org.example.Iface'");
+// …
+await sub.remove();
+
+const reg = await bus.ownName('com.example.Greeter');
+if (!reg.isPrimaryOwner) console.log('queued behind', reg.result);
+await reg.release();
+```
+
+Both implement `Symbol.asyncDispose`, as does the bus itself and the raw
+connection, so on Node 24+ the language can do it:
+
+```js
+await using bus = dbus.sessionBus();
+await using reg = await bus.ownName('com.example.Greeter');
+await using sub = await bus.watch(
+  "type='signal',interface='org.example.Iface'"
+);
+```
+
+or with `AsyncDisposableStack`, which is the shape of a whole service:
+
+```js
+await using stack = new AsyncDisposableStack();
+const bus = stack.use(dbus.sessionBus());
+stack.use(await bus.ownName('com.example.Greeter'));
+stack.use(await bus.watch("type='signal',interface='org.example.Iface'"));
+// everything unwinds in reverse, whether the scope ends normally or throws
+```
+
+**The protocol works on every supported Node; the syntax does not.**
+`Symbol.asyncDispose` is available from Node 20, so `await x[Symbol.asyncDispose]()`
+and the `close()`/`remove()`/`release()` methods work on the whole supported
+range. `AsyncDisposableStack` and the `using` keyword need Node 24 — that is
+the consumer's choice, not a floor this package imposes.
+
+`bus.close()` resolves once the connection is really closed, by which point
+every in-flight call has been failed with `ConnectionClosedError` rather than
+left waiting. Messages already sent are flushed on the way out. It is
+idempotent and safe on a connection that has already gone.
+
+It deliberately does **not** remove match rules or release names first: the bus
+drops both when the connection goes, so unwinding them by hand would be round
+trips whose only effect is a slower shutdown. Scope them individually when they
+need to end _before_ the connection does — which is the case that matters.
+
 ### Properties
 
 | property         |                                                           |

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,7 +13,15 @@ module.exports = [
       ecmaVersion: 2023,
       sourceType: 'commonjs',
       globals: {
-        ...globals.node
+        ...globals.node,
+        // Explicit resource management. Measured, not assumed:
+        // `Symbol.asyncDispose` exists from Node 20, but these two stacks only
+        // from Node 24 -- so code using them has to feature-detect on our floor
+        // of 20.8. The `using` *keyword* also needs 24 and must not appear in
+        // source or tests: it is a syntax error on the older two, which fails
+        // the file before any skip can run.
+        DisposableStack: 'readonly',
+        AsyncDisposableStack: 'readonly'
       }
     },
     rules: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -295,6 +295,8 @@ export interface DBusConnection extends EventEmitter {
     ayBuffer?: boolean;
     variants?: 'tree' | 'plain' | 'wrap';
   }): this;
+  /** End the transport, resolving once it is really down. */
+  [Symbol.asyncDispose](): Promise<void>;
 
   on(event: 'connect', listener: () => void): this;
   on(event: 'message', listener: (msg: Message) => void): this;
@@ -562,6 +564,25 @@ export interface ManagedObjects extends EventEmitter {
   on(event: string, listener: (...args: any[]) => void): this;
 }
 
+/** A match rule that can be removed, from `bus.watch()`. */
+export interface Subscription {
+  readonly rule: string;
+  readonly removed: boolean;
+  remove(): Promise<void>;
+  [Symbol.asyncDispose](): Promise<void>;
+}
+
+/** A well-known name that can be released, from `bus.ownName()`. */
+export interface NameRegistration {
+  readonly name: string;
+  /** The RequestName reply: 1 primary owner, 2 queued, 3 taken, 4 already ours. */
+  readonly result: number;
+  readonly isPrimaryOwner: boolean;
+  readonly released: boolean;
+  release(): Promise<void>;
+  [Symbol.asyncDispose](): Promise<void>;
+}
+
 export interface MessageBus {
   connection: DBusConnection;
   serial: number;
@@ -637,6 +658,40 @@ export interface MessageBus {
 
   /** Paths serving `org.freedesktop.DBus.ObjectManager`. */
   objectManagers: Set<string>;
+
+  /**
+   * Close the connection, resolving once it is actually closed.
+   *
+   * Every in-flight call has been failed with `ConnectionClosedError` by then,
+   * and writes already issued are flushed on the way out. Idempotent.
+   *
+   * It does not remove match rules or release names first — the bus drops both
+   * when the connection goes, so unwinding them by hand would only make
+   * shutdown slower. Use `watch()` and `ownName()` for resources that need to
+   * end before the connection does.
+   */
+  close(): Promise<void>;
+  [Symbol.asyncDispose](): Promise<void>;
+
+  /**
+   * Add a match rule, and get something that removes it.
+   *
+   * ```js
+   * await using sub = await bus.watch("type='signal',interface='…'");
+   * ```
+   *
+   * This is the resource people forget: a process that adds match rules and
+   * never removes them has the bus deliver steadily more traffic to it.
+   */
+  watch(rule: string): Promise<Subscription>;
+
+  /**
+   * Request a well-known name, and get something that releases it.
+   *
+   * Not getting the name is reported rather than thrown — being queued behind
+   * another owner is a legitimate outcome. Check `isPrimaryOwner`.
+   */
+  ownName(name: string, flags?: number): Promise<NameRegistration>;
 
   /**
    * A live view of the objects a service manages below `path`.

--- a/index.js
+++ b/index.js
@@ -208,6 +208,23 @@ function createConnection(opts) {
     return self;
   };
 
+  // Lets a raw connection be scoped the way a MessageBus can be. Resolves once
+  // the transport is actually down rather than merely asked to close, so a
+  // caller that awaits it knows the socket has gone.
+  self[Symbol.asyncDispose] = () =>
+    new Promise(resolve => {
+      if (stream.destroyed) return setImmediate(resolve);
+      let settled = false;
+      const done = () => {
+        if (settled) return;
+        settled = true;
+        resolve();
+      };
+      self.once('close', done);
+      self.once('end', done);
+      stream.end();
+    });
+
   // The shapes the parser hands back, changeable after the connection is up.
   //
   // This exists for `dbus-native/compat`, and it is the only faithful way to

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -80,6 +80,119 @@ module.exports = function bus(conn, opts) {
   conn.on('close', failPendingCalls);
   conn.on('end', () => failPendingCalls());
 
+  /**
+   * Close the connection, and resolve once it is actually closed.
+   *
+   * By the time this settles every in-flight call has been failed with
+   * `ConnectionClosedError`, rather than left waiting for a reply that cannot
+   * arrive. Writes already issued are flushed on the way out: `end()` uncorks
+   * the batch `writeMessage` builds, so a signal sent immediately before
+   * closing still goes out. Verified rather than assumed.
+   *
+   * It deliberately does **not** remove match rules or release names first.
+   * The bus drops both when the connection goes, so unwinding them by hand
+   * would be round trips whose only effect is a slower shutdown. Scope them
+   * with `watch()` and `ownName()` when they need to end before the connection
+   * does -- that is the case where it matters, and it is a different one.
+   *
+   * Idempotent, and safe on a connection that has already gone.
+   */
+  this.close = function () {
+    return new Promise(resolve => {
+      const stream = conn.stream;
+      if (closed || !stream || stream.destroyed) {
+        // Resolve on a later tick either way, so a caller racing the teardown
+        // does not sometimes get a synchronous answer and sometimes not.
+        return setImmediate(resolve);
+      }
+      let settled = false;
+      const done = () => {
+        if (settled) return;
+        settled = true;
+        resolve();
+      };
+      // 'close' is the real signal. 'end' is a fallback for a caller-supplied
+      // stream that never emits one -- a PassThrough, say -- which would
+      // otherwise hang here forever.
+      conn.once('close', done);
+      conn.once('end', done);
+      conn.end();
+    });
+  };
+
+  // Lets a connection be scoped: `await using bus = dbus.sessionBus()`.
+  // Implemented whatever the consumer's Node version -- only the `using`
+  // keyword needs 24, and that is their choice rather than a floor we impose.
+  this[Symbol.asyncDispose] = function () {
+    return self.close();
+  };
+
+  /**
+   * Add a match rule, and get something that removes it.
+   *
+   *     await using sub = await bus.watch("type='signal',interface='...'");
+   *
+   * This is the resource people forget. A long-lived process that adds match
+   * rules and never removes them has the bus deliver steadily more traffic to
+   * it, for signals nothing is still listening for.
+   */
+  this.watch = async function (rule) {
+    await self.addMatch(rule);
+    let removed = false;
+    const subscription = {
+      rule,
+      get removed() {
+        return removed;
+      },
+      async remove() {
+        if (removed) return;
+        removed = true;
+        // Nothing to remove once the connection has gone -- the bus dropped
+        // the rule with it. Checked rather than caught, so a RemoveMatch that
+        // fails for any other reason is still reported.
+        if (closed) return;
+        await self.removeMatch(rule);
+      },
+      async [Symbol.asyncDispose]() {
+        await subscription.remove();
+      }
+    };
+    return subscription;
+  };
+
+  /**
+   * Request a well-known name, and get something that releases it.
+   *
+   *     await using reg = await bus.ownName('com.example.Greeter');
+   *     if (!reg.isPrimaryOwner) { ... }
+   *
+   * `result` is the RequestName reply code, because not getting the name is a
+   * legitimate outcome rather than an error: 1 primary owner, 2 queued,
+   * 3 taken, 4 already ours.
+   */
+  this.ownName = async function (name, flags = 0) {
+    const result = await self.requestName(name, flags);
+    let released = false;
+    const registration = {
+      name,
+      result,
+      isPrimaryOwner: result === 1,
+      get released() {
+        return released;
+      },
+      async release() {
+        if (released) return;
+        released = true;
+        if (closed) return;
+        await self.releaseName(name);
+      },
+      async [Symbol.asyncDispose]() {
+        await registration.release();
+      }
+    };
+    return registration;
+  };
+
   // Returns a promise when no callback is given; the callback path is
   // unchanged. See lib/promisify.js.
   // invoke(msg, callback)

--- a/test/integration/disposal.js
+++ b/test/integration/disposal.js
@@ -1,0 +1,306 @@
+// Scoped resources: bus.close(), bus.watch(), bus.ownName(), and the
+// Symbol.asyncDispose that lets the language release all three.
+//
+// BIG_FUTURE_PLANS 1. The value is not the syntax, it is that a match rule
+// removed by leaving a scope is one nobody has to remember to remove -- and
+// forgetting is why a long-lived process ends up being sent signals nothing
+// still listens for.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('assert');
+const { sessionBus } = require('../utils/shape');
+
+const NO_BUS =
+  !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
+
+const NAME = 'com.github.sidorares.dbusnative.Scoped';
+const OBJECT_PATH = '/com/github/sidorares/dbusnative/Scoped';
+const IFACE = 'com.github.sidorares.dbusnative.ScopedIface';
+
+const settle = (ms = 120) => new Promise(resolve => setTimeout(resolve, ms));
+
+describe(
+  'integration: scoped resources',
+  { timeout: 15000, skip: NO_BUS },
+  () => {
+    let helper;
+
+    const whenReady = bus =>
+      new Promise((resolve, reject) =>
+        bus.getId(err => (err ? reject(err) : resolve()))
+      );
+
+    before(async () => {
+      helper = sessionBus();
+      await whenReady(helper);
+    });
+
+    after(async () => {
+      if (helper) await helper.close();
+    });
+
+    describe('bus.close()', () => {
+      it('resolves once the connection is really gone', async () => {
+        const bus = sessionBus();
+        await whenReady(bus);
+        await bus.close();
+        assert.strictEqual(bus.connection.stream.destroyed, true);
+      });
+
+      it('fails in-flight calls rather than leaving them waiting', async () => {
+        const bus = sessionBus();
+        await whenReady(bus);
+        // A call to a name nobody owns and nobody will answer, closed underneath.
+        const pending = bus.invoke({
+          destination: NAME,
+          path: OBJECT_PATH,
+          interface: IFACE,
+          member: 'NeverAnswered'
+        });
+        const settledWith = pending.then(
+          () => 'resolved',
+          err => err.constructor.name
+        );
+        await bus.close();
+        // Either the daemon's ServiceUnknown got there first or the close did;
+        // what matters is that it settled at all.
+        const outcome = await settledWith;
+        assert.ok(
+          ['DBusError', 'ConnectionClosedError'].includes(outcome),
+          `expected an error, got ${outcome}`
+        );
+      });
+
+      it('flushes a message sent immediately before it', async () => {
+        // writeMessage corks and uncorks on nextTick, so closing in the same
+        // tick as the last send is exactly the case that could drop it.
+        const listener = sessionBus();
+        await whenReady(listener);
+        const sub = await listener.watch(
+          `type='signal',interface='${IFACE}',member='Parting'`
+        );
+        const seen = [];
+        listener.signals.on(
+          listener.mangle(OBJECT_PATH, IFACE, 'Parting'),
+          body => seen.push(body)
+        );
+
+        const sender = sessionBus();
+        await whenReady(sender);
+        sender.sendSignal(OBJECT_PATH, IFACE, 'Parting', 's', ['last words']);
+        await sender.close();
+
+        await settle();
+        assert.deepStrictEqual(seen, [['last words']]);
+        await sub.remove();
+        await listener.close();
+      });
+
+      it('is idempotent, and safe on a connection already gone', async () => {
+        const bus = sessionBus();
+        await whenReady(bus);
+        await bus.close();
+        await bus.close();
+        await bus.close();
+      });
+
+      it('is what Symbol.asyncDispose does', async () => {
+        const bus = sessionBus();
+        await whenReady(bus);
+        assert.strictEqual(typeof bus[Symbol.asyncDispose], 'function');
+        await bus[Symbol.asyncDispose]();
+        assert.strictEqual(bus.connection.stream.destroyed, true);
+      });
+
+      it('works on a raw connection too', async () => {
+        const bus = sessionBus();
+        await whenReady(bus);
+        const conn = bus.connection;
+        assert.strictEqual(typeof conn[Symbol.asyncDispose], 'function');
+        await conn[Symbol.asyncDispose]();
+        assert.strictEqual(conn.stream.destroyed, true);
+      });
+    });
+
+    describe('bus.watch()', () => {
+      const emit = payload =>
+        helper.sendSignal(OBJECT_PATH, IFACE, 'Watched', 's', [payload]);
+
+      const collector = bus => {
+        const seen = [];
+        bus.signals.on(bus.mangle(OBJECT_PATH, IFACE, 'Watched'), body =>
+          seen.push(body[0])
+        );
+        return seen;
+      };
+
+      it('delivers while the subscription is alive', async () => {
+        const bus = sessionBus();
+        await whenReady(bus);
+        const seen = collector(bus);
+        const sub = await bus.watch(
+          `type='signal',interface='${IFACE}',member='Watched'`
+        );
+
+        emit('one');
+        await settle();
+        assert.deepStrictEqual(seen, ['one']);
+
+        await sub.remove();
+        await bus.close();
+      });
+
+      it('stops delivering once removed', async () => {
+        const bus = sessionBus();
+        await whenReady(bus);
+        const seen = collector(bus);
+        const sub = await bus.watch(
+          `type='signal',interface='${IFACE}',member='Watched'`
+        );
+
+        emit('before');
+        await settle();
+        await sub.remove();
+        emit('after');
+        await settle();
+
+        assert.deepStrictEqual(seen, ['before'], 'the rule really went away');
+        await bus.close();
+      });
+
+      it('removes through Symbol.asyncDispose, and only once', async () => {
+        const bus = sessionBus();
+        await whenReady(bus);
+        const sub = await bus.watch(
+          `type='signal',interface='${IFACE}',member='Watched'`
+        );
+        await sub[Symbol.asyncDispose]();
+        assert.strictEqual(sub.removed, true);
+        // A second RemoveMatch for a rule that is gone is an error on the bus,
+        // so this passing is the guard working.
+        await sub[Symbol.asyncDispose]();
+        await sub.remove();
+        await bus.close();
+      });
+
+      it('does not try to remove anything after the connection has gone', async () => {
+        const bus = sessionBus();
+        await whenReady(bus);
+        const sub = await bus.watch(
+          `type='signal',interface='${IFACE}',member='Watched'`
+        );
+        await bus.close();
+        // The bus dropped the rule with the connection. Reaching for it would be
+        // a call on a dead socket.
+        await sub.remove();
+        assert.strictEqual(sub.removed, true);
+      });
+    });
+
+    describe('bus.ownName()', () => {
+      it('takes the name and reports being the primary owner', async () => {
+        const bus = sessionBus();
+        await whenReady(bus);
+        const reg = await bus.ownName(NAME);
+
+        assert.strictEqual(reg.name, NAME);
+        assert.strictEqual(reg.result, 1);
+        assert.strictEqual(reg.isPrimaryOwner, true);
+        assert.strictEqual(await helper.nameHasOwner(NAME), true);
+
+        await reg.release();
+        await bus.close();
+      });
+
+      it('gives the name back on release', async () => {
+        const bus = sessionBus();
+        await whenReady(bus);
+        const reg = await bus.ownName(NAME);
+        await reg.release();
+        assert.strictEqual(reg.released, true);
+        assert.strictEqual(await helper.nameHasOwner(NAME), false);
+        await bus.close();
+      });
+
+      it('reports queueing rather than throwing', async () => {
+        // Not getting a name is a legitimate outcome, not an error -- a service
+        // may well want to know it is the standby rather than crash.
+        const first = sessionBus();
+        const second = sessionBus();
+        await Promise.all([whenReady(first), whenReady(second)]);
+
+        const held = await first.ownName(NAME);
+        const queued = await second.ownName(NAME);
+        assert.strictEqual(queued.result, 2, 'IN_QUEUE');
+        assert.strictEqual(queued.isPrimaryOwner, false);
+
+        await queued.release();
+        await held.release();
+        await first.close();
+        await second.close();
+      });
+
+      it('releases through Symbol.asyncDispose', async () => {
+        const bus = sessionBus();
+        await whenReady(bus);
+        const reg = await bus.ownName(NAME);
+        await reg[Symbol.asyncDispose]();
+        assert.strictEqual(await helper.nameHasOwner(NAME), false);
+        await bus.close();
+      });
+    });
+
+    // `await using` is deliberately not written anywhere in here. The keyword
+    // needs Node 24 and this package supports 20.8, so a file containing it
+    // would be a *syntax* error on the older two -- before any skip could run.
+    // That is the same split the library takes: it implements the protocol on
+    // every supported Node, and the keyword is the consumer's choice.
+    //
+    // So these drive the stack by hand. What `await using` adds on top is
+    // purely that the language calls disposeAsync() for you.
+    describe('composed with AsyncDisposableStack', () => {
+      const NO_STACK =
+        typeof AsyncDisposableStack !== 'function' &&
+        'AsyncDisposableStack needs a newer Node';
+
+      it('unwinds everything in reverse', { skip: NO_STACK }, async () => {
+        // The shape of a service: a connection, a name, and a subscription --
+        // the try/finally pyramid this replaces is the one nobody writes.
+        const stack = new AsyncDisposableStack();
+        const bus = sessionBus();
+        await whenReady(bus);
+        stack.use(bus);
+        stack.use(await bus.ownName(NAME));
+        stack.use(
+          await bus.watch(`type='signal',interface='${IFACE}',member='Stacked'`)
+        );
+
+        assert.strictEqual(await helper.nameHasOwner(NAME), true);
+
+        await stack.disposeAsync();
+
+        assert.strictEqual(bus.connection.stream.destroyed, true);
+        assert.strictEqual(await helper.nameHasOwner(NAME), false);
+      });
+
+      it('unwinds through a failure', { skip: NO_STACK }, async () => {
+        const stack = new AsyncDisposableStack();
+        const bus = sessionBus();
+        await whenReady(bus);
+        stack.use(bus);
+        stack.use(await bus.ownName(NAME));
+
+        // What `await using` does when the block throws.
+        try {
+          throw new Error('deliberate');
+        } catch (err) {
+          await stack.disposeAsync();
+          assert.strictEqual(err.message, 'deliberate');
+        }
+
+        assert.strictEqual(bus.connection.stream.destroyed, true);
+        assert.strictEqual(await helper.nameHasOwner(NAME), false);
+      });
+    });
+  }
+);


### PR DESCRIPTION
[BIG_FUTURE_PLANS §1](https://github.com/sidorares/dbus-native/blob/master/BIG_FUTURE_PLANS.md). A connection owns a socket, pending replies, match rules and possibly a well-known name — and today every one of those is released by hand. The `try`/`finally` pyramid that does it properly is the one nobody writes, which is why long-lived processes end up being sent signals nothing still listens for.

```js
const sub = await bus.watch("type='signal',interface='org.example.Iface'");
const reg = await bus.ownName('com.example.Greeter');
await bus.close();
```

All three implement `Symbol.asyncDispose`, so on Node 24+ the language does it:

```js
await using stack = new AsyncDisposableStack();
const bus = stack.use(dbus.sessionBus());
stack.use(await bus.ownName('com.example.Greeter'));
stack.use(await bus.watch("type='signal',interface='org.example.Iface'"));
// unwinds in reverse, whether the scope ends normally or throws
```

## `close()` does not unwind rules and names first — deliberately

The original sketch said it should: *"match rules removed, owned names released — in that order, and awaited"*. Having built it, that is wrong. **The bus drops both when the connection goes**, so unwinding them by hand would be round trips whose only effect is a slower shutdown.

What is worth scoping is a rule or a name that has to end *before* the connection does. That is a different case, and it is the one `watch()` and `ownName()` exist for.

`close()` does flush: `end()` uncorks the batch `writeMessage` builds, so a signal sent immediately before closing still goes out. Checked rather than assumed, and there is a test for it.

Not getting a name is **reported, not thrown** — being queued behind another owner is a legitimate outcome for a standby service, not an error. `reg.result` carries the RequestName code and `reg.isPrimaryOwner` is the usual question.

## The measurement that changed the tests

| | `Symbol.asyncDispose` | `AsyncDisposableStack` | `using` keyword |
|---|---|---|---|
| Node 20 | ✅ | ❌ | ❌ |
| Node 22 | ✅ | ❌ | ❌ |
| Node 24 | ✅ | ✅ | ✅ |

So the **protocol** works across the whole supported range — exactly the split this design argued for, now confirmed — but the **keyword cannot appear in our own source or tests at all**. It is a *syntax* error on 20 and 22, so a file containing it fails to parse before any `skip` could run. That is a sharper constraint than "don't require it of consumers", and I hit it: the first version of the test used `await using` and broke lint, which is what surfaced it.

The stack tests feature-detect instead, and `eslint.config.js` gains the two globals with the reasoning recorded next to them.

## Verification

Run on **Node 20.20, 22.16, 24.12 and 26** — 840 unit tests pass on each. Integration on the older two: 203 pass, 0 fail, 2 skipped (the `AsyncDisposableStack` pair, correctly).

| | dbus-daemon | broker |
|---|---|---|
| classic | 205/205 | 205/205 |
| `2.0` | 205/205 | 205/205 |
| `2.0-wrap` | 205/205 | 205/205 |
