### PR TITLE
feat: bus.proxy(), the remote object as an object

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -311,6 +311,79 @@ need to end _before_ the connection does — which is the case that matters.
 
 Introspects a remote object and builds a JavaScript object from it.
 
+### `bus.proxy()`
+
+The short way. Resolves each member against what the object actually declares,
+so you do not have to know which interface it lives on:
+
+```js
+const notifications = await bus.proxy(
+  'org.freedesktop.Notifications',
+  '/org/freedesktop/Notifications'
+);
+
+const id = await notifications.Notify('app', 0, '', 'hi', '', [], {}, 5000);
+notifications.$on('NotificationClosed', (id, reason) => {});
+
+await notifications.$props.$all();
+await notifications.$props.$set('Volume', 0.5);
+```
+
+| member                     |                                             |
+| -------------------------- | ------------------------------------------- |
+| `proxy.Member(...)`        | call it, wherever it is declared            |
+| `proxy.$props.Name`        | read a property — a promise                 |
+| `proxy.$props.$all()`      | every readable property, in one `GetAll`    |
+| `proxy.$props.$set(n, v)`  | write one, or an object of several          |
+| `proxy.$on/$once/$off`     | signals, wherever they are declared         |
+| `proxy.$as(interfaceName)` | the underlying interface, for anything else |
+| `proxy.$service`, `$path`  | what it stands for                          |
+| `proxy.$interfaces`        | the interfaces it dispatches across         |
+| `proxy.$nodes`             | child object paths                          |
+
+**Everything the proxy adds is `$`-prefixed**, and that is a guarantee rather
+than a convention: a D-Bus member name matches `[A-Za-z_][A-Za-z0-9_]*`, so `$`
+is an impossible first character and nothing can collide.
+
+**An ambiguous member throws, naming both interfaces.** Two interfaces on one
+object may declare the same member, and picking one silently would send the
+call to whichever introspected first. Narrow it:
+
+```js
+const player = await bus.proxy(
+  'org.mpris.MediaPlayer2.vlc',
+  '/org/mpris/MediaPlayer2',
+  {
+    interface: 'org.mpris.MediaPlayer2.Player'
+  }
+);
+```
+
+**`proxy.then` is always `undefined`**, even if the service really does declare
+a member called `then` — reach that one through `$as()`. A proxy that answered
+`then` with a function would make `await proxy` call it and wait forever for a
+resolve that never comes. Since `bus.proxy()` is itself async, that hang would
+happen at construction rather than at first use.
+
+**Assignment is refused**, for properties and members alike. `obj.x = v`
+evaluates to `v` rather than to a promise, so a failed write would be silently
+lost; `$props.$set()` can be awaited.
+
+`console.log(proxy)` prints what it stands for and what it can do, rather than
+walking the connection:
+
+```
+DBusProxy com.example.Proxy /com/example/Proxy
+  methods: Add, Echo, Get, GetAll, GetMachineId, Introspect, Ping, Set
+  properties: Greeting, Level
+  signals: Pinged, PropertiesChanged
+```
+
+### The explicit form
+
+Still there, and what `proxy()` is built on. Use it when you want one named
+interface and nothing else:
+
 ```js
 const iface = await bus
   .getService('org.freedesktop.Notifications')

--- a/index.d.ts
+++ b/index.d.ts
@@ -445,6 +445,12 @@ export interface DBusInterface {
   $callMethod(name: string, args: unknown[]): DBusPromise<any>;
   $readProp(name: string): DBusPromise<any>;
   $readProp(name: string, callback: InvokeCallback): void;
+  /**
+   * Every readable property, in one `GetAll` rather than N `Get`s. Values are
+   * plain whatever shape the connection reads in.
+   */
+  $readAllProps(): DBusPromise<Record<string, unknown>>;
+  $readAllProps(callback: InvokeCallback): void;
   $writeProp(name: string, value: unknown): DBusPromise<void>;
   $writeProp(name: string, value: unknown, callback: InvokeCallback): void;
 
@@ -562,6 +568,54 @@ export interface ManagedObjects extends EventEmitter {
   /** The service was replaced or went away; this view is watching nothing. */
   on(event: 'stale', listener: (newOwner: string) => void): this;
   on(event: string, listener: (...args: any[]) => void): this;
+}
+
+/**
+ * The property accessor on a proxy.
+ *
+ * A property reads as a promise; writing goes through `$set`, because
+ * `obj.x = v` evaluates to `v` and a failed write would have nowhere to go.
+ */
+export interface ProxyProps {
+  /** Every readable property, flattened across interfaces, in one call. */
+  $all(): Promise<Record<string, unknown>>;
+  $set(name: string, value: unknown): Promise<void>;
+  $set(values: Record<string, unknown>): Promise<void>;
+  [property: string]: any;
+}
+
+/**
+ * A remote object, from `bus.proxy()`.
+ *
+ * Members resolve against what the object introspected as, so a method can be
+ * called without naming its interface. Everything the proxy itself adds is
+ * `$`-prefixed — a D-Bus member name is `[A-Za-z_][A-Za-z0-9_]*`, so `$` is an
+ * impossible prefix rather than merely an unlikely one.
+ */
+export interface DBusProxy {
+  readonly $bus: MessageBus;
+  readonly $service: string;
+  readonly $path: string;
+  /** The interfaces this proxy dispatches across. */
+  readonly $interfaces: string[];
+  /** Child object paths, from the same introspection. */
+  readonly $nodes: string[];
+  readonly $props: ProxyProps;
+
+  /** The underlying interface, for anything the proxy will not do. */
+  $as(interfaceName: string): DBusInterface;
+
+  $on(signal: string, handler: (...args: any[]) => void): this;
+  $once(signal: string, handler: (...args: any[]) => void): this;
+  $off(signal: string, handler: (...args: any[]) => void): this;
+
+  /**
+   * Never present, whatever the object declares — a proxy that answered `then`
+   * with a function would hang every `await` on it, forever.
+   */
+  readonly then?: undefined;
+
+  [member: string]: any;
 }
 
 /** A match rule that can be removed, from `bus.watch()`. */
@@ -692,6 +746,29 @@ export interface MessageBus {
    * another owner is a legitimate outcome. Check `isPrimaryOwner`.
    */
   ownName(name: string, flags?: number): Promise<NameRegistration>;
+
+  /**
+   * The remote object, as an object.
+   *
+   * ```js
+   * const notifications = await bus.proxy(
+   *   'org.freedesktop.Notifications',
+   *   '/org/freedesktop/Notifications'
+   * );
+   * await notifications.Notify('app', 0, '', 'hi', '', [], {}, 5000);
+   * await notifications.$props.$all();
+   * ```
+   *
+   * Introspects once and resolves each member against what the object declares,
+   * instead of making you name the interface first. A member declared by two
+   * interfaces throws rather than being guessed at — pass `{ interface }` or
+   * use `$as()`.
+   */
+  proxy(
+    service: string,
+    path: string,
+    options?: { interface?: string }
+  ): Promise<DBusProxy>;
 
   /**
    * A live view of the objects a service manages below `path`.

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -687,6 +687,35 @@ module.exports = function bus(conn, opts) {
   };
 
   /**
+   * The remote object, as an object.
+   *
+   *     const notifications = await bus.proxy(
+   *       'org.freedesktop.Notifications',
+   *       '/org/freedesktop/Notifications'
+   *     );
+   *     await notifications.Notify('app', 0, '', 'hi', '', [], {}, 5000);
+   *     await notifications.$props.$all();
+   *
+   * Introspects once and resolves each member against what the object actually
+   * declares, instead of making the caller name the interface first. A member
+   * declared by two interfaces throws rather than being guessed at; name one
+   * with `{ interface }` or reach for `$as()`.
+   *
+   * Everything the proxy adds is `$`-prefixed, which cannot collide: a D-Bus
+   * member name is `[A-Za-z_][A-Za-z0-9_]*`, so `$` is not merely an unlikely
+   * prefix but an impossible one.
+   *
+   * @param {string} service the bus name
+   * @param {string} path the object path
+   * @param {{interface?: string}} [options] restrict lookups to one interface
+   */
+  this.proxy = async function (service, path, options) {
+    const { createProxy } = require('./proxy');
+    const obj = await self.getObject(service, path);
+    return createProxy(obj, options || {});
+  };
+
+  /**
    * A live view of the objects a service manages below `path`.
    *
    * One round trip for the whole tree, then kept current from

--- a/lib/introspect.js
+++ b/lib/introspect.js
@@ -1,6 +1,6 @@
 const xml2js = require('xml2js');
 const { maybePromise } = require('./promisify');
-const { variantValue } = require('./values');
+const { variantValue, toPlain } = require('./values');
 const { ConnectionClosedError } = require('./errors');
 
 module.exports.introspectBus = function (obj, callback) {
@@ -399,6 +399,36 @@ DBusInterface.prototype.$readProp = function (propName, callback) {
     )
   );
 };
+/**
+ * Every readable property of this interface, in one round trip.
+ *
+ * `Properties.GetAll` rather than N `Get`s, which is the whole reason the
+ * method exists on the bus. Write-only properties are absent, because the
+ * service leaves them out.
+ */
+DBusInterface.prototype.$readAllProps = function (callback) {
+  const bus = this.$parent.service.bus;
+  return maybePromise(callback, cb =>
+    bus.invoke(
+      {
+        destination: this.$parent.service.name,
+        path: this.$parent.name,
+        interface: 'org.freedesktop.DBus.Properties',
+        member: 'GetAll',
+        signature: 's',
+        body: [this.$name]
+      },
+      (err, all) => {
+        if (err) return cb(err);
+        // `a{sv}`: pairs of variants classically, a plain object under
+        // plainValues. toPlain() flattens both to the same thing, so a caller
+        // sees one shape whatever the connection was configured with.
+        cb(null, toPlain(all));
+      }
+    )
+  );
+};
+
 DBusInterface.prototype.$writeProp = function (propName, val, callback) {
   const bus = this.$parent.service.bus;
   return bus.invoke(

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -1,0 +1,274 @@
+// bus.proxy(): the remote object, as an object.
+//
+//     const notifications = await bus.proxy(
+//       'org.freedesktop.Notifications',
+//       '/org/freedesktop/Notifications'
+//     );
+//     const id = await notifications.Notify('app', 0, '', 'hi', '', [], {}, 5000);
+//
+// The existing surface makes you name the interface before you can call
+// anything -- getService().getInterface(path, iface) -- which means knowing
+// which of an object's interfaces a member lives on before you can use it.
+// Almost nobody does; they look it up once and hard-code it. This resolves the
+// member against what the object actually introspected as.
+//
+// BIG_FUTURE_PLANS 2, with the correction from 2.3.
+
+const util = require('util');
+
+/**
+ * Names the proxy must never manufacture a method for.
+ *
+ * `then` is the one that matters. `await` looks up `.then`, finds a function,
+ * calls it with (resolve, reject) and waits forever for a resolve that never
+ * comes -- so the program hangs with no error and no stack.
+ *
+ * And it hangs *immediately*, not at first use: `bus.proxy()` is async, so
+ * returning the proxy from it awaits it on the caller's behalf. Measured by
+ * emptying this set and running the suite -- every one of the 23 tests
+ * cancelled, none even reached, because the `before` hook never returned. That
+ * is a worse failure than a wrong answer, and it is one line away.
+ *
+ * A service is free to have a member genuinely called `then`, so this is
+ * checked before the member table rather than after. Reach it with `$as()`.
+ */
+const NEVER_A_MEMBER = new Set(['then']);
+
+/** Build `member -> [interfaceName, ...]` across every interface on an object. */
+function index(interfaces, kind) {
+  const byMember = new Map();
+  for (const [interfaceName, iface] of Object.entries(interfaces)) {
+    for (const member of Object.keys(iface[kind] || {})) {
+      if (!byMember.has(member)) byMember.set(member, []);
+      byMember.get(member).push(interfaceName);
+    }
+  }
+  return byMember;
+}
+
+/**
+ * Resolve a member to exactly one interface.
+ *
+ * Ambiguity throws rather than picking: two interfaces on one object really can
+ * declare the same member name, and guessing would send the call to whichever
+ * happened to introspect first. The error names both so the fix is obvious.
+ */
+function resolve(byMember, member, kind, path) {
+  const found = byMember.get(member);
+  if (!found) return undefined;
+  if (found.length > 1) {
+    throw new Error(
+      `${kind} "${member}" is declared by more than one interface at ${path}: ` +
+        `${found.join(', ')}. Name one with bus.proxy(..., { interface }) or $as().`
+    );
+  }
+  return found[0];
+}
+
+/** The `$props` accessor: a property reads as a promise of its value. */
+function makeProps(interfaces, byProperty, path, only) {
+  const target = {
+    /**
+     * Every readable property, flattened across interfaces.
+     *
+     * Flat rather than grouped by interface because that is how people think
+     * about an object's properties, and because grouping would make the common
+     * case -- one interface -- noisier for no gain.
+     */
+    $all: async () => {
+      const out = {};
+      for (const [interfaceName, iface] of Object.entries(interfaces)) {
+        if (only && interfaceName !== only) continue;
+        if (!Object.keys(iface.$properties || {}).length) continue;
+        Object.assign(out, await iface.$readAllProps());
+      }
+      return out;
+    },
+
+    /** `$set(name, value)` or `$set({ name: value, ... })`. */
+    $set: async (nameOrValues, maybeValue) => {
+      const values =
+        typeof nameOrValues === 'string'
+          ? { [nameOrValues]: maybeValue }
+          : nameOrValues;
+      for (const [name, value] of Object.entries(values)) {
+        const interfaceName = resolve(byProperty, name, 'Property', path);
+        if (interfaceName === undefined) {
+          throw new Error(`No property "${name}" at ${path}`);
+        }
+        await interfaces[interfaceName].$writeProp(name, value);
+      }
+    }
+  };
+
+  return new Proxy(target, {
+    get(t, key) {
+      if (typeof key !== 'string' || Object.hasOwn(t, key)) {
+        return Reflect.get(t, key);
+      }
+      if (NEVER_A_MEMBER.has(key)) return undefined;
+      const interfaceName = resolve(byProperty, key, 'Property', path);
+      if (interfaceName === undefined) return undefined;
+      // A getter that returns a promise, so `await proxy.$props.Volume` reads
+      // like a property access and still surfaces failures.
+      return interfaces[interfaceName].$readProp(key);
+    },
+    has(t, key) {
+      return Object.hasOwn(t, key) || byProperty.has(key);
+    },
+    ownKeys(t) {
+      return [...new Set([...Reflect.ownKeys(t), ...byProperty.keys()])];
+    },
+    getOwnPropertyDescriptor(t, key) {
+      if (Object.hasOwn(t, key))
+        return Reflect.getOwnPropertyDescriptor(t, key);
+      if (byProperty.has(key)) {
+        return { configurable: true, enumerable: true, value: undefined };
+      }
+      return undefined;
+    },
+    set() {
+      // `obj.x = v` evaluates to `v`, not to a promise, so a failed write would
+      // be silently lost. Refusing is the one place asymmetry beats a footgun.
+      throw new Error(
+        'Assigning to a property cannot report failure. Use $props.$set(name, value).'
+      );
+    }
+  });
+}
+
+/**
+ * Build the proxy for an already-introspected object.
+ *
+ * @param {object} obj a DBusObject from bus.getObject()
+ * @param {{interface?: string}} options restrict every lookup to one interface
+ */
+function createProxy(obj, options = {}) {
+  const all = obj.proxy || {};
+  const only = options.interface;
+  if (only !== undefined && !Object.hasOwn(all, only)) {
+    const names = Object.keys(all);
+    throw new Error(
+      `No interface "${only}" at ${obj.name}. ${
+        names.length ? `Available: ${names.join(', ')}` : 'It has none.'
+      }`
+    );
+  }
+  const interfaces = only ? { [only]: all[only] } : all;
+  const path = obj.name;
+
+  const byMethod = index(interfaces, '$methods');
+  const byProperty = index(interfaces, '$properties');
+  const bySignal = index(interfaces, '$signals');
+
+  const target = {
+    $bus: obj.service.bus,
+    $service: obj.service.name,
+    $path: path,
+    /** The interfaces this proxy dispatches across. */
+    $interfaces: Object.keys(interfaces),
+    /** Child object paths, from the same introspection. */
+    $nodes: obj.nodes || [],
+
+    /** The underlying interface, for anything this proxy will not do. */
+    $as(interfaceName) {
+      const iface = all[interfaceName];
+      if (!iface) {
+        throw new Error(
+          `No interface "${interfaceName}" at ${path}. ` +
+            `Available: ${Object.keys(all).join(', ') || 'none'}`
+        );
+      }
+      return iface;
+    },
+
+    /** Subscribe to a signal, wherever it is declared. */
+    $on(signal, handler) {
+      const interfaceName = resolve(bySignal, signal, 'Signal', path);
+      if (interfaceName === undefined) {
+        throw new Error(`No signal "${signal}" at ${path}`);
+      }
+      interfaces[interfaceName].on(signal, handler);
+      return target;
+    },
+
+    $once(signal, handler) {
+      const interfaceName = resolve(bySignal, signal, 'Signal', path);
+      if (interfaceName === undefined) {
+        throw new Error(`No signal "${signal}" at ${path}`);
+      }
+      interfaces[interfaceName].once(signal, handler);
+      return target;
+    },
+
+    $off(signal, handler) {
+      const interfaceName = resolve(bySignal, signal, 'Signal', path);
+      if (interfaceName === undefined) return target;
+      interfaces[interfaceName].off(signal, handler);
+      return target;
+    }
+  };
+
+  target.$props = makeProps(interfaces, byProperty, path, only);
+
+  // Without this, `console.log(proxy)` prints `$bus` and walks the whole
+  // connection -- an EventEmitter, a socket, every pending call. What a reader
+  // wants is which object this is and what it can do, which is the same
+  // argument that earned Variant a custom inspect.
+  target[util.inspect.custom] = (depth, opts) => {
+    const members = [...byMethod.keys()].sort();
+    const props = [...byProperty.keys()].sort();
+    const sigs = [...bySignal.keys()].sort();
+    const line = (label, xs) =>
+      xs.length ? `\n  ${label}: ${xs.join(', ')}` : '';
+    return `DBusProxy ${opts.stylize(obj.service.name, 'string')} ${opts.stylize(path, 'string')}${line(
+      'methods',
+      members
+    )}${line('properties', props)}${line('signals', sigs)}`;
+  };
+
+  return new Proxy(target, {
+    get(t, key, receiver) {
+      // Symbols are never D-Bus member names -- `util.inspect.custom`,
+      // `Symbol.toStringTag`, `Symbol.iterator` -- so they pass through
+      // untouched rather than being answered with a manufactured method.
+      if (typeof key !== 'string') return Reflect.get(t, key, receiver);
+      if (Object.hasOwn(t, key)) return Reflect.get(t, key, receiver);
+      if (NEVER_A_MEMBER.has(key)) return undefined;
+
+      const interfaceName = resolve(byMethod, key, 'Method', path);
+      if (interfaceName !== undefined) {
+        const iface = interfaces[interfaceName];
+        return (...args) => iface[key](...args);
+      }
+      // Not a method, and not something this proxy adds. Left undefined rather
+      // than thrown so `key in proxy`, `typeof proxy.X` and feature checks all
+      // behave; a call then fails as "is not a function", which is the usual
+      // JavaScript answer to a name that is not there.
+      return undefined;
+    },
+    has(t, key) {
+      return (
+        Object.hasOwn(t, key) || (typeof key === 'string' && byMethod.has(key))
+      );
+    },
+    ownKeys(t) {
+      return [...new Set([...Reflect.ownKeys(t), ...byMethod.keys()])];
+    },
+    getOwnPropertyDescriptor(t, key) {
+      if (Object.hasOwn(t, key))
+        return Reflect.getOwnPropertyDescriptor(t, key);
+      if (typeof key === 'string' && byMethod.has(key)) {
+        return { configurable: true, enumerable: true, value: undefined };
+      }
+      return undefined;
+    },
+    set(t, key) {
+      throw new Error(
+        `Cannot assign to "${String(key)}" on a proxy. Use $props.$set() for properties.`
+      );
+    }
+  });
+}
+
+module.exports = { createProxy, NEVER_A_MEMBER };

--- a/test/integration/proxy.js
+++ b/test/integration/proxy.js
@@ -1,0 +1,251 @@
+// bus.proxy(): the remote object, as an object.
+//
+// The existing surface makes you name the interface before you can call
+// anything. This resolves the member against what the object introspected as,
+// which means the interesting cases are the ones where that resolution is
+// ambiguous or where the name collides with something JavaScript expects.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('assert');
+const util = require('util');
+const { EventEmitter } = require('events');
+const { sessionBus } = require('../utils/shape');
+
+const NO_BUS =
+  !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
+
+const SERVICE = 'com.github.sidorares.dbusnative.Proxied';
+const PATH = '/com/github/sidorares/dbusnative/Proxied';
+const ALPHA = 'com.github.sidorares.dbusnative.Alpha';
+const BETA = 'com.github.sidorares.dbusnative.Beta';
+
+// Two interfaces on one object, deliberately sharing `Shared` and `Colour` --
+// which is legal, and the case a proxy has to refuse to guess about.
+const alphaDesc = {
+  name: ALPHA,
+  methods: {
+    Echo: ['s', 's', ['in'], ['out']],
+    Shared: ['', 's', [], ['who']],
+    // A member named `then`. Legal on the wire, and lethal to a naive proxy.
+    then: ['', 's', [], ['out']]
+  },
+  signals: { Pinged: ['s', 'payload'] },
+  properties: { Greeting: 's', Colour: 's' }
+};
+
+const betaDesc = {
+  name: BETA,
+  methods: { Shared: ['', 's', [], ['who']] },
+  signals: {},
+  properties: { Level: 'd', Colour: 's' }
+};
+
+describe('integration: bus.proxy', { timeout: 15000, skip: NO_BUS }, () => {
+  let serviceBus, clientBus, impl, proxy;
+
+  const whenReady = bus =>
+    new Promise((resolve, reject) =>
+      bus.getId(err => (err ? reject(err) : resolve()))
+    );
+
+  before(async () => {
+    serviceBus = sessionBus();
+    clientBus = sessionBus();
+    await Promise.all([whenReady(serviceBus), whenReady(clientBus)]);
+    await new Promise((resolve, reject) =>
+      serviceBus.requestName(SERVICE, 0, err => (err ? reject(err) : resolve()))
+    );
+
+    impl = Object.assign(Object.create(EventEmitter.prototype), {
+      Greeting: 'hello',
+      Colour: 'red',
+      Level: 0.5,
+      Echo: input => input,
+      Shared: () => 'alpha',
+      then: () => 'a member really called then'
+    });
+    EventEmitter.call(impl);
+    serviceBus.exportInterface(impl, PATH, alphaDesc);
+
+    const beta = Object.assign(Object.create(EventEmitter.prototype), {
+      Level: 0.5,
+      Colour: 'blue',
+      Shared: () => 'beta'
+    });
+    EventEmitter.call(beta);
+    serviceBus.exportInterface(beta, PATH, betaDesc);
+
+    proxy = await clientBus.proxy(SERVICE, PATH);
+  });
+
+  after(async () => {
+    for (const bus of [serviceBus, clientBus]) if (bus) await bus.close();
+  });
+
+  describe('methods', () => {
+    it('calls one without naming its interface', async () => {
+      assert.strictEqual(await proxy.Echo('round trip'), 'round trip');
+    });
+
+    it('reaches the standard interfaces too', async () => {
+      // Peer and Introspectable are on every object, so they come for free.
+      const id = await proxy.GetMachineId();
+      assert.match(id, /^[0-9a-f]{32}$/);
+    });
+
+    it('refuses to guess when two interfaces declare the same name', () => {
+      assert.throws(() => proxy.Shared, {
+        message: new RegExp(
+          `Method "Shared" is declared by more than one interface at ${PATH}`
+        )
+      });
+      // And it names both, so the fix is obvious rather than a hunt.
+      assert.throws(() => proxy.Shared, new RegExp(ALPHA));
+      assert.throws(() => proxy.Shared, new RegExp(BETA));
+    });
+
+    it('is undefined for a name the object does not declare', () => {
+      assert.strictEqual(proxy.NoSuchMethod, undefined);
+      assert.strictEqual('NoSuchMethod' in proxy, false);
+      assert.strictEqual('Echo' in proxy, true);
+    });
+  });
+
+  describe('the `then` hazard', () => {
+    // BIG_FUTURE_PLANS 2.3. A get trap that answers every name with a function
+    // makes `await proxy` look up .then, call it, and wait forever.
+    it('never manufactures a then, even for a member really called then', () => {
+      assert.strictEqual(proxy.then, undefined);
+    });
+
+    it('can be awaited without hanging', async () => {
+      const same = await proxy;
+      assert.strictEqual(same, proxy, 'await resolved to the proxy itself');
+    });
+
+    it('survives being returned from an async function', async () => {
+      // The subtler form: returning a thenable from async makes the runtime
+      // await it for you, so this hangs even if nobody wrote `await proxy`.
+      const returned = await (async () => proxy)();
+      assert.strictEqual(returned, proxy);
+    });
+
+    it('still reaches the real member through $as', async () => {
+      const alpha = proxy.$as(ALPHA);
+      assert.strictEqual(await alpha.then(), 'a member really called then');
+    });
+  });
+
+  describe('{ interface } narrows it', () => {
+    it('resolves a shared name once only one interface is in scope', async () => {
+      const alpha = await clientBus.proxy(SERVICE, PATH, { interface: ALPHA });
+      assert.strictEqual(await alpha.Shared(), 'alpha');
+
+      const beta = await clientBus.proxy(SERVICE, PATH, { interface: BETA });
+      assert.strictEqual(await beta.Shared(), 'beta');
+    });
+
+    it('hides the other interfaces entirely', async () => {
+      const beta = await clientBus.proxy(SERVICE, PATH, { interface: BETA });
+      assert.deepStrictEqual(beta.$interfaces, [BETA]);
+      assert.strictEqual(beta.Echo, undefined);
+    });
+
+    it('rejects an interface the object does not have', async () => {
+      await assert.rejects(
+        () => clientBus.proxy(SERVICE, PATH, { interface: 'com.example.Nope' }),
+        /No interface "com\.example\.Nope"/
+      );
+    });
+  });
+
+  describe('$props', () => {
+    it('reads one as a promise', async () => {
+      assert.strictEqual(await proxy.$props.Greeting, 'hello');
+      assert.strictEqual(await proxy.$props.Level, 0.5);
+    });
+
+    it('reads them all in one round trip, flattened', async () => {
+      const all = await proxy.$props.$all();
+      assert.strictEqual(all.Greeting, 'hello');
+      assert.strictEqual(all.Level, 0.5);
+    });
+
+    it('writes one, and several', async () => {
+      await proxy.$props.$set('Greeting', 'written');
+      assert.strictEqual(impl.Greeting, 'written');
+      assert.strictEqual(await proxy.$props.Greeting, 'written');
+
+      await proxy.$props.$set({ Greeting: 'batched' });
+      assert.strictEqual(impl.Greeting, 'batched');
+    });
+
+    it('refuses assignment rather than losing the failure', () => {
+      // `obj.x = v` evaluates to v, so a rejected write has nowhere to go.
+      assert.throws(() => {
+        proxy.$props.Greeting = 'nope';
+      }, /Assigning to a property cannot report failure/);
+    });
+
+    it('refuses to guess a property two interfaces declare', () => {
+      assert.throws(() => proxy.$props.Colour, /more than one interface/);
+    });
+
+    it('is undefined for a property that is not there', () => {
+      assert.strictEqual(proxy.$props.Nope, undefined);
+    });
+  });
+
+  describe('signals', () => {
+    it('subscribes without naming the interface', async () => {
+      const got = new Promise(resolve => proxy.$on('Pinged', resolve));
+      await new Promise(resolve => setTimeout(resolve, 120));
+      impl.emit('Pinged', 'payload');
+      assert.strictEqual(await got, 'payload');
+    });
+
+    it('unsubscribes', async () => {
+      let count = 0;
+      const handler = () => count++;
+      proxy.$on('Pinged', handler);
+      await new Promise(resolve => setTimeout(resolve, 120));
+      impl.emit('Pinged', 'one');
+      await new Promise(resolve => setTimeout(resolve, 120));
+      proxy.$off('Pinged', handler);
+      impl.emit('Pinged', 'two');
+      await new Promise(resolve => setTimeout(resolve, 120));
+      assert.strictEqual(count, 1);
+    });
+
+    it('says so for a signal that does not exist', () => {
+      assert.throws(() => proxy.$on('Nope', () => {}), /No signal "Nope"/);
+    });
+  });
+
+  describe('what it looks like', () => {
+    it('inspects as the object it stands for, not the connection', () => {
+      // Without a custom inspect this prints $bus and walks the whole socket.
+      const shown = util.inspect(proxy);
+      assert.match(shown, /^DBusProxy/);
+      assert.ok(shown.includes(SERVICE));
+      assert.ok(shown.includes(PATH));
+      assert.match(shown, /methods: .*Echo/);
+      assert.match(shown, /properties: .*Greeting/);
+      assert.match(shown, /signals: .*Pinged/);
+      assert.ok(!shown.includes('connection'), 'no internals');
+    });
+
+    it('reports what it is standing in for', () => {
+      assert.strictEqual(proxy.$service, SERVICE);
+      assert.strictEqual(proxy.$path, PATH);
+      assert.ok(proxy.$interfaces.includes(ALPHA));
+      assert.ok(proxy.$interfaces.includes(BETA));
+    });
+
+    it('refuses assignment of a method name', () => {
+      assert.throws(() => {
+        proxy.Echo = () => {};
+      }, /Cannot assign to "Echo"/);
+    });
+  });
+});


### PR DESCRIPTION
[BIG_FUTURE_PLANS §2](https://github.com/sidorares/dbus-native/blob/master/BIG_FUTURE_PLANS.md), with the correction from §2.3.

```js
const notifications = await bus.proxy(
  'org.freedesktop.Notifications',
  '/org/freedesktop/Notifications'
);

