### PR TITLE
feat: UNIX_FD, carried over a transport the caller supplies

### DIFF
--- a/BIG_FUTURE_PLANS.md
+++ b/BIG_FUTURE_PLANS.md
@@ -310,6 +310,14 @@ closes without it, UNIX_FD costs another major later. Defining
 `stream.writeWithFds?` / `stream.on('fds')` as an optional capability now, with
 nothing behind it, is cheap insurance and belongs in this release train.
 
+**Shipped, and it turned out to be more than a seam.** Once the message is
+`{ bytes, fds }` and `h` is the uint32 index the spec always said it was, the
+only missing piece is the stream — so the whole protocol is implemented and
+tested against a mock transport, and UNIX_FD works today for anyone who supplies
+one. The package still depends on nothing. That is a better outcome than the
+placeholder this section asked for, and it came from noticing that "not
+buildable" was about the _transport_, never about the protocol.
+
 ---
 
 ## 4. The platform moved — re-checked on Node 26

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -413,7 +413,28 @@ works for the case it was published for — handing TCP sockets between
 processes — and fails on precisely the case d-bus needs. `process.binding` is
 also internal and deprecated.
 
-#### What to do before 3.0/4.0
+#### What to do before 3.0/4.0 — DONE, and further than planned
+
+The plan was to shape the seam and build nothing. In the event the seam turned
+out to be almost all of it: once a message is `{ bytes, fds }` and `h` is the
+uint32 index the spec says it is, the only missing piece is a stream that can
+carry descriptors — and that is exactly what a caller can supply.
+
+So the whole protocol is implemented and tested against a mock fd-capable
+transport, and **UNIX_FD works today for anyone who brings their own stream**.
+The package still depends on nothing, which was the point.
+
+- `writeWithFds(bytes, fds)` on the stream, and an `'fds'` event, are the seam.
+- `connection.canPassFds` / `connection.unixFdsAgreed` report each half.
+- `NEGOTIATE_UNIX_FD` is sent only when the transport can carry one, and the
+  server agrees only when its own can.
+- An fd-carrying message is never batched: ancillary data attaches to a write,
+  not to a message.
+- Header field 9 is in the tables. It was missing, so a peer that sent one
+  produced `msg.undefined = 2` — latent only because we never negotiated.
+
+The original text follows, because the transport findings are still why there
+is no built-in one.
 
 Do not build it; there is nothing safe to depend on. But **shape the transport
 seam**, because that is the part that would otherwise force a major later.

