### PR TITLE
fix: never answer a method call addressed to someone else

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,19 +119,36 @@ real connection delivers, because `DBUS_TEST_SHAPE` travels through two
 `npm run` hops and a wrapper process to get there. A broken chain would turn
 the whole gate green while testing nothing, which is worse than red.
 
-**The integration suite runs one file at a time** (`--test-concurrency=1`).
-That is deliberate. Every file shares the one daemon the wrapper started, and
-running them concurrently made roughly one run in five fail — a different test
-each time, always a service answering `UnknownObject` or `UnknownMethod` for
-something it had definitely exported. Measured on master before any of this
-was touched: 3 failures in 10 concurrent runs, 0 in 10 serial ones.
+**The integration suite used to run one file at a time**, because roughly one
+concurrent run in five failed — a different test each time, always a service
+answering `UnknownMethod` for something it had definitely exported. It runs in
+parallel again, and is about 3× faster for it (9.3s → 3.1s).
 
-The mechanism is not fully explained. One captured instance had a connection
-with an empty `exportedObjects` receiving a method call addressed to a
-well-known name it did not own, which should not be possible with unicast
-routing. It costs about three seconds to serialise (1.9s → 5.2s) and it makes
-the suite trustworthy, so it is serial until someone gets to the bottom of it.
-If you are chasing it, `--test-concurrency=8` in a loop reproduces.
+The cause was a **bug in this library, not in the tests**: dispatch never
+looked at `msg.destination`. A match rule with no `type=` — `''`, or
+`eavesdrop='true'` — makes the daemon deliver every message on the bus to that
+connection, method calls included. The connection answered each one as if it
+were its own, found nothing exported, and replied `UnknownMethod` **to the
+original sender, carrying the original serial** — settling a call the victim
+was waiting on with a failure from a process it had never spoken to, in a
+different test file.
+
+`test/integration/match-rules.js` asks the daemon which rules it accepts, and
+both of those are in its corpus, so the suite was generating the traffic that
+broke itself. `lib/bus.js` now ignores what is not addressed to it, checked
+before `stdifaces` so an eavesdropper does not answer `Introspect` for other
+people's objects either. See `test/integration/eavesdropping.js`, which fails
+three ways without the fix.
+
+Two things worth keeping in mind when touching dispatch:
+
+- A connection knows which well-known names it owns from `bus.names`, kept
+  current by the `NameAcquired`/`NameLost` signals the daemon sends unprompted.
+  The reply to `RequestName` is deliberately _not_ consulted — it would be
+  redundant, since the signal is emitted while the daemon handles RequestName,
+  before any other client can learn the name has an owner.
+- `--test-concurrency=8` in a loop is still the way to shake out anything like
+  this. It reproduced at 3/10 before and 0/15 after.
 
 The integration tests **skip themselves** when `DBUS_SESSION_BUS_ADDRESS` is
 unset, so a bare `node --test` run stays green without a bus. If you add

--- a/BIG_FUTURE_PLANS.md
+++ b/BIG_FUTURE_PLANS.md
@@ -466,14 +466,19 @@ Mostly unchanged, with one downgraded and one added.
   migration tooling now exists — lint rule, codemod, `withClassicTypes`,
   `docs/migrating-to-2.0.md` — which is the difference between a break and a
   fork.
-- **New: the integration flake is mitigated, not explained.** The suite runs
-  serially because concurrent runs failed roughly 1 in 5, always a service
-  answering `UnknownObject` for something it had exported. One captured instance
-  had a connection with an empty `exportedObjects` receiving a call addressed to
-  a name it did not own, which should not be possible with unicast routing.
-  Rewriting the dispatch layer on top of an unexplained dispatch bug is how a
-  known-flaky suite becomes a mysteriously-broken one. **Root-cause it before
-  the proxy and service work lands**, not after.
+- ~~**The integration flake is mitigated, not explained.**~~ **Root-caused and
+  fixed.** It was a real dispatch bug, and the instinct to chase it before
+  building more on top was right: a connection answered method calls it was
+  merely _overhearing_, because dispatch never checked `msg.destination`. A
+  match rule with no `type=` makes the daemon deliver everything, and the
+  eavesdropper's `UnknownMethod` reply carried the real sender's serial —
+  settling somebody else's call, in another process, with an error. The suite's
+  own `match-rules.js` corpus generates exactly that traffic.
+
+  The suite runs in parallel again and is 3× faster. Worth noting what it says
+  about the earlier evidence: "a connection with an empty `exportedObjects`
+  receiving a call for a name it does not own" was reported as impossible under
+  unicast routing, and it _was_ — the message was never unicast to it.
 
 ---
 

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -1,5 +1,7 @@
 const EventEmitter = require('events').EventEmitter;
 const constants = require('./constants');