const id = await notifications.Notify('app', 0, '', 'hi', '', [], {}, 5000);
notifications.$on('NotificationClosed', (id, reason) => { … });
await notifications.$props.$all();
```

The existing surface makes you name the interface before you can call anything — which means knowing which of an object's interfaces a member lives on *before* you can use it. Almost nobody does; they look it up once and hard-code it.

An ambiguous member **throws, naming both interfaces**, rather than picking: two interfaces on one object may legitimately declare the same name, and guessing would send the call to whichever introspected first. Narrow with `{ interface }` or `$as()`.

Everything the proxy adds is `$`-prefixed, and that is a *guarantee* rather than a convention — a D-Bus member name matches `[A-Za-z_][A-Za-z0-9_]*`, so `$` is an impossible first character.

## The `then` guard is load-bearing, and worse than §2.3 said

§2.3 described the hazard as hitting when you await the proxy. Building it showed that is optimistic. **`bus.proxy()` is itself `async`**, so returning the proxy from it awaits it on the caller's behalf — the hang happens at *construction*, before anyone touches a member.

Measured by emptying the guard set and running the suite:

```
ℹ tests 23   ℹ pass 0   ℹ fail 0   ℹ cancelled 23
```

Not one test reached, because the `before` hook never returned. No error, no stack, no failing assertion — just nothing. That is a worse failure mode than a wrong answer and it is one line away.

The test service declares a member **genuinely called `then`** (legal on the wire), reachable through `$as()`, so the guard is exercised rather than assumed.

## Assignment is refused

For properties and members alike. `obj.x = v` evaluates to `v` rather than to a promise, so a rejected write has nowhere to go and would be silently lost. `$props.$set()` can be awaited. This is the one place the sketch accepted asymmetry over a footgun, and it was right.

## Two smaller things

- **`$readAllProps()` on `DBusInterface`** — one `GetAll` rather than N `Get`s. It is what `$props.$all()` is built on, and useful on its own.
- **A custom inspect.** Without one, `console.log(proxy)` prints `$bus` and walks the entire connection. Now:

```
DBusProxy com.example.Proxy /com/example/Proxy
  methods: Add, Echo, Get, GetAll, GetMachineId, Introspect, Ping, Set
  properties: Greeting, Level
  signals: Pinged, PropertiesChanged
```

Same argument that earned `Variant` one — the debugging loop is most of the DX.

## Verification

23 new integration tests covering method dispatch, ambiguity, `{ interface }` narrowing, properties, signals, the `then` hazard and the inspect output.

| | dbus-daemon | broker |
|---|---|---|
| classic | 228/228 | 228/228 |
| `2.0` | 228/228 | 228/228 |
| `2.0-wrap` | 228/228 | 228/228 |

`npm test` — 840 unit tests, lint, format, tsc — green.