--- a/docs/api.md
+++ b/docs/api.md
@@ -243,6 +243,71 @@ bus.signals.on(key, (body, signature) => console.log(body));
 The [proxy API](#proxy-api) wraps both steps — `iface.on('Pinged', handler)`
 adds the match rule for you.
 
+### File descriptors
+
+`h` (`UNIX_FD`) is a **uint32 index**, not a descriptor — "the value is an index
+into the array of file descriptors that accompany the message", per the
+specification. The descriptors themselves travel as ancillary data
+(`SCM_RIGHTS`) beside the bytes, and ride on `msg.fds`:
+
+```js
+bus.connection.message({
+  destination: 'org.example.Sink',
+  path: '/org/example/Sink',
+  interface: 'org.example.Sink',
+  member: 'Take',
+  signature: 'sh',
+  body: ['a name', 0], //        ^ index into fds
+  fds: [fd]
+});
+```
+
+and the same shape arrives:
+
+```js
+bus.connection.on('message', msg => {
+  if (msg.fds) console.log(msg.fds[msg.body[1]]);
+});
+```
+
+**Node has no ancillary-data API**, so nothing here provides a transport that
+can carry them — [nodejs/node#53391](https://github.com/nodejs/node/issues/53391)
+is closed as not planned, and every addon that does needs a compiler on every
+install, which is the property this package spent three releases acquiring. See
+[ROADMAP.md §2.8](../ROADMAP.md) for what was measured.
+
+**So the capability is a seam on the stream.** Supply your own transport as
+`opts.stream` implementing two things, and everything above it works:
+
+| on the stream              |                                                     |
+| -------------------------- | --------------------------------------------------- |
+| `writeWithFds(bytes, fds)` | write, carrying descriptors; returns like `write()` |
+| `emit('fds', fds)`         | descriptors received, in arrival order              |
+
+`test/utils/fd-transport.js` is a working example, minus the kernel.
+
+| on the connection          |                                                |
+| -------------------------- | ---------------------------------------------- |
+| `connection.canPassFds`    | whether the transport declared the capability  |
+| `connection.unixFdsAgreed` | whether the _peer_ agreed during the handshake |
+
+Both must be true before a descriptor gets anywhere. `NEGOTIATE_UNIX_FD` is only
+sent when the transport can carry one — claiming the capability and then failing
+on the first `h` would leave the peer with no way to know to use a different
+call.
+
+Three details that matter if you write a transport:
+
+- **Descriptors must arrive in the same order as their bytes.** That is what
+  lets each message take the number its `UNIX_FDS` header claims, which is how
+  libdbus does it too. `SCM_RIGHTS` gives this for free.
+- **An fd-carrying message is never batched.** Ancillary data attaches to a
+  _write_, not to a message, so a batched one would hand its descriptors to
+  whichever message the kernel associated them with. Such a message flushes the
+  cork and goes on its own.
+- **Ownership is yours.** Nothing here dups or closes anything; a received
+  descriptor is a live fd in your process and closing it is your job.
+
 ### Scoped resources
 
 A match rule is the thing people forget to remove. A process that adds them and

--- a/index.d.ts
+++ b/index.d.ts
@@ -188,6 +188,16 @@ export interface Message {
   sender?: string;
   signature?: string;
   body?: unknown[];
+  /**
+   * File descriptors accompanying this message. `h` values in the body are
+   * *indices* into this array, per the specification — not descriptors.
+   *
+   * The `UNIX_FDS` header field is derived from its length; do not set
+   * `unixFds` yourself. Sending requires a transport that can carry them.
+   */
+  fds?: number[];
+  /** How many descriptors the message declared. Derived from `fds` on send. */
+  unixFds?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -284,6 +294,14 @@ export interface DBusConnection extends EventEmitter {
    */
   message(msg: Message): boolean;
   end(): this;
+  /**
+   * Whether this connection's transport can carry file descriptors — i.e.
+   * whether the stream implements `writeWithFds`. Nothing in this package
+   * provides one; supply your own as `opts.stream`.
+   */
+  canPassFds: boolean;
+  /** Whether the peer agreed to descriptors during the handshake. */
+  unixFdsAgreed: boolean;
   /**
    * Change the value shapes this connection's parser produces. Takes effect on
    * the next message in; a reply already parsed keeps the shape it was read

--- a/index.js
+++ b/index.js
@@ -186,9 +186,31 @@ function createConnection(opts) {
     typeof stream.cork === 'function' && typeof stream.uncork === 'function';
   let corked = false;
 
+  // A transport that can carry file descriptors declares itself by having
+  // these. Nothing in this package provides one -- see ROADMAP 2.8 for why --
+  // so it comes from `opts.stream`, and everything above this line works the
+  // day one exists.
+  const canSendFds = typeof stream.writeWithFds === 'function';
+  self.canPassFds = canSendFds;
+
   function writeMessage(msg) {
     publishSend(msg);
     const buffer = message.marshall(msg);
+
+    if (msg.fds && msg.fds.length) {
+      if (!canSendFds) throw new Error(constants.noFdTransport('sent'));
+      // Deliberately outside the cork. Batching concatenates messages into one
+      // write, and ancillary data attaches to a write rather than to a message
+      // -- so a batched fd-carrying message would hand its descriptors to
+      // whichever message the kernel happened to associate them with. Flushing
+      // first costs a syscall on a rare message and keeps fds with their own.
+      if (corked && !stream.destroyed) {
+        corked = false;
+        stream.uncork();
+      }
+      return stream.writeWithFds(buffer, msg.fds);
+    }
+
     if (canCork && !corked) {
       corked = true;
       stream.cork();
@@ -246,17 +268,41 @@ function createConnection(opts) {
   };
 
   const handshake = opts.server ? serverHandshake : clientHandshake;
-  handshake(stream, opts, (error, guid, identity) => {
+  handshake(stream, opts, (error, guid, identity, negotiated) => {
     if (error) {
       return self.emit('error', error);
     }
     self.guid = guid;
+    // Whether the *peer* agreed to descriptors, which is not the same question
+    // as whether our transport can carry them: both have to be true before a
+    // message with fds will get anywhere.
+    self.unixFdsAgreed = Boolean(negotiated && negotiated.unixFd);
     // What the server side learnt about the peer while authenticating: the
     // mechanism, and the uid it claimed. Undefined on a client connection,
     // where there is nothing to learn. lib/broker.js answers
     // GetConnectionUnixUser from it.
     if (identity) self.identity = identity;
     self.emit('connect');
+    // Descriptors arrive alongside the bytes but on their own event, so they
+    // are queued in arrival order and each message takes the number its
+    // UNIX_FDS header claims. SCM_RIGHTS delivers them in the same order as
+    // the bytes they accompany, which is what makes counting sufficient --
+    // and is how libdbus does it too.
+    const received = [];
+    stream.on('fds', fds => {
+      for (const fd of fds) received.push(fd);
+    });
+    const takeFds = count => {
+      // One capability, both directions: a stream that cannot send descriptors
+      // is not going to have received any either, and saying *that* is more
+      // use than "claimed 1, got 0" -- which is true but leaves the reader to
+      // work out that the transport was never able to.
+      if (count > 0 && !canSendFds) {
+        throw new message.ProtocolError(constants.noFdTransport('received'));
+      }
+      return received.splice(0, count);
+    };
+
     message.unmarshalMessages(
       stream,
       msg => {
@@ -288,7 +334,8 @@ function createConnection(opts) {
         process.nextTick(() => {
           throw err;
         });
-      }
+      },
+      takeFds
     );
   });
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -7,6 +7,9 @@ module.exports = {
     signal: 4
   },
 
+  // Field 9 is UNIX_FDS: how many descriptors accompany this message. It used
+  // to be absent, which meant a peer that sent one produced `msg.undefined = 2`
+  // -- harmless only because we never asked for fd passing, so nothing sent it.
   headerTypeName: [
     null,
     'path',
@@ -16,7 +19,8 @@ module.exports = {
     'replySerial',
     'destination',
     'sender',
-    'signature'
+    'signature',
+    'unixFds'
   ],
 
   // TODO: merge to single hash? e.g path -> [1, 'o']
@@ -28,7 +32,8 @@ module.exports = {
     replySerial: 'u',
     destination: 's',
     sender: 's',
-    signature: 'g'
+    signature: 'g',
+    unixFds: 'u'
   },
   headerTypeId: {
     path: 1,
@@ -38,7 +43,8 @@ module.exports = {
     replySerial: 5,
     destination: 6,
     sender: 7,
-    signature: 8
+    signature: 8,
+    unixFds: 9
   },
   protocolVersion: 1,
   flags: {
@@ -66,17 +72,32 @@ module.exports = {
    * has nothing to do with this library not recognising it. People rediscover
    * that repeatedly, so the message says it outright.
    */
-  unsupportedType(type, direction) {
-    if (type === 'h') {
-      return (
-        `UNIX_FD ('h') is not supported, so this message cannot be ${direction}. ` +
-        'A file descriptor does not travel in the message body -- it is passed ' +
-        'as ancillary data (SCM_RIGHTS) alongside it, and Node has no API for ' +
-        'that: https://github.com/nodejs/node/issues/53391 is closed as not ' +
-        'planned. See ROADMAP.md section 2.8 for what it would take. This ' +
-        'affects systemd, the XDG desktop portals and PipeWire.'
-      );
-    }
+  unsupportedType(type) {
     return `Unknown data type format: ${type}`;
+  },
+
+  /**
+   * Why a message carrying descriptors could not be sent or received.
+   *
+   * `h` itself marshals fine -- it is a uint32 index into the message's fd
+   * array, exactly as the spec defines it. What is missing is a transport that
+   * can carry the descriptors alongside the bytes, because a file descriptor
+   * travels as ancillary data (SCM_RIGHTS) rather than in the body, and Node
+   * has no API for that: nodejs/node#53391 is closed as not planned.
+   *
+   * So the seam is on the stream. Supply one that implements `writeWithFds`
+   * and emits `'fds'` -- see docs/api.md, "File descriptors" -- and everything
+   * above it works. This affects systemd, the XDG desktop portals and PipeWire.
+   */
+  noFdTransport(direction) {
+    return (
+      `This message carries file descriptors, which cannot be ${direction}: ` +
+      'the stream does not support them. A descriptor is passed as ancillary ' +
+      'data (SCM_RIGHTS) alongside the message rather than inside it, and Node ' +
+      'has no API for that -- https://github.com/nodejs/node/issues/53391 is ' +
+      'closed as not planned. Pass your own transport as `opts.stream`, ' +
+      "implementing writeWithFds(bytes, fds) and emitting 'fds'. See " +
+      'docs/api.md and ROADMAP.md section 2.8.'
+    );
   }
 };

--- a/lib/dbus-buffer.js
+++ b/lib/dbus-buffer.js
@@ -295,6 +295,10 @@ DBusBuffer.prototype.readSimpleType = function readSimpleType(t) {
       return this.readInt16();
     case 'u':
       return this.readInt32();
+    // UNIX_FD: an index into the message's fd array, not a descriptor. The
+    // descriptors themselves are on `msg.fds`.
+    case 'h':
+      return this.readInt32();
     case 'i':
       return this.readSInt32();
     case 'g':
@@ -329,7 +333,7 @@ DBusBuffer.prototype.readSimpleType = function readSimpleType(t) {
     case 'd':
       return this.readDouble();
     default:
-      throw new Error(constants.unsupportedType(t, 'read'));
+      throw new Error(constants.unsupportedType(t));
   }
 };
 

--- a/lib/handshake.js
+++ b/lib/handshake.js
@@ -86,11 +86,14 @@ function send(stream, data) {
 module.exports = function auth(stream, opts, cb) {
   const authMethods = opts.authMethods || constants.defaultAuthMethods;
   if (!send(stream, '\0')) return;
+  // Asked for only when the transport can carry a descriptor, which is what
+  // `writeWithFds` on the stream declares. See ROADMAP 2.8.
+  const negotiateUnixFd = typeof stream.writeWithFds === 'function';
   // slice() so we don't accidentally mutate the caller's array
-  tryAuth(stream, authMethods.slice(), cb);
+  tryAuth(stream, authMethods.slice(), cb, negotiateUnixFd);
 };
 
-function tryAuth(stream, methods, cb) {
+function tryAuth(stream, methods, cb, negotiateUnixFd) {
   if (methods.length === 0) {
     return cb(new Error('No authentication methods left to try'));
   }
@@ -99,17 +102,38 @@ function tryAuth(stream, methods, cb) {
   const uid = hasGetuid() ? process.getuid() : 0;
   const id = hexlify(uid);
 
+  /**
+   * Ask the peer to allow descriptors, then BEGIN either way.
+   *
+   * A server that says ERROR here is saying "not on this connection", which is
+   * a perfectly ordinary answer and not a reason to fail the handshake -- the
+   * connection is still usable for everything that does not carry an fd.
+   */
+  function negotiateFds(guid) {
+    if (!send(stream, 'NEGOTIATE_UNIX_FD\r\n')) return;
+    readLine(stream, reply => {
+      const agreed = /^AGREE_UNIX_FD/.test(reply.toString('ascii'));
+      if (!send(stream, 'BEGIN\r\n')) return;
+      cb(null, guid, undefined, { unixFd: agreed });
+    });
+  }
+
   function beginOrNextAuth() {
     readLine(stream, line => {
       const ok = line.toString('ascii').match(/^([A-Za-z]+) (.*)/);
       if (ok && ok[1] === 'OK') {
+        // Only asked for when the transport could actually carry a descriptor.
+        // Claiming the capability and then failing on the first `h` would be
+        // worse than not claiming it: the peer would have had no way to know
+        // to use a different call.
+        if (negotiateUnixFd) return negotiateFds(ok[2]);
         if (!send(stream, 'BEGIN\r\n')) return;
         return cb(null, ok[2]); // ok[2] = guid. Do we need it?
       }
       // The server rejected this mechanism (typically `REJECTED <methods>`);
       // fall through to the next one we know about.
       if (methods.length > 0) {
-        return tryAuth(stream, methods, cb);
+        return tryAuth(stream, methods, cb, negotiateUnixFd);
       }
       return cb(
         new Error(

--- a/lib/marshallers.js
+++ b/lib/marshallers.js
@@ -284,6 +284,20 @@ const marshallers = {
     },
     marshall: (writer, data) => writer.uint32(data)
   },
+  // UNIX_FD -- a uint32 on the wire, and *not* a file descriptor.
+  //
+  // "The value is an index into the array of file descriptors that accompany
+  // the message" (D-Bus specification, Basic types). The descriptors travel as
+  // ancillary data; the body carries positions in that array. So this marshals
+  // exactly like `u`, and it is the transport that has to be able to carry
+  // `msg.fds` alongside -- see constants.noFdTransport.
+  h: {
+    check(data) {
+      checkInteger(data);
+      checkRange(0, 0xffffffff, data);
+    },
+    marshall: (writer, data) => writer.uint32(data)
+  },
   // UINT64
   t: {
     check: data => makeBigInt(data, false),
@@ -324,7 +338,7 @@ const marshallers = {
 const MakeSimpleMarshaller = function (signature) {
   const marshaller = marshallers[signature];
   if (!marshaller) {
-    throw new Error(constants.unsupportedType(signature, 'written'));
+    throw new Error(constants.unsupportedType(signature));
   }
   return marshaller;
 };

--- a/lib/message.js
+++ b/lib/message.js
@@ -28,7 +28,8 @@ module.exports.unmarshalMessages = function messageParser(
   onMessage,
   opts,
   onError,
-  onHandlerError
+  onHandlerError,
+  takeFds
 ) {
   const maxMessageSize =
     (opts && opts.maxMessageSize) || constants.maxMessageSize;
@@ -129,6 +130,32 @@ module.exports.unmarshalMessages = function messageParser(
     message.type = header[1];
     message.flags = header[2];
 
+    // Descriptors arrive as ancillary data, out of band from the bytes, so a
+    // message claims its share by count rather than carrying them. They are
+    // taken here -- after the header, before the body -- because the count is
+    // in the header and `h` values in the body index into what we take.
+    //
+    // Taken even when there is no transport to have received any: a message
+    // whose header says 2 and whose fds we cannot produce is a message we
+    // cannot deliver correctly, and saying so is better than handing over a
+    // body full of indices into nothing.
+    if (message.unixFds) {
+      if (!takeFds) {
+        throw new ProtocolError(constants.noFdTransport('received'));
+      }
+      message.fds = takeFds(message.unixFds);
+      if (message.fds.length !== message.unixFds) {
+        // The transport can carry descriptors but the right number did not
+        // turn up, so the queue and the byte stream have drifted apart. There
+        // is no way back from that: every later message would take someone
+        // else's.
+        const n = message.unixFds;
+        throw new ProtocolError(
+          `Message claims ${n} file descriptor${n === 1 ? '' : 's'} but ${message.fds.length} arrived`
+        );
+      }
+    }
+
     if (bodyLength > 0 && message.signature) {
       message.body = messageBuffer.read(message.signature);
     }
@@ -223,7 +250,14 @@ module.exports.marshall = function marshallMessage(message) {
   const headerBuff = marshall('yyyyuu', header);
   const fields = [];
   constants.headerTypeName.forEach(fieldName => {
-    const fieldVal = message[fieldName];
+    // UNIX_FDS is a count derived from `message.fds`, not something the caller
+    // sets. Deriving it is what keeps the header and the ancillary data from
+    // disagreeing, which is a desynchronised connection rather than a bad
+    // message: the peer takes the count it was told.
+    const fieldVal =
+      fieldName === 'unixFds'
+        ? message.fds && message.fds.length
+        : message[fieldName];
     if (fieldVal) {
       fields.push([
         constants.headerTypeId[fieldName],

--- a/lib/server-handshake.js
+++ b/lib/server-handshake.js
@@ -150,6 +150,8 @@ module.exports = function serverHandshake(stream, opts, cb) {
   let rejections = 0;
   let firstLine = true;
   let settled = false;
+  // Whether we told the client it may send descriptors on this connection.
+  let unixFdAgreed = false;
   // Set while a mechanism is mid-exchange, so a DATA line knows who wants it.
   let pending = null;
   // What we learnt about the peer; passed to `authorize` and to the caller.
@@ -184,7 +186,7 @@ module.exports = function serverHandshake(stream, opts, cb) {
     if (settled) return;
     settled = true;
     if (timer) clearTimeout(timer);
-    cb(null, guid, identity);
+    cb(null, guid, identity, { unixFd: unixFdAgreed });
   }
 
   // Refuse this attempt and let the client try again with another mechanism,
@@ -292,11 +294,18 @@ module.exports = function serverHandshake(stream, opts, cb) {
   function onBegin(command) {
     if (command === 'BEGIN') return succeed();
     if (command === 'NEGOTIATE_UNIX_FD') {
-      // Refused rather than agreed. A file descriptor travels as ancillary
-      // data, which Node cannot send or receive -- see
-      // constants.unsupportedType and ROADMAP section 2.8. ERROR is what the
-      // spec expects here, and the client carries on without fd passing.
-      send('ERROR UNIX_FD passing is not supported');
+      // Agreed only if this connection's transport can actually carry a
+      // descriptor. Nothing in this package provides one -- a descriptor
+      // travels as ancillary data and Node has no API for it, ROADMAP 2.8 --
+      // so this is ERROR unless the caller supplied a stream that can, which
+      // is the seam. The client carries on either way; ERROR here means "not
+      // on this connection", not "handshake failed".
+      if (typeof stream.writeWithFds === 'function') {
+        unixFdAgreed = true;
+        send('AGREE_UNIX_FD');
+      } else {
+        send('ERROR UNIX_FD passing is not supported');
+      }
       return next();
     }
     send(`ERROR Expected BEGIN, got ${command}`);

--- a/test/unix-fd.js
+++ b/test/unix-fd.js
@@ -1,75 +1,285 @@
-// UNIX_FD ('h') is not supported, and the error says why.
+// UNIX_FD ('h'), and the transport seam that carries the descriptors.
 //
-// "Unknown data type format: h" was accurate but misleading: the signature
-// parses, the type is real, and the reason it cannot be carried has nothing to
-// do with this library failing to recognise it. A file descriptor is passed as
-// ancillary data (SCM_RIGHTS) alongside the message rather than inside it, and
-// Node has no API for that.
+// `h` used to throw in both directions with a long explanation. That explained
+// the right thing in the wrong place: the type is not the problem. "The value
+// is an index into the array of file descriptors that accompany the message"
+// (D-Bus specification, Basic types) -- so `h` is a uint32 and always was. What
+// is missing is a transport that can carry descriptors alongside the bytes,
+// because they travel as ancillary data (SCM_RIGHTS) and Node has no API for
+// it: nodejs/node#53391 is closed as not planned.
 //
-// See ROADMAP.md §2.8 for the options that were measured, and why none of them
-// works today.
+// So the capability lives on the stream. Supply one implementing
+// `writeWithFds(bytes, fds)` that emits 'fds', and everything above it works --
+// which is what these tests demonstrate, against a channel that does exactly
+// that. See ROADMAP.md 2.8 for the transports that were measured and rejected.
 
 const { describe, it } = require('node:test');
 const assert = require('assert');
 const marshall = require('../lib/marshall');
 const unmarshall = require('../lib/unmarshall');
 const parseSignature = require('../lib/signature');
+const constants = require('../lib/constants');
+const message = require('../lib/message');
+const dbus = require('../index');
+const { fdChannelPair, plainChannelPair } = require('./utils/fd-transport');
 
-describe("UNIX_FD ('h')", () => {
+describe("UNIX_FD ('h') as a value", () => {
   it('parses as a signature, since it is a real type', () => {
     assert.deepStrictEqual(parseSignature('h'), [{ type: 'h', child: [] }]);
   });
 
-  it('cannot be written, and says why', () => {
-    assert.throws(
-      () => marshall('h', [0]),
-      err => {
-        assert.match(err.message, /UNIX_FD \('h'\) is not supported/);
-        assert.match(err.message, /cannot be written/);
-        assert.match(err.message, /ancillary data \(SCM_RIGHTS\)/);
-        return true;
-      }
-    );
+  it('marshals as the uint32 index the spec says it is', () => {
+    // Not a descriptor. An index into the fds that came with the message.
+    const buffer = marshall('h', [2]);
+    assert.strictEqual(buffer.length, 4);
+    assert.deepStrictEqual(unmarshall(buffer, 'h'), [2]);
   });
 
-  it('cannot be read, and says why', () => {
-    assert.throws(
-      () => unmarshall(Buffer.alloc(4), 'h'),
-      err => {
-        assert.match(err.message, /UNIX_FD \('h'\) is not supported/);
-        assert.match(err.message, /cannot be read/);
-        return true;
-      }
-    );
+  it('round-trips inside a container', () => {
+    assert.deepStrictEqual(unmarshall(marshall('ah', [[0, 1, 2]]), 'ah'), [
+      [0, 1, 2]
+    ]);
+    assert.deepStrictEqual(unmarshall(marshall('(sh)', [['x', 1]]), '(sh)'), [
+      ['x', 1]
+    ]);
   });
 
-  it('points at the reason rather than at this library', () => {
-    // Someone hitting this should not have to work out whether it is our bug.
-    const message = (() => {
-      try {
-        marshall('h', [0]);
-      } catch (e) {
-        return e.message;
-      }
-    })();
-    assert.match(message, /nodejs\/node\/issues\/53391/);
-    assert.match(message, /ROADMAP/);
-    // and which real-world APIs it costs them
-    assert.match(message, /systemd|portals|PipeWire/);
+  it('rejects a value outside uint32 range, like any index', () => {
+    assert.throws(() => marshall('h', [-1]), /Number outside range/);
   });
 
-  it('is reported the same way inside a container', () => {
-    assert.throws(() => marshall('ah', [[0]]), /UNIX_FD/);
-    assert.throws(() => marshall('(sh)', [['x', 0]]), /UNIX_FD/);
-  });
-
-  it('leaves other unsupported types with the generic message', () => {
-    // A type code the signature parser rejects never reaches the marshaller,
-    // so this is the fallback for anything that parses but has no marshaller.
-    const constants = require('../lib/constants');
+  it('leaves genuinely unknown types with the generic message', () => {
     assert.strictEqual(
-      constants.unsupportedType('Z', 'written'),
+      constants.unsupportedType('Z'),
       'Unknown data type format: Z'
     );
+  });
+});
+
+describe('the UNIX_FDS header field', () => {
+  it('is field 9, and used to land on the key "undefined"', () => {
+    // Before this it was absent from the table, so a peer that sent one
+    // produced `msg.undefined = 2`. Harmless only because we never negotiated
+    // fd passing, so nothing ever sent it.
+    assert.strictEqual(constants.headerTypeName[9], 'unixFds');
+    assert.strictEqual(constants.headerTypeId.unixFds, 9);
+    assert.strictEqual(constants.fieldSignature.unixFds, 'u');
+  });
+
+  it('is derived from msg.fds rather than set by the caller', () => {
+    // The header and the ancillary data disagreeing is a desynchronised
+    // connection, not a bad message: the peer takes the count it was told.
+    const buffer = message.marshall({
+      serial: 1,
+      type: constants.messageType.methodCall,
+      path: '/x',
+      member: 'M',
+      signature: 'h',
+      body: [0],
+      fds: [7, 8]
+    });
+    // Field 9 present, carrying 2.
+    assert.ok(buffer.includes(Buffer.from([9, 1, 117, 0])), 'field 9 as a `u`');
+  });
+
+  it('is absent when there are no descriptors', () => {
+    const buffer = message.marshall({
+      serial: 1,
+      type: constants.messageType.methodCall,
+      path: '/x',
+      member: 'M'
+    });
+    assert.ok(!buffer.includes(Buffer.from([9, 1, 117, 0])));
+  });
+});
+
+describe('the transport seam', () => {
+  // Two connected peers, speaking d-bus directly rather than through a bus.
+  const connectPair = channels =>
+    new Promise(resolve => {
+      const [left, right] = channels;
+      const server = dbus.createConnection({ stream: left, server: true });
+      const client = dbus.createConnection({ stream: right, direct: true });
+      let ready = 0;
+      const done = () => ++ready === 2 && resolve({ server, client });
+      server.on('connect', done);
+      client.on('connect', done);
+    });
+
+  const nextMessage = conn =>
+    new Promise(resolve => conn.once('message', resolve));
+
+  it('reports whether this connection can carry descriptors', async () => {
+    const { server, client } = await connectPair(fdChannelPair());
+    assert.strictEqual(client.canPassFds, true);
+    assert.strictEqual(server.canPassFds, true);
+
+    const plain = await connectPair(plainChannelPair());
+    assert.strictEqual(plain.client.canPassFds, false);
+  });
+
+  it('negotiates NEGOTIATE_UNIX_FD only when the transport can', async () => {
+    const { client } = await connectPair(fdChannelPair());
+    assert.strictEqual(client.unixFdsAgreed, true);
+
+    // The same handshake over a stream that cannot: the client never asks, so
+    // there is nothing for the server to agree to. Claiming the capability and
+    // then failing on the first `h` would be worse than not claiming it.
+    const plain = await connectPair(plainChannelPair());
+    assert.strictEqual(plain.client.unixFdsAgreed, false);
+  });
+
+  it('carries descriptors with the message that claims them', async () => {
+    const { server, client } = await connectPair(fdChannelPair());
+    const arriving = nextMessage(server);
+
+    client.message({
+      serial: 1,
+      type: constants.messageType.methodCall,
+      path: '/com/example/Fd',
+      member: 'Take',
+      signature: 'sh',
+      body: ['a file', 0],
+      fds: [42]
+    });
+
+    const msg = await arriving;
+    assert.strictEqual(msg.unixFds, 1);
+    assert.deepStrictEqual(msg.fds, [42]);
+    // The body carries the index; the descriptor is on the message.
+    assert.deepStrictEqual(msg.body, ['a file', 0]);
+    assert.strictEqual(msg.fds[msg.body[1]], 42);
+  });
+
+  it('gives each message its own share, in order', async () => {
+    // The property that makes counting sufficient: SCM_RIGHTS delivers fds in
+    // the same order as the bytes they accompanied, so message N takes the
+    // next N descriptors rather than needing to be told which.
+    const { server, client } = await connectPair(fdChannelPair());
+    const seen = [];
+    server.on('message', msg => seen.push(msg.fds));
+
+    client.message({
+      serial: 1,
+      type: constants.messageType.methodCall,
+      path: '/x',
+      member: 'A',
+      signature: 'ah',
+      body: [[0, 1]],
+      fds: [10, 11]
+    });
+    client.message({
+      serial: 2,
+      type: constants.messageType.methodCall,
+      path: '/x',
+      member: 'B',
+      signature: 'h',
+      body: [0],
+      fds: [12]
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+    assert.deepStrictEqual(seen, [[10, 11], [12]]);
+  });
+
+  it('does not batch an fd message in with the others', async () => {
+    // Ancillary data attaches to a *write*, not to a message. Batched, a
+    // descriptor would land on whichever message the kernel associated it
+    // with -- so an fd-carrying message flushes the cork and goes alone.
+    const [left, right] = fdChannelPair();
+    const { server, client } = await connectPair([left, right]);
+    const seen = [];
+    server.on('message', msg => seen.push([msg.member, msg.fds]));
+
+    // Same tick: without the flush these would share one write.
+    client.message({
+      serial: 1,
+      type: constants.messageType.methodCall,
+      path: '/x',
+      member: 'Plain'
+    });
+    client.message({
+      serial: 2,
+      type: constants.messageType.methodCall,
+      path: '/x',
+      member: 'WithFd',
+      signature: 'h',
+      body: [0],
+      fds: [99]
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+    assert.deepStrictEqual(seen, [
+      ['Plain', undefined],
+      ['WithFd', [99]]
+    ]);
+    // Exactly one write carried descriptors, and it carried only its own.
+    assert.strictEqual(right.sentWithFds.length, 1);
+    assert.deepStrictEqual(right.sentWithFds[0].fds, [99]);
+  });
+
+  it('refuses to send descriptors over a transport that cannot', async () => {
+    const { client } = await connectPair(plainChannelPair());
+    assert.throws(
+      () =>
+        client.message({
+          serial: 1,
+          type: constants.messageType.methodCall,
+          path: '/x',
+          member: 'M',
+          signature: 'h',
+          body: [0],
+          fds: [3]
+        }),
+      err => {
+        assert.match(err.message, /carries file descriptors/);
+        assert.match(err.message, /ancillary data \(SCM_RIGHTS\)/);
+        // Points at the reason and the way out, not at this library.
+        assert.match(err.message, /nodejs\/node\/issues\/53391/);
+        assert.match(err.message, /opts\.stream/);
+        return true;
+      }
+    );
+  });
+
+  it('sends an ordinary message over a plain transport unchanged', async () => {
+    const { server, client } = await connectPair(plainChannelPair());
+    const arriving = nextMessage(server);
+    client.message({
+      serial: 1,
+      type: constants.messageType.methodCall,
+      path: '/x',
+      member: 'M',
+      signature: 's',
+      body: ['no descriptors here']
+    });
+    const msg = await arriving;
+    assert.deepStrictEqual(msg.body, ['no descriptors here']);
+    assert.strictEqual(msg.fds, undefined);
+  });
+
+  it('refuses a message claiming descriptors it cannot have received', async () => {
+    // A header saying 2 with nothing to take is not a message we can deliver
+    // correctly -- the body is full of indices into nothing. Better to say so
+    // than to hand it over.
+    const { server, client } = await connectPair(plainChannelPair());
+    const failed = new Promise(resolve => server.once('error', resolve));
+
+    // Bypass the connection's own refusal by writing the bytes directly.
+    client.stream.write(
+      message.marshall({
+        serial: 1,
+        type: constants.messageType.methodCall,
+        path: '/x',
+        member: 'M',
+        signature: 'h',
+        body: [0],
+        fds: [3]
+      })
+    );
+
+    const err = await failed;
+    assert.match(err.message, /carries file descriptors/);
+    assert.match(err.message, /received/);
   });
 });

--- a/test/utils/fd-transport.js
+++ b/test/utils/fd-transport.js
@@ -1,0 +1,79 @@
+// A stream pair that carries file descriptors, for testing the seam.
+//
+// Nothing in this package provides an fd-capable transport -- Node has no
+// ancillary-data API and the addons that do need a compiler on every install,
+// which is the property three releases were spent acquiring (ROADMAP 2.8). So
+// the capability lives on the stream: supply one that implements
+// `writeWithFds(bytes, fds)` and emits `'fds'`, and everything above works.
+//
+// This is that stream, minus the kernel. It is not a simulation of SCM_RIGHTS
+// -- it does not dup, and the "descriptors" are whatever the test put in -- but
+// it has the property that matters: fds arrive in the same order as the bytes
+// they accompanied, which is what lets a message take its share by count.
+
+const { Duplex } = require('stream');
+
+class FdChannel extends Duplex {
+  constructor() {
+    super();
+    this.peer = null;
+    /** Every (bytes, fds) pair written through writeWithFds, for assertions. */
+    this.sentWithFds = [];
+    /** True once a plain write() happened, to catch fds leaking into a batch. */
+    this.plainWrites = 0;
+  }
+
+  /** The seam: a write that carries descriptors alongside the bytes. */
+  writeWithFds(bytes, fds) {
+    this.sentWithFds.push({ bytes, fds: [...fds] });
+    // Order matters and is the whole contract: the peer must see the fds
+    // before it finishes parsing the message that claims them. Emitting first
+    // is what a recvmsg() loop does -- ancillary data comes off the same call
+    // as its bytes.
+    if (this.peer) {
+      this.peer.emit('fds', fds);
+      this.peer.push(bytes);
+    }
+    return true;
+  }
+
+  _write(chunk, encoding, callback) {
+    this.plainWrites++;
+    if (this.peer) this.peer.push(chunk);
+    callback();
+  }
+
+  _read() {}
+}
+
+/** Two channels wired to each other. */
+function fdChannelPair() {
+  const a = new FdChannel();
+  const b = new FdChannel();
+  a.peer = b;
+  b.peer = a;
+  return [a, b];
+}
+
+/** A Duplex with no fd capability at all, to check the refusal path. */
+class PlainChannel extends Duplex {
+  constructor() {
+    super();
+    this.peer = null;
+  }
+  _write(chunk, encoding, callback) {
+    if (this.peer) this.peer.push(chunk);
+    callback();
+  }
+  _read() {}
+}
+
+function plainChannelPair() {
+  const a = new PlainChannel();
+  const b = new PlainChannel();
+  a.peer = b;
+  b.peer = a;
+  return [a, b];
+}
+
+module.exports = { FdChannel, fdChannelPair, PlainChannel, plainChannelPair };


### PR DESCRIPTION
The last breaking-shaped item from the re-evaluated plan. [ROADMAP §2.8](https://github.com/sidorares/dbus-native/blob/master/ROADMAP.md) asked for a **seam with nothing behind it** — the feature is additive, but `message = { bytes, fds }` is a major, so deferring it would cost another one.

Building the seam showed that *"not buildable"* was always about the **transport**, never the protocol. Once a message carries `fds` and `h` is the uint32 index the spec says it is, the only missing piece is a stream that can carry descriptors — and a caller can supply that. So the protocol is implemented and tested, and **UNIX_FD works today for anyone who brings their own transport**. The package still depends on nothing, which was the point.

## `h` was never the problem

It used to throw in both directions with a long explanation. That explained the right thing in the wrong place:

> The value is an index into the array of file descriptors that accompany the message
> — D-Bus specification, *Basic types*

It is a `uint32`, and always was. Descriptors ride on `msg.fds`; `h` values index into them, symmetrically in both directions, because that is what the wire does.

```js
bus.connection.message({
  …,
  signature: 'sh',
  body: ['a name', 0], //        ^ index into fds
  fds: [fd]
});
```

## The seam

Two things on the stream — `writeWithFds(bytes, fds)`, and an `'fds'` event. `test/utils/fd-transport.js` implements them minus the kernel, and the suite drives the whole path through it.

| | |
|---|---|
| `connection.canPassFds` | the transport declared the capability |
| `connection.unixFdsAgreed` | the *peer* agreed during the handshake |

## Four details that took working through

**An fd-carrying message is never batched.** Ancillary data attaches to a *write*, not to a message, so a batched one would hand its descriptors to whichever message the kernel associated them with. It flushes the cork and goes alone — one syscall on a rare message, against silent misdelivery. There is a test that asserts exactly one write carried fds and it carried only its own.

**Each message takes the count its header claims**, in arrival order. That is sufficient *only* because `SCM_RIGHTS` delivers descriptors in the same order as the bytes they accompanied — the same reasoning libdbus uses, and the contract any transport must honour.

**`NEGOTIATE_UNIX_FD` only when the transport can carry one**, and the server agrees only when its own can. Claiming the capability and then failing on the first `h` is worse than not claiming it: the peer would have had no way to know to use a different call.

**A count that cannot be satisfied is fatal**, not a warning. The fd queue and the byte stream have drifted apart, and every later message would take someone else's descriptors.

## A latent bug, fixed

Header field 9 (`UNIX_FDS`) was absent from the tables, so a peer that sent one produced **`msg.undefined = 2`**. Harmless only because we never negotiated fd passing, so nothing ever sent it — but it would have bitten the first person to talk to a peer that sends it unsolicited.

## Verification

| | dbus-daemon | broker |
|---|---|---|
| classic | 228/228 | 228/228 |
| `2.0` | 228/228 | 228/228 |
| `2.0-wrap` | 228/228 | 228/228 |

850 unit tests on **Node 20.20, 22.16 and 26**, plus lint, format and tsc. The 16 in `test/unix-fd.js` were rewritten from asserting the old "always throws" behaviour to driving the real thing.

`ROADMAP.md` §2.8 and `BIG_FUTURE_PLANS.md` §3.3 both updated — the transport findings still stand and are why there is no built-in one.