+
+const DBUS_NAME = 'org.freedesktop.DBus';
 const stdDbusIfaces = require('./stdifaces');
 const introspect = require('./introspect').introspectBus;
 const { maybePromise } = require('./promisify');
@@ -34,6 +36,34 @@ module.exports = function bus(conn, opts) {
   this.methodCallHandlers = {};
   this.signals = new EventEmitter();
   this.exportedObjects = {};
+  /**
+   * Well-known names this connection owns.
+   *
+   * Used to tell a method call meant for us from one we are merely
+   * overhearing. Kept current from the NameAcquired and NameLost signals
+   * alone, which is enough: the daemon sends them to the connection concerned
+   * unprompted, and it emits NameAcquired while handling RequestName -- before
+   * any other client can learn the name has an owner, and therefore before any
+   * call to it can be routed here. Messages are processed in arrival order, so
+   * there is no window.
+   *
+   * Reading it from the RequestName reply as well would be redundant, and
+   * would have to reach inside the lazy promise `invokeDbus` returns.
+   */
+  this.names = new Set();
+
+  /**
+   * Is this message addressed to us?
+   *
+   * Only a bus connection can be handed somebody else's mail, and only once it
+   * has a unique name of its own to compare against -- so a peer-to-peer or
+   * pre-Hello connection answers everything, exactly as before.
+   */
+  function addressedToUs(msg) {
+    if (!msg.destination) return true;
+    if (!self.name) return true;
+    return msg.destination === self.name || self.names.has(msg.destination);
+  }
   // Paths serving org.freedesktop.DBus.ObjectManager, in export order.
   this.objectManagers = new Set();
 
@@ -518,9 +548,37 @@ module.exports = function bus(conn, opts) {
         }
       }
     } else if (msg.type === constants.messageType.signal) {
+      // NameAcquired and NameLost are sent to the connection concerned whether
+      // or not it asked, so tracking them here keeps `self.names` correct with
+      // no match rule and no round trip.
+      if (
+        msg.sender === DBUS_NAME &&
+        msg['interface'] === DBUS_NAME &&
+        msg.body &&
+        typeof msg.body[0] === 'string'
+      ) {
+        if (msg.member === 'NameAcquired') self.names.add(msg.body[0]);
+        else if (msg.member === 'NameLost') self.names.delete(msg.body[0]);
+      }
       self.signals.emit(self.mangle(msg), msg.body, msg.signature);
     } else {
       // methodCall
+
+      // Not ours to answer. A match rule with no `type=` -- `''`, or
+      // `eavesdrop='true'` -- makes the daemon deliver every message on the
+      // bus here, method calls included. Answering one addressed to somebody
+      // else sends them an error reply carrying *their* serial, which settles
+      // the call they were waiting on with a failure from a process they never
+      // spoke to.
+      //
+      // That is not hypothetical: it is what made this project's own
+      // integration suite fail about one run in five, because
+      // test/integration/match-rules.js asks the daemon which rules it accepts
+      // and those two are in the corpus. See test/integration/eavesdropping.js.
+      //
+      // Checked before stdDbusIfaces, or an eavesdropper answers Introspect
+      // and Properties.Get for other people's objects too.
+      if (!addressedToUs(msg)) return;
 
       if (stdDbusIfaces(msg, self)) return;
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "test": "npm run lint && npm run format:check && npm run test:types && npm run test:raw",
     "test:raw": "node --test --test-reporter=spec test/*.js",
     "test:integration": "node scripts/with-dbus.js -- npm run test:integration:raw",
-    "test:integration:raw": "node --test --test-concurrency=1 --test-reporter=spec test/integration/*.js",
+    "test:integration:raw": "node --test --test-reporter=spec test/integration/*.js",
     "test:integration:broker": "node scripts/with-broker.js -- npm run test:integration:raw",
     "test:integration:2.0": "DBUS_TEST_SHAPE=2.0 npm run test:integration",
     "test:integration:2.0-wrap": "DBUS_TEST_SHAPE=2.0-wrap npm run test:integration",

--- a/test/integration/eavesdropping.js
+++ b/test/integration/eavesdropping.js
@@ -1,0 +1,143 @@
+// A connection must not answer messages it was merely allowed to see.
+//
+// This is the root cause of the integration flake that made the suite run
+// `--test-concurrency=1`. A match rule with no `type=` -- `''`, or
+// `eavesdrop='true'` -- makes the daemon deliver *every message on the bus* to
+// that connection, including method calls addressed to somebody else. Dispatch
+// never looked at `msg.destination`, so the eavesdropper treated each one as
+// its own, found nothing exported, and replied
+// `org.freedesktop.DBus.Error.UnknownMethod` -- to the original sender, with
+// the original serial.
+//
+// The victim is whoever was waiting for the real reply. Their call fails with
+// an error from a process they never talked to, in a different test file,
+// depending on which reply arrived first. That is exactly the reported
+// symptom: "a service answering UnknownMethod for something it had definitely
+// exported", at random, only under concurrency.
+//
+// test/integration/match-rules.js installs both of those rules against the
+// real daemon on purpose -- it checks which rules the daemon accepts -- so the
+// suite was generating the traffic that broke itself.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const { sessionBus } = require('../utils/shape');
+
+const NO_BUS =
+  !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
+
+const SERVICE = 'com.github.sidorares.dbusnative.Overheard';
+const PATH = '/com/github/sidorares/dbusnative/Overheard';
+const IFACE = 'com.github.sidorares.dbusnative.OverheardIface';
+
+describe('integration: eavesdropping', { timeout: 20000, skip: NO_BUS }, () => {
+  let serviceBus, eavesdropper, caller;
+
+  const whenReady = bus =>
+    new Promise((resolve, reject) =>
+      bus.getId(err => (err ? reject(err) : resolve()))
+    );
+
+  before(async () => {
+    serviceBus = sessionBus();
+    eavesdropper = sessionBus();
+    caller = sessionBus();
+    await Promise.all([
+      whenReady(serviceBus),
+      whenReady(eavesdropper),
+      whenReady(caller)
+    ]);
+
+    await new Promise((resolve, reject) =>
+      serviceBus.requestName(SERVICE, 0, err => (err ? reject(err) : resolve()))
+    );
+    const impl = Object.assign(Object.create(EventEmitter.prototype), {
+      Echo: input => input
+    });
+    EventEmitter.call(impl);
+    serviceBus.exportInterface(impl, PATH, {
+      name: IFACE,
+      methods: { Echo: ['s', 's', ['in'], ['out']] },
+      signals: {},
+      properties: {}
+    });
+
+    // The rule at the heart of it: no `type=`, so it matches method calls
+    // too, and `eavesdrop` tells a modern daemon we mean it.
+    await eavesdropper.addMatch("eavesdrop='true'");
+  });
+
+  after(async () => {
+    for (const bus of [serviceBus, eavesdropper, caller]) {
+      if (bus) await bus.close();
+    }
+  });
+
+  it('does not answer a call addressed to someone else', async () => {
+    // With the bug, the eavesdropper replies UnknownMethod using the
+    // caller's own serial, and whichever reply lands first wins -- usually
+    // the eavesdropper's, since it does no work.
+    const answer = await caller.invoke({
+      destination: SERVICE,
+      path: PATH,
+      interface: IFACE,
+      member: 'Echo',
+      signature: 's',
+      body: ['still mine']
+    });
+    assert.strictEqual(answer, 'still mine');
+  });
+
+  it('does not answer a call it overhears to the bus itself', async () => {
+    // The captured instance: a connection receiving back the AddMatch it had
+    // just sent, and replying to itself.
+    await caller.addMatch(
+      `type='signal',interface='${IFACE}',member='Nothing'`
+    );
+    await caller.removeMatch(
+      `type='signal',interface='${IFACE}',member='Nothing'`
+    );
+  });
+
+  it('still answers calls that really are addressed to it', async () => {
+    // The check has to be narrow enough not to make the service deaf.
+    const answer = await caller.invoke({
+      destination: SERVICE,
+      path: PATH,
+      interface: IFACE,
+      member: 'Echo',
+      signature: 's',
+      body: ['addressed properly']
+    });
+    assert.strictEqual(answer, 'addressed properly');
+  });
+
+  it('answers when addressed by unique name too', async () => {
+    const owner = await caller.getNameOwner(SERVICE);
+    assert.match(owner, /^:\d+\.\d+$/);
+    const answer = await caller.invoke({
+      destination: owner,
+      path: PATH,
+      interface: IFACE,
+      member: 'Echo',
+      signature: 's',
+      body: ['by unique name']
+    });
+    assert.strictEqual(answer, 'by unique name');
+  });
+
+  it('reports an unknown member on a call really meant for it', async () => {
+    // Ignoring what is not ours must not turn into ignoring what is.
+    await assert.rejects(
+      () =>
+        caller.invoke({
+          destination: SERVICE,
+          path: PATH,
+          interface: IFACE,
+          member: 'NoSuchMethod'
+        }),
+      { dbusName: 'org.freedesktop.DBus.Error.UnknownMethod' }
+    );
+  });
+});


### PR DESCRIPTION
Root-causes the integration flake that has kept the suite on `--test-concurrency=1` since #358. It is a real bug in this library, not a test problem — and it affects anyone who adds a broad match rule.

## What was happening

Dispatch never looked at `msg.destination`.

A match rule with no `type=` — `''`, or `eavesdrop='true'` — makes the daemon deliver **every message on the bus** to that connection, method calls included. The connection treated each one as its own, found nothing exported, and replied `org.freedesktop.DBus.Error.UnknownMethod` **to the original sender, carrying the original serial**.

That settles a call the victim was waiting on with a failure from a process it never spoke to. Captured mid-flight:

```
reply: { errorName: 'UnknownMethod', replySerial: 3,
         sender: ':1.0',       ← the eavesdropper
         destination: ':1.2' } ← the caller, who was waiting on :1.1
```

Which explains every reported symptom: random, cross-file, only under concurrency, and always *"a service answering `UnknownMethod` for something it had definitely exported"* — the answering party was never the service.

`test/integration/match-rules.js` asks the daemon which rules it accepts, and both of those are in its corpus. **The suite was generating the traffic that broke itself.**

The note in AGENTS.md said a connection with an empty `exportedObjects` was receiving a call for a name it did not own, *"which should not be possible with unicast routing"*. It was not possible — the message was never unicast to it.

## How it was found

Previous attempts chased name collisions, corrupted member names and eavesdropping *rules*, and ruled all three out. What worked was instrumenting the fallback that produces the error and running at `--test-concurrency=8` in a loop, printing the receiving connection's identity alongside the message.

Every captured event was an `AddMatch` whose `sender` equalled **the receiving connection's own unique name**. A connection answering itself is a much smaller puzzle than a daemon misrouting.

## The fix

A destination check, placed **before `stdifaces`** — otherwise an eavesdropper answers `Introspect` and `Properties.Get` for other people's objects too, which is the same bug wearing a nicer hat.

`bus.names` tracks the well-known names a connection owns, from the `NameAcquired`/`NameLost` signals the daemon sends unprompted. The `RequestName` reply is deliberately *not* consulted: it would be redundant, since the signal is emitted while the daemon handles `RequestName` — before any other client can learn the name has an owner, and therefore before any call to it can be routed here.

A peer-to-peer or pre-Hello connection is unaffected: with no unique name of its own there is nothing to compare against, so it answers everything exactly as before.

## Verification

`test/integration/eavesdropping.js` fails **three ways** without the fix and passes with it.

| | before | after |
|---|---|---|
| concurrent runs with failures | 3 / 10 | **0 / 15** |
| suite wall clock | 9.3s (serial) | **3.1s** (parallel) |

`--test-concurrency=1` is removed, so the suite is 3× faster and back to exercising concurrency.

| | dbus-daemon | broker |
|---|---|---|
| classic | 233/233 | 233/233 |
| `2.0` | 233/233 | 233/233 |
| `2.0-wrap` | 233/233 | 233/233 |

850 unit tests on Node 20.20, 22.16 and 26; integration green on the older two as well.
