### PR TITLE
feat: proxy.$watch() and proxy.$signal(), bounded

### DIFF
--- a/BIG_FUTURE_PLANS.md
+++ b/BIG_FUTURE_PLANS.md
@@ -184,7 +184,7 @@ Two consequences for the design:
   `[A-Za-z_][A-Za-z0-9_]*`, so `$` is a **guaranteed-collision-free** namespace
   rather than merely an unlikely one.
 
-### 2.4 Signals: the callback form is primary, not the iterable
+### 2.4 Signals: the callback form is primary, not the iterable ✅
 
 The original §5 led with `for await`. That emphasis is wrong, for two reasons
 that only became clear with the async-iterator-helper check.
@@ -215,6 +215,16 @@ for await (const [state] of nm.signal('StateChanged', { queue: 64 })) {
 unbounded option, because a long-lived daemon with an unbounded signal queue is
 a memory leak with a countdown, and this library's users skew toward long-lived
 daemons.
+
+**Shipped** as `proxy.$watch()` and `proxy.$signal()`. Two details the sketch
+did not settle: overflow drops the _oldest_, because a consumer catching up
+wants current state rather than what it already missed, and the count is on
+`iterator.dropped` so it is not silent. `$watch` earns its place separately
+from `$on` by resolving once the match rule is actually in place — `$on` cannot
+report that, so a signal emitted immediately after subscribing was a coin flip.
+
+The queue policy is `lib/signal-stream.js`, which is pure logic and unit-tested
+without a bus; only "the rule really goes on and comes off" needs a daemon.
 
 ### 2.5 The value-shape gate is the precondition, and it now exists
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -400,7 +400,9 @@ await notifications.$props.$set('Volume', 0.5);
 | `proxy.$props.Name`        | read a property — a promise                 |
 | `proxy.$props.$all()`      | every readable property, in one `GetAll`    |
 | `proxy.$props.$set(n, v)`  | write one, or an object of several          |
-| `proxy.$on/$once/$off`     | signals, wherever they are declared         |
+| `proxy.$watch(sig, fn)`    | subscribe; resolves when live, disposable   |
+| `proxy.$signal(sig, opts)` | the same signal as a bounded async iterable |
+| `proxy.$on/$once/$off`     | signals, fire and forget                    |
 | `proxy.$as(interfaceName)` | the underlying interface, for anything else |
 | `proxy.$service`, `$path`  | what it stands for                          |
 | `proxy.$interfaces`        | the interfaces it dispatches across         |
@@ -433,6 +435,48 @@ happen at construction rather than at first use.
 **Assignment is refused**, for properties and members alike. `obj.x = v`
 evaluates to `v` rather than to a promise, so a failed write would be silently
 lost; `$props.$set()` can be awaited.
+
+#### Signals from a proxy
+
+**The callback form is the primary one.** `$watch` resolves once the match rule
+is really in place — which `$on` cannot report, so a signal emitted immediately
+after subscribing used to be a coin flip — and hands back something that
+unsubscribes:
+
+```js
+const sub = await nm.$watch('StateChanged', state => {});
+await sub.remove(); // or Symbol.asyncDispose, so a scope can release it
+```
+
+**Iteration is the convenience**, for consuming in sequence:
+
+```js
+for await (const [state] of nm.$signal('StateChanged')) {
+  if (state === CONNECTED) break; // removes the match rule
+}
+```
+
+Leaving the loop — `break`, `return`, a throw, or an `AbortSignal` — removes
+the subscription, which is the point of the shape.
+
+It is deliberately the secondary API. Async iterator helpers are **not** in
+Node yet (checked on 26), so `.map()`, `.filter()` and `.take()` do not exist on
+these streams, and composing by hand with an async generator is a worse API than
+a callback.
+
+```js
+const stream = nm.$signal('StateChanged', {
+  queue: 'latest', // or a positive integer; 64 by default
+  signal: AbortSignal.timeout(30_000)
+});
+```
+
+**There is no unbounded option.** An async iterator is a queue and a signal is a
+broadcast, so a slow consumer has to lose something — and an unbounded signal
+queue in a long-lived process is a memory leak with a countdown. When the bound
+is reached the _oldest_ is dropped, because a consumer catching up wants current
+state rather than what it already missed, and `iterator.dropped` says how many
+went so it is not silent.
 
 `console.log(proxy)` prints what it stands for and what it can do, rather than
 walking the connection:

--- a/index.d.ts
+++ b/index.d.ts
@@ -628,12 +628,66 @@ export interface DBusProxy {
   $off(signal: string, handler: (...args: any[]) => void): this;
 
   /**
+   * Subscribe, and get something that unsubscribes.
+   *
+   * The primary signal API: it resolves once the match rule is really in
+   * place — which `$on` cannot report — and the subscription implements
+   * `Symbol.asyncDispose`.
+   */
+  $watch(
+    signal: string,
+    handler: (...args: any[]) => void
+  ): Promise<SignalSubscription>;
+
+  /**
+   * The same signal as an async iterable, for consuming in sequence.
+   *
+   * ```js
+   * for await (const [state] of nm.$signal('StateChanged')) {
+   *   if (state === CONNECTED) break; // removes the match rule
+   * }
+   * ```
+   *
+   * Bounded: `queue` is a positive integer or `'latest'`, defaulting to 64.
+   * There is no unbounded option — an unbounded signal queue in a long-lived
+   * process is a memory leak with a countdown.
+   */
+  $signal(signal: string, options?: SignalStreamOptions): SignalStream;
+
+  /**
    * Never present, whatever the object declares — a proxy that answered `then`
    * with a function would hang every `await` on it, forever.
    */
   readonly then?: undefined;
 
   [member: string]: any;
+}
+
+/** A signal subscription that can be removed, from `proxy.$watch()`. */
+export interface SignalSubscription {
+  readonly signal: string;
+  readonly removed: boolean;
+  remove(): Promise<void>;
+  [Symbol.asyncDispose](): Promise<void>;
+}
+
+export interface SignalStreamOptions {
+  /**
+   * How many undelivered signals to hold, or `'latest'` for just the most
+   * recent. Defaults to 64. There is deliberately no unbounded value.
+   */
+  queue?: number | 'latest';
+  /** Ends the loop and removes the match rule. */
+  signal?: AbortSignal;
+}
+
+export interface SignalStreamIterator extends AsyncIterableIterator<unknown[]> {
+  /** How many signals were discarded because the consumer fell behind. */
+  readonly dropped: number;
+}
+
+export interface SignalStream {
+  [Symbol.asyncIterator](): SignalStreamIterator;
 }
 
 /** A match rule that can be removed, from `bus.watch()`. */

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -15,6 +15,7 @@
 // BIG_FUTURE_PLANS 2, with the correction from 2.3.
 
 const util = require('util');
+const { signalStream } = require('./signal-stream');
 
 /**
  * Names the proxy must never manufacture a method for.
@@ -161,6 +162,15 @@ function createProxy(obj, options = {}) {
   const byProperty = index(interfaces, '$properties');
   const bySignal = index(interfaces, '$signals');
 
+  /** The one interface declaring this signal, or a thrown explanation. */
+  const signalInterface = signal => {
+    const interfaceName = resolve(bySignal, signal, 'Signal', path);
+    if (interfaceName === undefined) {
+      throw new Error(`No signal "${signal}" at ${path}`);
+    }
+    return interfaceName;
+  };
+
   const target = {
     $bus: obj.service.bus,
     $service: obj.service.name,
@@ -206,6 +216,59 @@ function createProxy(obj, options = {}) {
       if (interfaceName === undefined) return target;
       interfaces[interfaceName].off(signal, handler);
       return target;
+    },
+
+    /**
+     * Subscribe, and get something that unsubscribes.
+     *
+     * The primary signal API. Resolves once the match rule is actually in
+     * place, which `$on` cannot report, and the subscription implements
+     * `Symbol.asyncDispose` so leaving a scope releases it.
+     */
+    async $watch(signal, handler) {
+      const iface = interfaces[signalInterface(signal)];
+      await iface.$subscribe(signal, handler);
+      let removed = false;
+      const subscription = {
+        signal,
+        get removed() {
+          return removed;
+        },
+        async remove() {
+          if (removed) return;
+          removed = true;
+          await iface.$unsubscribe(signal, handler);
+        },
+        async [Symbol.asyncDispose]() {
+          await subscription.remove();
+        }
+      };
+      return subscription;
+    },
+
+    /**
+     * The same signal as an async iterable, for consuming in sequence.
+     *
+     *     for await (const [state] of nm.$signal('StateChanged')) {
+     *       if (state === CONNECTED) break; // removes the match rule
+     *     }
+     *
+     * Bounded: `queue` is a positive integer or `'latest'`, never unbounded.
+     * See lib/signal-stream.js for why, and `stream.dropped` for how many were
+     * discarded when the consumer fell behind.
+     */
+    $signal(signal, options) {
+      const interfaceName = signalInterface(signal);
+      return signalStream(async handler => {
+        // The stream hands us one argument per signal body; the interface
+        // emits them spread, so they are collected back into the array a
+        // `for await (const [a, b] of ...)` destructures.
+        const listener = (...args) => handler(args);
+        await interfaces[interfaceName].$subscribe(signal, listener);
+        return {
+          remove: () => interfaces[interfaceName].$unsubscribe(signal, listener)
+        };
+      }, options);
     }
   };
 

--- a/lib/signal-stream.js
+++ b/lib/signal-stream.js
@@ -1,0 +1,150 @@
+// Signals as an async iterable, with a bound on what it will hold.
+//
+// An async iterator is a queue and a signal is a broadcast. If the consumer is
+// slower than the bus, something has to give, and the only genuinely wrong
+// answer is to buffer without limit -- a long-lived daemon with an unbounded
+// signal queue is a memory leak with a countdown, and this library's users skew
+// toward long-lived daemons. So there is no unbounded option: `queue` is a
+// positive integer or the literal 'latest'.
+//
+// The callback form is the primary API and this is the convenience, which is
+// the opposite of how the first draft of BIG_FUTURE_PLANS put it. Async
+// iterator helpers are still not in Node (checked on 26), so `.map()`,
+// `.filter()` and `.take()` do not exist on these streams -- which removes most
+// of what made iteration attractive over a callback. See BIG_FUTURE_PLANS 2.4.
+
+const DEFAULT_QUEUE = 64;
+
+function normaliseQueue(queue) {
+  if (queue === undefined) return DEFAULT_QUEUE;
+  if (queue === 'latest') return 1;
+  if (Number.isInteger(queue) && queue > 0) return queue;
+  throw new TypeError(
+    `queue must be a positive integer or 'latest', got ${JSON.stringify(queue)}`
+  );
+}
+
+/**
+ * An async iterable over one signal.
+ *
+ * `subscribe(handler)` is called on the first `next()` and must resolve to
+ * something with a `remove()`. It is removed again when the loop ends, however
+ * it ends: `break`, `throw`, `return`, or the abort signal firing. That is the
+ * point of the shape -- the subscription is released by the language rather
+ * than by remembering to.
+ *
+ * @param {(handler: Function) => Promise<{remove: Function}>} subscribe
+ * @param {{queue?: number|'latest', signal?: AbortSignal}} [options]
+ */
+function signalStream(subscribe, options = {}) {
+  const limit = normaliseQueue(options.queue);
+  const abort = options.signal;
+
+  return {
+    [Symbol.asyncIterator]() {
+      /** Delivered but not yet consumed. */
+      const pending = [];
+      /** How many were dropped because the consumer fell behind. */
+      let dropped = 0;
+      /** Resolves the `next()` that is currently waiting, if any. */
+      let waiting = null;
+      let subscription = null;
+      let started = false;
+      let done = false;
+
+      const push = value => {
+        if (done) return;
+        if (waiting) {
+          const resolve = waiting;
+          waiting = null;
+          resolve({ value, done: false });
+          return;
+        }
+        pending.push(value);
+        // Drop the oldest rather than the newest: a consumer catching up wants
+        // the current state, not the state it already missed. Counted rather
+        // than silent -- `stream.dropped` is how anyone finds out.
+        while (pending.length > limit) {
+          pending.shift();
+          dropped++;
+        }
+      };
+
+      const finish = () => {
+        if (done) return Promise.resolve();
+        done = true;
+        if (waiting) {
+          const resolve = waiting;
+          waiting = null;
+          resolve({ value: undefined, done: true });
+        }
+        if (abort) abort.removeEventListener('abort', onAbort);
+        const sub = subscription;
+        subscription = null;
+        return sub
+          ? Promise.resolve(sub.remove()).catch(() => {})
+          : Promise.resolve();
+      };
+
+      function onAbort() {
+        finish();
+      }
+
+      const iterator = {
+        get dropped() {
+          return dropped;
+        },
+
+        async next() {
+          if (!started) {
+            started = true;
+            // Aborted before we began: subscribe to nothing.
+            if (abort && abort.aborted) {
+              done = true;
+              return { value: undefined, done: true };
+            }
+            try {
+              subscription = await subscribe(push);
+            } catch (err) {
+              done = true;
+              throw err;
+            }
+            // The abort may have fired while AddMatch was in flight.
+            if (abort) {
+              if (abort.aborted) {
+                await finish();
+                return { value: undefined, done: true };
+              }
+              abort.addEventListener('abort', onAbort, { once: true });
+            }
+          }
+          if (pending.length) return { value: pending.shift(), done: false };
+          if (done) return { value: undefined, done: true };
+          return new Promise(resolve => {
+            waiting = resolve;
+          });
+        },
+
+        // Called by `break`, an early `return`, or leaving the loop any other
+        // way. This is what makes the subscription lexically scoped.
+        async return(value) {
+          await finish();
+          return { value, done: true };
+        },
+
+        async throw(err) {
+          await finish();
+          throw err;
+        },
+
+        [Symbol.asyncIterator]() {
+          return iterator;
+        }
+      };
+
+      return iterator;
+    }
+  };
+}
+
+module.exports = { signalStream, normaliseQueue, DEFAULT_QUEUE };

--- a/test/integration/proxy-signals.js
+++ b/test/integration/proxy-signals.js
@@ -1,0 +1,190 @@
+// proxy.$watch() and proxy.$signal(), against a real bus.
+//
+// BIG_FUTURE_PLANS 2.4. The callback form is primary and the iterable is the
+// convenience -- the reverse of the original sketch, because async iterator
+// helpers are still not in Node, so `.map()`/`.filter()`/`.take()` do not exist
+// on these streams and most of what made iteration attractive is missing.
+//
+// The queue policy is unit-tested in test/signal-stream.js without a bus. What
+// needs a daemon is that the match rule really goes on and really comes off.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const { sessionBus } = require('../utils/shape');
+
+const NO_BUS =
+  !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
+
+const SERVICE = 'com.github.sidorares.dbusnative.Streamed';
+const PATH = '/com/github/sidorares/dbusnative/Streamed';
+const IFACE = 'com.github.sidorares.dbusnative.StreamedIface';
+
+const settle = (ms = 120) => new Promise(resolve => setTimeout(resolve, ms));
+
+describe('integration: proxy signals', { timeout: 20000, skip: NO_BUS }, () => {
+  let serviceBus, clientBus, impl, proxy;
+
+  const whenReady = bus =>
+    new Promise((resolve, reject) =>
+      bus.getId(err => (err ? reject(err) : resolve()))
+    );
+
+  before(async () => {
+    serviceBus = sessionBus();
+    clientBus = sessionBus();
+    await Promise.all([whenReady(serviceBus), whenReady(clientBus)]);
+    await new Promise((resolve, reject) =>
+      serviceBus.requestName(SERVICE, 0, err => (err ? reject(err) : resolve()))
+    );
+
+    impl = Object.assign(Object.create(EventEmitter.prototype), {});
+    EventEmitter.call(impl);
+    serviceBus.exportInterface(impl, PATH, {
+      name: IFACE,
+      methods: {},
+      signals: { Ticked: ['s', 'label'], Paired: ['si', 'name', 'count'] },
+      properties: {}
+    });
+
+    proxy = await clientBus.proxy(SERVICE, PATH);
+  });
+
+  after(async () => {
+    for (const bus of [serviceBus, clientBus]) if (bus) await bus.close();
+  });
+
+  describe('$watch', () => {
+    it('resolves once the match rule is really in place', async () => {
+      // $on cannot report that, which is the reason this exists: a signal
+      // emitted immediately after subscribing used to be a coin flip.
+      const seen = [];
+      const sub = await proxy.$watch('Ticked', label => seen.push(label));
+      impl.emit('Ticked', 'immediately after');
+      await settle();
+      assert.deepStrictEqual(seen, ['immediately after']);
+      await sub.remove();
+    });
+
+    it('stops delivering once removed', async () => {
+      const seen = [];
+      const sub = await proxy.$watch('Ticked', label => seen.push(label));
+      impl.emit('Ticked', 'before');
+      await settle();
+      await sub.remove();
+      assert.strictEqual(sub.removed, true);
+      impl.emit('Ticked', 'after');
+      await settle();
+      assert.deepStrictEqual(seen, ['before']);
+    });
+
+    it('removes through Symbol.asyncDispose, and only once', async () => {
+      const sub = await proxy.$watch('Ticked', () => {});
+      await sub[Symbol.asyncDispose]();
+      await sub[Symbol.asyncDispose]();
+      assert.strictEqual(sub.removed, true);
+    });
+
+    it('says so for a signal the object does not declare', async () => {
+      await assert.rejects(
+        () => proxy.$watch('Nope', () => {}),
+        /No signal "Nope"/
+      );
+    });
+  });
+
+  describe('$signal', () => {
+    it('iterates, and breaking removes the subscription', async () => {
+      const stream = proxy.$signal('Ticked');
+      const seen = [];
+
+      const loop = (async () => {
+        for await (const [label] of stream) {
+          seen.push(label);
+          if (label === 'stop') break;
+        }
+      })();
+
+      await settle();
+      impl.emit('Ticked', 'one');
+      await settle();
+      impl.emit('Ticked', 'stop');
+      await loop;
+
+      assert.deepStrictEqual(seen, ['one', 'stop']);
+
+      // The rule is off: a later signal reaches nothing. Checked through a
+      // fresh subscription rather than by inspecting internals.
+      const after = [];
+      const sub = await proxy.$watch('Ticked', l => after.push(l));
+      impl.emit('Ticked', 'later');
+      await settle();
+      assert.deepStrictEqual(after, ['later'], 'the bus still works');
+      await sub.remove();
+    });
+
+    it('destructures a multi-argument signal', async () => {
+      const stream = proxy.$signal('Paired');
+      const seen = [];
+      const loop = (async () => {
+        for await (const [name, count] of stream) {
+          seen.push([name, count]);
+          break;
+        }
+      })();
+      await settle();
+      impl.emit('Paired', 'widget', 7);
+      await loop;
+      assert.deepStrictEqual(seen, [['widget', 7]]);
+    });
+
+    it('ends on an AbortSignal', async () => {
+      const ac = new AbortController();
+      const stream = proxy.$signal('Ticked', { signal: ac.signal });
+      const seen = [];
+      const loop = (async () => {
+        for await (const [label] of stream) seen.push(label);
+      })();
+
+      await settle();
+      impl.emit('Ticked', 'before abort');
+      await settle();
+      ac.abort();
+      await loop;
+
+      assert.deepStrictEqual(seen, ['before abort']);
+    });
+
+    it('refuses an unbounded queue', () => {
+      // The one option that is deliberately unavailable.
+      assert.throws(
+        () => proxy.$signal('Ticked', { queue: 0 }),
+        /queue must be a positive integer or 'latest'/
+      );
+      assert.throws(
+        () => proxy.$signal('Ticked', { queue: Infinity }),
+        /queue must be a positive integer or 'latest'/
+      );
+    });
+
+    it('keeps the most recent when the consumer is slow', async () => {
+      const stream = proxy.$signal('Ticked', { queue: 2 });
+      const iterator = stream[Symbol.asyncIterator]();
+
+      // Take one, to get the subscription established.
+      const first = iterator.next();
+      await settle();
+      impl.emit('Ticked', 'a');
+      assert.deepStrictEqual((await first).value, ['a']);
+
+      // Four more with nobody waiting, against a bound of two.
+      for (const label of ['b', 'c', 'd', 'e']) impl.emit('Ticked', label);
+      await settle();
+
+      assert.deepStrictEqual((await iterator.next()).value, ['d']);
+      assert.deepStrictEqual((await iterator.next()).value, ['e']);
+      assert.strictEqual(iterator.dropped, 2);
+      await iterator.return();
+    });
+  });
+});

--- a/test/signal-stream.js
+++ b/test/signal-stream.js
@@ -1,0 +1,239 @@
+// The queue policy behind proxy.$signal(), tested without a bus.
+//
+// An async iterator is a queue and a signal is a broadcast, so the interesting
+// behaviour is all at the seam where the consumer is slower than the producer.
+// None of that needs a daemon.
+
+const { describe, it } = require('node:test');
+const assert = require('assert');
+const {
+  signalStream,
+  normaliseQueue,
+  DEFAULT_QUEUE
+} = require('../lib/signal-stream');
+
+/** A subscribe() that hands back the emitter, and records removal. */
+function fakeSource() {
+  const state = { emit: null, removed: 0, subscribed: 0 };
+  const subscribe = async handler => {
+    state.subscribed++;
+    state.emit = handler;
+    return {
+      remove() {
+        state.removed++;
+        state.emit = null;
+      }
+    };
+  };
+  return { state, subscribe };
+}
+
+const tick = () => new Promise(resolve => setImmediate(resolve));
+
+describe('signal stream: the queue bound', () => {
+  it("accepts a positive integer or 'latest', and nothing else", () => {
+    assert.strictEqual(normaliseQueue(undefined), DEFAULT_QUEUE);
+    assert.strictEqual(normaliseQueue(1), 1);
+    assert.strictEqual(normaliseQueue(500), 500);
+    assert.strictEqual(normaliseQueue('latest'), 1);
+
+    // There is deliberately no unbounded option: an unbounded signal queue in
+    // a long-lived daemon is a memory leak with a countdown.
+    for (const bad of [0, -1, 1.5, Infinity, null, 'all', 'unbounded', {}]) {
+      assert.throws(
+        () => normaliseQueue(bad),
+        /queue must be a positive integer or 'latest'/,
+        JSON.stringify(bad)
+      );
+    }
+  });
+
+  it('drops the oldest when the consumer falls behind, and counts it', async () => {
+    const { state, subscribe } = fakeSource();
+    const stream = signalStream(subscribe, { queue: 2 });
+    const it = stream[Symbol.asyncIterator]();
+
+    // Start the subscription, then let four arrive with nobody waiting.
+    const first = it.next();
+    await tick();
+    state.emit(['a']);
+    assert.deepStrictEqual((await first).value, ['a']);
+
+    state.emit(['b']);
+    state.emit(['c']);
+    state.emit(['d']);
+    state.emit(['e']);
+
+    // A consumer catching up wants the current state, not what it missed.
+    assert.deepStrictEqual((await it.next()).value, ['d']);
+    assert.deepStrictEqual((await it.next()).value, ['e']);
+    assert.strictEqual(it.dropped, 2, 'and it says how many went');
+    await it.return();
+  });
+
+  it("'latest' keeps exactly one", async () => {
+    const { state, subscribe } = fakeSource();
+    const it = signalStream(subscribe, { queue: 'latest' })[
+      Symbol.asyncIterator
+    ]();
+    const first = it.next();
+    await tick();
+    state.emit([1]);
+    await first;
+
+    state.emit([2]);
+    state.emit([3]);
+    state.emit([4]);
+    assert.deepStrictEqual((await it.next()).value, [4]);
+    assert.strictEqual(it.dropped, 2);
+    await it.return();
+  });
+
+  it('delivers straight through to a waiting consumer', async () => {
+    const { state, subscribe } = fakeSource();
+    const it = signalStream(subscribe)[Symbol.asyncIterator]();
+    const pending = it.next();
+    await tick();
+    state.emit(['immediate']);
+    assert.deepStrictEqual((await pending).value, ['immediate']);
+    assert.strictEqual(it.dropped, 0);
+    await it.return();
+  });
+});
+
+describe('signal stream: lifetime', () => {
+  it('subscribes once, on the first next()', async () => {
+    const { state, subscribe } = fakeSource();
+    const it = signalStream(subscribe)[Symbol.asyncIterator]();
+    assert.strictEqual(state.subscribed, 0, 'not until asked');
+
+    const first = it.next();
+    await tick();
+    assert.strictEqual(state.subscribed, 1);
+    state.emit([1]);
+    await first;
+    state.emit([2]);
+    await it.next();
+    assert.strictEqual(state.subscribed, 1, 'and only once');
+    await it.return();
+  });
+
+  it('unsubscribes when the loop breaks', async () => {
+    const { state, subscribe } = fakeSource();
+    const stream = signalStream(subscribe);
+
+    const seen = [];
+    const loop = (async () => {
+      for await (const value of stream) {
+        seen.push(value);
+        if (value[0] === 'stop') break;
+      }
+    })();
+
+    await tick();
+    state.emit(['go']);
+    await tick();
+    state.emit(['stop']);
+    await loop;
+
+    assert.deepStrictEqual(seen, [['go'], ['stop']]);
+    assert.strictEqual(state.removed, 1, 'break released the subscription');
+  });
+
+  it('unsubscribes when the loop throws', async () => {
+    const { state, subscribe } = fakeSource();
+    const stream = signalStream(subscribe);
+
+    const loop = (async () => {
+      // eslint-disable-next-line no-unused-vars
+      for await (const value of stream) {
+        throw new Error('from inside the loop');
+      }
+    })();
+
+    await tick();
+    state.emit([1]);
+    await assert.rejects(loop, /from inside the loop/);
+    assert.strictEqual(state.removed, 1);
+  });
+
+  it('surfaces a failed subscribe on the first next()', async () => {
+    const stream = signalStream(async () => {
+      throw new Error('AddMatch refused');
+    });
+    await assert.rejects(
+      (async () => {
+        for await (const _ of stream) void _;
+      })(),
+      /AddMatch refused/
+    );
+  });
+
+  it('is idempotent about finishing', async () => {
+    const { state, subscribe } = fakeSource();
+    const it = signalStream(subscribe)[Symbol.asyncIterator]();
+    const first = it.next();
+    await tick();
+    state.emit([1]);
+    await first;
+    await it.return();
+    await it.return();
+    assert.strictEqual(state.removed, 1);
+    assert.deepStrictEqual(await it.next(), { value: undefined, done: true });
+  });
+});
+
+describe('signal stream: AbortSignal', () => {
+  it('ends the loop and unsubscribes', async () => {
+    const { state, subscribe } = fakeSource();
+    const ac = new AbortController();
+    const stream = signalStream(subscribe, { signal: ac.signal });
+
+    const seen = [];
+    const loop = (async () => {
+      for await (const value of stream) seen.push(value);
+    })();
+
+    await tick();
+    state.emit(['before']);
+    await tick();
+    ac.abort();
+    await loop;
+
+    assert.deepStrictEqual(seen, [['before']]);
+    assert.strictEqual(state.removed, 1);
+  });
+
+  it('never subscribes if it was already aborted', async () => {
+    const { state, subscribe } = fakeSource();
+    const stream = signalStream(subscribe, { signal: AbortSignal.abort() });
+    const seen = [];
+    for await (const value of stream) seen.push(value);
+    assert.deepStrictEqual(seen, []);
+    assert.strictEqual(state.subscribed, 0, 'no AddMatch for a dead loop');
+  });
+
+  it('cleans up when it fires while AddMatch is in flight', async () => {
+    // The window that is easy to miss: abort between subscribe() being called
+    // and its promise settling, which would otherwise leave the rule in place
+    // with nothing consuming it.
+    const state = { removed: 0 };
+    const ac = new AbortController();
+    const stream = signalStream(
+      async () => {
+        ac.abort();
+        return {
+          remove() {
+            state.removed++;
+          }
+        };
+      },
+      { signal: ac.signal }
+    );
+
+    const seen = [];
+    for await (const value of stream) seen.push(value);
+    assert.deepStrictEqual(seen, []);
+    assert.strictEqual(state.removed, 1, 'the rule was taken back off');
+  });
+});


### PR DESCRIPTION
[BIG_FUTURE_PLANS §2.4](https://github.com/sidorares/dbus-native/blob/master/BIG_FUTURE_PLANS.md) — the last of the four corrections from the re-evaluation, and the one where the correction was about *emphasis*: the original design led with `for await`, and that is the wrong way round.

## `$watch` is the primary form

```js
const sub = await nm.$watch('StateChanged', state => { … });
await sub.remove();          // or Symbol.asyncDispose
```

It earns its place separately from `$on` by resolving once the match rule is **really in place**. `$on` returns `this` and cannot report that, so a signal emitted immediately after subscribing was a coin flip.

## `$signal` is the convenience

```js
for await (const [state] of nm.$signal('StateChanged')) {
  if (state === CONNECTED) break;   // removes the match rule
}
```

Leaving the loop by any route — `break`, `return`, a throw, or an `AbortSignal` — removes the subscription. That is the whole point of the shape.

It stays *secondary* on the evidence: **async iterator helpers are still not in Node** (re-checked on 26), so `.map()`, `.filter()` and `.take()` do not exist on these streams, and most of what made iteration attractive over a callback is simply missing.

## There is no unbounded queue

An async iterator is a queue and a signal is a broadcast, so a slow consumer has to lose something. An unbounded signal queue in a long-lived process is a memory leak with a countdown — and long-lived daemons are most of this library's audience. `queue` is a positive integer or `'latest'`, 64 by default, and `0`, `Infinity`, `'all'` and friends are rejected outright.

Two things the sketch left open, settled here:

- **Overflow drops the oldest.** A consumer catching up wants current state, not the state it already missed.
- **It is not silent.** `iterator.dropped` counts what went, so falling behind is discoverable rather than mysterious.

## Where the tests live

`lib/signal-stream.js` is pure queue logic with no bus in it, so the interesting cases are unit tested without a daemon — overflow, `'latest'`, break, throw, a failed `AddMatch`, an abort *while `AddMatch` is in flight* (the window that would otherwise leave a rule installed with nothing consuming it).

Only "the rule really goes on and really comes off" needs a daemon, and that is the integration test — which verifies removal by observing a later signal through a fresh subscription rather than by poking at internals.

## Verification

| | dbus-daemon | broker |
|---|---|---|
| classic | 242/242 | 242/242 |
| `2.0` | 242/242 | 242/242 |
| `2.0-wrap` | 242/242 | 242/242 |

862 unit tests on Node 20.20, 22.16 and 26; integration green on the older two.
