### PR TITLE
feat: defineInterface(), declaring a service without positional arrays

### DIFF
--- a/BIG_FUTURE_PLANS.md
+++ b/BIG_FUTURE_PLANS.md
@@ -407,8 +407,13 @@ The useful cut, now that the gate exists to verify it.
 - the Node floor (§4)
 - dropping `long`, `ReturnLongjs`, `dbus2js`, and `lib/address-x11.js` — which
   is published in `lib/` and throws `Cannot find module 'x11'` on require
-- `defineInterface` replacing the positional descriptor arrays (§7 of the
-  original, unchanged and still right)
+- ~~`defineInterface` replacing the positional descriptor arrays~~ — shipped
+  **additively** instead, which turned out to be the whole of it: it compiles
+  to the classic descriptor, so `exportInterface` is unchanged and nothing
+  downstream knows which spelling was used. Nothing had to break. The handler
+  context (#230) came for free, because `bus.js` already passed the message
+  after the arguments — what was missing was a shape around it rather than the
+  data.
 
 **Additive, ships whenever it is ready:**
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -600,6 +600,81 @@ iface.$signals; // { ActionInvoked: ['su', 'id', 'action'] }
 
 ## Exporting a service
 
+### `defineInterface()`
+
+```js
+const { defineInterface } = require('dbus-native');
+
+let volume = 0.5;
+
+const greeter = defineInterface({
+  name: 'com.example.Greeter',
+  methods: {
+    Hello: {
+      in: { name: 's' },
+      out: { greeting: 's' },
+      handler: ({ name }, { sender }) => `Hello ${name}, from ${sender}`
+    }
+  },
+  properties: {
+    Volume: {
+      type: 'd',
+      get: () => volume,
+      set: v => {
+        volume = v;
+      }
+    },
+    Version: { type: 's', access: 'read', get: () => '1.2.3' }
+  },
+  signals: { Greeted: { args: { who: 's' } } }
+});
+
+await bus.requestName('com.example.Greeter', 0);
+await using reg = await bus.export('/com/example/Greeter', greeter);
+
+greeter.emit.Greeted('world');
+```
+
+Four things this has that the positional form does not:
+
+- **Arguments have names in the source**, not just in the introspection XML,
+  and a handler receives them as an object. `in: { name: 's', count: 'u' }`
+  says what `'su'` meant.
+- **A handler is told who called it** — `{ sender, path, interface, member,
+message }`. That was reachable before only because the raw message happens to
+  be passed after the arguments, which is
+  [#230](https://github.com/sidorares/dbus-native/issues/230).
+- **A property can be computed.** `get`/`set` are functions, so a value can be
+  derived rather than stored, and a `set` still gets `PropertiesChanged`
+  emitted for it automatically.
+- **Mistakes are caught where they were written.** An unknown key, a `set` on a
+  read-only property, an invalid member name — all rejected by
+  `defineInterface()` rather than at export or on the first call.
+
+Returning values: give the value directly when one `out` is declared, and an
+object keyed by the `out` names when there are several.
+
+```js
+Split: {
+  in: { text: 's' },
+  out: { head: 's', tail: 's' },
+  handler: ({ text }) => ({ head: text[0], tail: text.slice(1) })
+}
+```
+
+That asymmetry is deliberate and matches how a reply is read: `invoke` hands
+back the value for a one-value reply and an array for several.
+
+`bus.export(path, definition)` resolves to a registration with `remove()` and
+`Symbol.asyncDispose`, so an exported object can be scoped like any other
+resource. `greeter.emit.Greeted(...)` throws if the interface has not been
+exported yet, rather than emitting into nothing.
+
+### The positional form
+
+Still supported, still what `exportInterface` takes, and what `defineInterface`
+compiles to:
+
 ```js
 const ifaceDesc = {
   name: 'com.example.Iface',

--- a/index.d.ts
+++ b/index.d.ts
@@ -663,6 +663,94 @@ export interface DBusProxy {
   [member: string]: any;
 }
 
+/** What a handler is told about the call it is answering. Closes #230. */
+export interface HandlerContext {
+  /** The caller's unique name. */
+  sender?: string;
+  path?: string;
+  interface?: string;
+  member?: string;
+  /** The whole message, for anything this does not name. */
+  message?: Message;
+}
+
+/** A method, declared with named arguments rather than four positional slots. */
+export interface MethodDefinition {
+  /** `{ name: 's', count: 'u' }` — order is the wire order. */
+  in?: Record<string, string>;
+  out?: Record<string, string>;
+  /**
+   * Called with the arguments by name and a context.
+   *
+   * Return the value directly when one `out` is declared; return an object
+   * keyed by the `out` names when there are several.
+   */
+  handler: (args: any, context: HandlerContext) => unknown;
+}
+
+export interface PropertyDefinition {
+  type: string;
+  /** Defaults to `readwrite`, and is enforced. */
+  access?: 'read' | 'write' | 'readwrite';
+  get?: () => unknown;
+  /** Writing through this emits `PropertiesChanged` for you. */
+  set?: (value: unknown) => void;
+  /** A plain starting value, instead of `get`/`set`. */
+  value?: unknown;
+}
+
+export interface InterfaceDefinition {
+  name: string;
+  methods?: Record<
+    string,
+    MethodDefinition | ((args: any, context: HandlerContext) => unknown)
+  >;
+  properties?: Record<string, PropertyDefinition | string>;
+  signals?: Record<string, { args?: Record<string, string> }>;
+}
+
+/** What `defineInterface()` produces. */
+export interface DefinedInterface {
+  readonly name: string;
+  /** The classic positional descriptor, for `exportInterface()`. */
+  readonly descriptor: InterfaceDescriptor;
+  /** The object the descriptor is bound to. */
+  readonly impl: Record<string, any>;
+  /** One function per declared signal. Throws before the interface is exported. */
+  readonly emit: Record<string, (...args: any[]) => void>;
+}
+
+/**
+ * Declare an interface without the positional arrays.
+ *
+ * ```js
+ * const greeter = defineInterface({
+ *   name: 'com.example.Greeter',
+ *   methods: {
+ *     Hello: {
+ *       in: { name: 's' },
+ *       out: { greeting: 's' },
+ *       handler: ({ name }, { sender }) => `Hello ${name}, from ${sender}`
+ *     }
+ *   }
+ * });
+ * ```
+ *
+ * Compiles to the classic descriptor, so it exports through the same path.
+ * Names, accessors and unknown keys are checked here — where the declaration
+ * was written — rather than at export or on the first call.
+ */
+export function defineInterface(spec: InterfaceDefinition): DefinedInterface;
+
+/** An exported interface that can be unexported, from `bus.export()`. */
+export interface ExportRegistration {
+  readonly path: string;
+  readonly interfaceName: string;
+  readonly removed: boolean;
+  remove(): Promise<void>;
+  [Symbol.asyncDispose](): Promise<void>;
+}
+
 /** A signal subscription that can be removed, from `proxy.$watch()`. */
 export interface SignalSubscription {
   readonly signal: string;
@@ -750,6 +838,18 @@ export interface MessageBus {
     handler: [(...args: any[]) => any, string]
   ): void;
   exportInterface(obj: unknown, path: string, iface: InterfaceDescriptor): void;
+
+  /**
+   * Export an interface definition, and get something that unexports it.
+   *
+   * ```js
+   * await using reg = await bus.export('/com/example/Greeter', greeter);
+   * ```
+   */
+  export(
+    path: string,
+    definition: DefinedInterface
+  ): Promise<ExportRegistration>;
 
   /**
    * Stop serving an object, or one interface of it.

--- a/index.js
+++ b/index.js
@@ -408,6 +408,12 @@ module.exports.isValidBusName = names.isValidBusName;
 
 module.exports.createConnection = createConnection;
 
+// Declaring a service interface without the positional arrays. Compiles to the
+// classic descriptor, so it exports through the same path. See
+// lib/define-interface.js.
+module.exports.defineInterface =
+  require('./lib/define-interface').defineInterface;
+
 module.exports.createServer = server.createServer;
 
 // An in-process message bus. Not a replacement for dbus-daemon -- no security

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -695,6 +695,42 @@ module.exports = function bus(conn, opts) {
   };
 
   /**
+   * Export an interface definition, and get something that unexports it.
+   *
+   *     const greeter = defineInterface({ ... });
+   *     await using reg = await bus.export('/com/example/Greeter', greeter);
+   *
+   * Takes what `defineInterface()` returns. `exportInterface()` is still there
+   * and still takes the positional descriptor; this is the same machinery with
+   * the lifetime attached.
+   */
+  this.export = async function (path, definition) {
+    if (!definition || !definition.descriptor || !definition.impl) {
+      throw new TypeError(
+        'bus.export expects an interface from defineInterface()'
+      );
+    }
+    self.exportInterface(definition.impl, path, definition.descriptor);
+    let removed = false;
+    const registration = {
+      path,
+      interfaceName: definition.name,
+      get removed() {
+        return removed;
+      },
+      async remove() {
+        if (removed) return;
+        removed = true;
+        self.unexportInterface(path, definition.name);
+      },
+      async [Symbol.asyncDispose]() {
+        await registration.remove();
+      }
+    };
+    return registration;
+  };
+
+  /**
    * Stop serving an object, or one interface of it.
    *
    * Needed for InterfacesRemoved to mean anything -- a manager that can only

--- a/lib/define-interface.js
+++ b/lib/define-interface.js
@@ -1,0 +1,248 @@
+// Declaring a service interface, without the positional arrays.
+//
+// The classic descriptor is `Echo: ['s', 's', ['input'], ['output']]` -- four
+// slots whose meaning has to be memorised, in an order nothing reminds you of.
+// It also has no room for anything else, which is why `access` arrived as a
+// second accepted spelling for the property value and why a handler's only
+// route to its caller's name is that the raw message happens to be passed after
+// the arguments.
+//
+//     const greeter = defineInterface({
+//       name: 'com.example.Greeter',
+//       methods: {
+//         Hello: {
+//           in: { name: 's' },
+//           out: { greeting: 's' },
+//           handler: ({ name }, { sender }) => `Hello ${name}, from ${sender}`
+//         }
+//       },
+//       properties: {
+//         Volume: { type: 'd', get: () => volume, set: v => (volume = v) }
+//       },
+//       signals: { Greeted: { args: { who: 's' } } }
+//     });
+//
+// It compiles to the classic descriptor and an impl object, so it exports
+// through the same path everything else does and nothing downstream needs to
+// know which spelling was used. BIG_FUTURE_PLANS 7.
+
+const { EventEmitter } = require('events');
+const {
+  assertValidName,
+  isValidMemberName,
+  isValidPropertyName
+} = require('./names');
+
+const ACCESS = new Set(['read', 'write', 'readwrite']);
+const METHOD_KEYS = new Set(['in', 'out', 'handler']);
+const PROPERTY_KEYS = new Set(['type', 'access', 'get', 'set', 'value']);
+const SIGNAL_KEYS = new Set(['args']);
+
+function checkKeys(what, name, given, allowed) {
+  for (const key of Object.keys(given)) {
+    if (!allowed.has(key)) {
+      throw new Error(
+        `${what} "${name}" has an unknown key "${key}"; expected ${[...allowed].join(', ')}`
+      );
+    }
+  }
+}
+
+/** `{ name: 's', count: 'u' }` -> `['su', ['name', 'count']]`. */
+function splitArgs(what, member, args) {
+  const names = Object.keys(args || {});
+  let signature = '';
+  for (const name of names) {
+    const type = args[name];
+    if (typeof type !== 'string') {
+      throw new Error(
+        `${what} "${member}" argument "${name}" must be a signature string, got ${typeof type}`
+      );
+    }
+    signature += type;
+  }
+  return [signature, names];
+}
+
+function defineMethod(name, spec, methods, impl) {
+  if (typeof spec === 'function') spec = { handler: spec };
+  if (!spec || typeof spec !== 'object') {
+    throw new Error(`Method "${name}" must be an object or a function`);
+  }
+  checkKeys('Method', name, spec, METHOD_KEYS);
+  if (typeof spec.handler !== 'function') {
+    throw new Error(`Method "${name}" needs a handler function`);
+  }
+
+  const [inSignature, inNames] = splitArgs('Method', name, spec.in);
+  const [outSignature, outNames] = splitArgs('Method', name, spec.out);
+  methods[name] = [inSignature, outSignature, inNames, outNames];
+
+  const handler = spec.handler;
+  impl[name] = function (...args) {
+    // bus.js calls a handler as `func.apply(impl, body.concat(msg))`, so the
+    // message is always last. Reading it from the end rather than by declared
+    // arity means a peer that sends the wrong number of arguments still gets a
+    // sensible context instead of the message being mistaken for one of them.
+    const msg = args[args.length - 1];
+    const body = args.slice(0, -1);
+
+    const named = {};
+    for (let i = 0; i < inNames.length; i++) named[inNames[i]] = body[i];
+
+    const context = {
+      sender: msg && msg.sender,
+      path: msg && msg.path,
+      interface: msg && msg['interface'],
+      member: msg && msg.member,
+      message: msg
+    };
+
+    const result = handler.call(this, named, context);
+    // Named going in, named coming back -- except for the single-value case,
+    // which is what a JavaScript function naturally returns and what `invoke`
+    // already hands a caller for a one-value reply. Wrapping that in an object
+    // would be ceremony for the overwhelmingly common shape.
+    if (outNames.length < 2) return result;
+    return Promise.resolve(result).then(values => {
+      if (!values || typeof values !== 'object') {
+        throw new Error(
+          `Method "${name}" declares ${outNames.length} return values, so it must return an object keyed by ${outNames.join(', ')}`
+        );
+      }
+      return outNames.map(key => values[key]);
+    });
+  };
+}
+
+function defineProperty(name, spec, properties, impl) {
+  if (typeof spec === 'string') spec = { type: spec };
+  if (!spec || typeof spec !== 'object') {
+    throw new Error(`Property "${name}" must be an object or a signature`);
+  }
+  checkKeys('Property', name, spec, PROPERTY_KEYS);
+  if (typeof spec.type !== 'string') {
+    throw new Error(`Property "${name}" needs a type`);
+  }
+
+  const access = spec.access === undefined ? 'readwrite' : spec.access;
+  if (!ACCESS.has(access)) {
+    throw new Error(
+      `Property "${name}" declares access "${access}"; expected one of ${[...ACCESS].join(', ')}`
+    );
+  }
+  if (spec.set && access === 'read') {
+    throw new Error(`Property "${name}" is read-only but declares a set`);
+  }
+  if (spec.get && access === 'write') {
+    throw new Error(`Property "${name}" is write-only but declares a get`);
+  }
+  if (spec.value !== undefined && (spec.get || spec.set)) {
+    throw new Error(
+      `Property "${name}" has both a value and an accessor; use one or the other`
+    );
+  }
+
+  properties[name] = { type: spec.type, access };
+
+  // Defined as an accessor because that is exactly how stdifaces reads and
+  // writes a property: `impl[name]` and `impl[name] = value`. So a computed
+  // property costs nothing extra, and a `set` still gets PropertiesChanged
+  // emitted for it by the ordinary path.
+  let stored = spec.value;
+  Object.defineProperty(impl, name, {
+    enumerable: true,
+    configurable: true,
+    get: spec.get ? () => spec.get() : () => stored,
+    set: spec.set
+      ? value => {
+          spec.set(value);
+        }
+      : value => {
+          stored = value;
+        }
+  });
+}
+
+function defineSignal(name, spec, signals) {
+  if (!spec || typeof spec !== 'object') {
+    throw new Error(`Signal "${name}" must be an object`);
+  }
+  checkKeys('Signal', name, spec, SIGNAL_KEYS);
+  const [signature, names] = splitArgs('Signal', name, spec.args);
+  signals[name] = [signature, ...names];
+}
+
+/**
+ * Compile an interface definition.
+ *
+ * @returns {{name: string, descriptor: object, impl: object, emit: object}}
+ *   `descriptor` and `impl` are what `exportInterface` takes; `emit` has one
+ *   function per declared signal.
+ */
+function defineInterface(spec) {
+  if (!spec || typeof spec !== 'object') {
+    throw new Error('defineInterface needs a definition object');
+  }
+  // Checked here rather than at export: a definition is a declaration, and the
+  // useful place to complain about one is where it was written.
+  assertValidName('interface name', spec.name, 'the interface definition');
+
+  const methods = {};
+  const signals = {};
+  const properties = {};
+  // An EventEmitter because that is what `exportInterface` wraps to put a
+  // signal on the bus -- it only patches `emit` if there is one to patch, so a
+  // plain object would export methods and properties fine and silently never
+  // emit anything.
+  const impl = Object.create(EventEmitter.prototype);
+  EventEmitter.call(impl);
+
+  for (const [name, method] of Object.entries(spec.methods || {})) {
+    if (!isValidMemberName(name)) {
+      throw new Error(`Method "${name}" is not a valid member name`);
+    }
+    defineMethod(name, method, methods, impl);
+  }
+  for (const [name, signal] of Object.entries(spec.signals || {})) {
+    if (!isValidMemberName(name)) {
+      throw new Error(`Signal "${name}" is not a valid member name`);
+    }
+    defineSignal(name, signal, signals);
+  }
+  for (const [name, property] of Object.entries(spec.properties || {})) {
+    // Looser than a member name on purpose: a property name is a string
+    // argument to Properties.Get, never a header field, and '-' in one is the
+    // GObject convention. See isValidPropertyName.
+    if (!isValidPropertyName(name)) {
+      throw new Error(`Property "${name}" is not a valid property name`);
+    }
+    defineProperty(name, property, properties, impl);
+  }
+
+  const descriptor = { name: spec.name, methods, signals, properties };
+
+  // `exportInterface` monkey-patches `impl.emit` to put the signal on the bus,
+  // so this is a named front for it -- `greeter.emit.Greeted('world')` rather
+  // than a stringly-typed `impl.emit('Greeted', 'world')`.
+  //
+  // Emitting before export would otherwise reach EventEmitter's own `emit` and
+  // do nothing at all on the bus, which is the kind of silence that costs an
+  // afternoon. The patch is an *own* property while EventEmitter's is on the
+  // prototype, so this tells them apart exactly.
+  const emit = {};
+  for (const name of Object.keys(signals)) {
+    emit[name] = (...args) => {
+      if (!Object.hasOwn(impl, 'emit')) {
+        throw new Error(
+          `Cannot emit "${name}": ${spec.name} has not been exported yet`
+        );
+      }
+      return impl.emit(name, ...args);
+    };
+  }
+
+  return { name: spec.name, descriptor, impl, emit };
+}
+
+module.exports = { defineInterface };

--- a/test/define-interface.js
+++ b/test/define-interface.js
@@ -1,0 +1,353 @@
+// defineInterface(): what it compiles to, and what it refuses.
+//
+// It produces the classic positional descriptor, so everything it does can be
+// checked without a bus -- the descriptor is the contract with the rest of the
+// library. What needs a daemon is only that a service built this way answers,
+// which is the integration test.
+
+const { describe, it } = require('node:test');
+const assert = require('assert');
+const { defineInterface } = require('../lib/define-interface');
+
+const MESSAGE = {
+  sender: ':1.7',
+  path: '/com/example/Obj',
+  interface: 'com.example.I',
+  member: 'Hello'
+};
+
+describe('defineInterface: the descriptor it compiles to', () => {
+  it('turns named arguments into a signature and a name list', () => {
+    const iface = defineInterface({
+      name: 'com.example.I',
+      methods: {
+        Hello: {
+          in: { name: 's', times: 'u' },
+          out: { greeting: 's' },
+          handler: () => ''
+        }
+      }
+    });
+    // Exactly what exportInterface has always taken.
+    assert.deepStrictEqual(iface.descriptor.methods.Hello, [
+      'su',
+      's',
+      ['name', 'times'],
+      ['greeting']
+    ]);
+  });
+
+  it('handles a method with no arguments either way', () => {
+    const iface = defineInterface({
+      name: 'com.example.I',
+      methods: { Ping: { handler: () => {} } }
+    });
+    assert.deepStrictEqual(iface.descriptor.methods.Ping, ['', '', [], []]);
+  });
+
+  it('accepts a bare function as a method', () => {
+    const iface = defineInterface({
+      name: 'com.example.I',
+      methods: { Ping: () => {} }
+    });
+    assert.deepStrictEqual(iface.descriptor.methods.Ping, ['', '', [], []]);
+  });
+
+  it('compiles signals to signature-then-names', () => {
+    const iface = defineInterface({
+      name: 'com.example.I',
+      signals: { Greeted: { args: { who: 's', count: 'i' } } }
+    });
+    assert.deepStrictEqual(iface.descriptor.signals.Greeted, [
+      'si',
+      'who',
+      'count'
+    ]);
+  });
+
+  it('compiles properties to { type, access }', () => {
+    const iface = defineInterface({
+      name: 'com.example.I',
+      properties: {
+        A: 's',
+        B: { type: 'd', access: 'read', get: () => 1 },
+        C: { type: 'b', access: 'write', set: () => {} }
+      }
+    });
+    assert.deepStrictEqual(iface.descriptor.properties, {
+      A: { type: 's', access: 'readwrite' },
+      B: { type: 'd', access: 'read' },
+      C: { type: 'b', access: 'write' }
+    });
+  });
+
+  it("accepts a property name with '-', as the looser rule allows", () => {
+    const iface = defineInterface({
+      name: 'com.example.I',
+      properties: { 'my-prop': 's' }
+    });
+    assert.ok(iface.descriptor.properties['my-prop']);
+  });
+});
+
+describe('defineInterface: handlers', () => {
+  const call = (iface, member, ...body) =>
+    iface.impl[member].apply(iface.impl, [...body, MESSAGE]);
+
+  it('receives arguments by name', () => {
+    const iface = defineInterface({
+      name: 'com.example.I',
+      methods: {
+        Hello: {
+          in: { name: 's', times: 'u' },
+          out: { greeting: 's' },
+          handler: ({ name, times }) => `${name} x${times}`
+        }
+      }
+    });
+    assert.strictEqual(call(iface, 'Hello', 'world', 3), 'world x3');
+  });
+
+  it('receives the caller in a context, which closes #230', () => {
+    // The message was already passed after the arguments, but only as an
+    // accident of argument order that a handler had to know about.
+    let seen;
+    const iface = defineInterface({
+      name: 'com.example.I',
+      methods: {
+        Hello: { in: { name: 's' }, handler: (_args, ctx) => (seen = ctx) }
+      }
+    });
+    call(iface, 'Hello', 'x');
+    assert.strictEqual(seen.sender, ':1.7');
+    assert.strictEqual(seen.path, '/com/example/Obj');
+    assert.strictEqual(seen.interface, 'com.example.I');
+    assert.strictEqual(seen.member, 'Hello');
+    assert.strictEqual(seen.message, MESSAGE);
+  });
+
+  it('reads the message from the end, not by declared arity', () => {
+    // A peer that sends more arguments than declared should still leave the
+    // context intact rather than have the message read as an argument.
+    let seen;
+    const iface = defineInterface({
+      name: 'com.example.I',
+      methods: {
+        Hello: { in: { name: 's' }, handler: (a, ctx) => (seen = ctx) }
+      }
+    });
+    iface.impl.Hello('x', 'unexpected', MESSAGE);
+    assert.strictEqual(seen.sender, ':1.7');
+  });
+
+  it('returns a single value directly', async () => {
+    const iface = defineInterface({
+      name: 'com.example.I',
+      methods: {
+        One: { out: { only: 's' }, handler: () => 'just this' }
+      }
+    });
+    assert.strictEqual(await call(iface, 'One'), 'just this');
+  });
+
+  it('returns several by name, converted to positional', async () => {
+    const iface = defineInterface({
+      name: 'com.example.I',
+      methods: {
+        Two: {
+          out: { a: 's', b: 'i' },
+          handler: () => ({ b: 2, a: 'first' })
+        }
+      }
+    });
+    // Declaration order, not the order the handler happened to write them.
+    assert.deepStrictEqual(await call(iface, 'Two'), ['first', 2]);
+  });
+
+  it('says so when a multi-value handler returns the wrong shape', async () => {
+    const iface = defineInterface({
+      name: 'com.example.I',
+      methods: {
+        Two: { out: { a: 's', b: 'i' }, handler: () => 'not an object' }
+      }
+    });
+    await assert.rejects(
+      () => Promise.resolve(call(iface, 'Two')),
+      /declares 2 return values, so it must return an object keyed by a, b/
+    );
+  });
+
+  it('awaits an async handler before rearranging its result', async () => {
+    const iface = defineInterface({
+      name: 'com.example.I',
+      methods: {
+        Two: {
+          out: { a: 's', b: 'i' },
+          handler: async () => ({ a: 'x', b: 1 })
+        }
+      }
+    });
+    assert.deepStrictEqual(await call(iface, 'Two'), ['x', 1]);
+  });
+});
+
+describe('defineInterface: properties', () => {
+  it('reads and writes through get/set, as stdifaces does', () => {
+    let volume = 0.5;
+    const iface = defineInterface({
+      name: 'com.example.I',
+      properties: {
+        Volume: {
+          type: 'd',
+          get: () => volume,
+          set: v => {
+            volume = v;
+          }
+        }
+      }
+    });
+    // stdifaces uses plain property access, so an accessor is all it takes.
+    assert.strictEqual(iface.impl.Volume, 0.5);
+    iface.impl.Volume = 0.9;
+    assert.strictEqual(volume, 0.9);
+    assert.strictEqual(iface.impl.Volume, 0.9);
+  });
+
+  it('stores a plain value when there is no accessor', () => {
+    const iface = defineInterface({
+      name: 'com.example.I',
+      properties: { Greeting: { type: 's', value: 'hello' } }
+    });
+    assert.strictEqual(iface.impl.Greeting, 'hello');
+    iface.impl.Greeting = 'changed';
+    assert.strictEqual(iface.impl.Greeting, 'changed');
+  });
+
+  it('recomputes a getter every read', () => {
+    let n = 0;
+    const iface = defineInterface({
+      name: 'com.example.I',
+      properties: { Count: { type: 'u', access: 'read', get: () => ++n } }
+    });
+    assert.strictEqual(iface.impl.Count, 1);
+    assert.strictEqual(iface.impl.Count, 2);
+  });
+});
+
+describe('defineInterface: what it refuses', () => {
+  const bad = (spec, message) =>
+    assert.throws(() => defineInterface(spec), message);
+
+  it('needs a valid interface name', () => {
+    bad({ name: 'nodots' }, /interface name/);
+    bad({}, /interface name/);
+    assert.throws(() => defineInterface(), /needs a definition object/);
+  });
+
+  it('needs a handler on every method', () => {
+    bad(
+      { name: 'com.example.I', methods: { Hello: { in: { a: 's' } } } },
+      /needs a handler function/
+    );
+  });
+
+  it('rejects an unknown key, rather than ignoring it', () => {
+    // A typo in a declaration is silent forever otherwise.
+    bad(
+      {
+        name: 'com.example.I',
+        methods: { Hello: { handler: () => {}, input: { a: 's' } } }
+      },
+      /unknown key "input"/
+    );
+    bad(
+      {
+        name: 'com.example.I',
+        properties: { A: { type: 's', acces: 'read' } }
+      },
+      /unknown key "acces"/
+    );
+    bad(
+      { name: 'com.example.I', signals: { S: { arguments: {} } } },
+      /unknown key "arguments"/
+    );
+  });
+
+  it('rejects an accessor that contradicts the access', () => {
+    bad(
+      {
+        name: 'com.example.I',
+        properties: { A: { type: 's', access: 'read', set: () => {} } }
+      },
+      /read-only but declares a set/
+    );
+    bad(
+      {
+        name: 'com.example.I',
+        properties: { A: { type: 's', access: 'write', get: () => 1 } }
+      },
+      /write-only but declares a get/
+    );
+  });
+
+  it('rejects a value alongside an accessor', () => {
+    bad(
+      {
+        name: 'com.example.I',
+        properties: { A: { type: 's', value: 'x', get: () => 'y' } }
+      },
+      /use one or the other/
+    );
+  });
+
+  it('rejects an invalid member name at definition time', () => {
+    bad(
+      { name: 'com.example.I', methods: { 'not-a-member': () => {} } },
+      /not a valid member name/
+    );
+    bad(
+      { name: 'com.example.I', signals: { 'not-a-member': { args: {} } } },
+      /not a valid member name/
+    );
+  });
+
+  it('rejects a non-string signature', () => {
+    bad(
+      {
+        name: 'com.example.I',
+        methods: { Hello: { in: { a: 42 }, handler: () => {} } }
+      },
+      /must be a signature string/
+    );
+  });
+
+  it('rejects an unknown access', () => {
+    bad(
+      { name: 'com.example.I', properties: { A: { type: 's', access: 'rw' } } },
+      /expected one of read, write, readwrite/
+    );
+  });
+});
+
+describe('defineInterface: emit', () => {
+  it('refuses before export rather than silently doing nothing', () => {
+    const iface = defineInterface({
+      name: 'com.example.I',
+      signals: { Greeted: { args: { who: 's' } } }
+    });
+    // The impl is an EventEmitter, so emitting would otherwise reach its own
+    // emit() and go nowhere near the bus.
+    assert.throws(
+      () => iface.emit.Greeted('world'),
+      /has not been exported yet/
+    );
+  });
+
+  it('has one function per declared signal, and no others', () => {
+    const iface = defineInterface({
+      name: 'com.example.I',
+      signals: { A: { args: {} }, B: { args: { x: 's' } } }
+    });
+    assert.deepStrictEqual(Object.keys(iface.emit).sort(), ['A', 'B']);
+  });
+});

--- a/test/integration/define-interface.js
+++ b/test/integration/define-interface.js
@@ -1,0 +1,242 @@
+// A service declared with defineInterface(), answering on a real bus.
+//
+// The compilation is unit-tested without a daemon; what needs one is that the
+// result actually serves -- methods, properties with accessors, the automatic
+// PropertiesChanged, signals, and the introspection XML a client reads to build
+// a proxy from it.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('assert');
+const dbus = require('../../index');
+const { sessionBus } = require('../utils/shape');
+
+const NO_BUS =
+  !process.env.DBUS_SESSION_BUS_ADDRESS && 'no DBUS_SESSION_BUS_ADDRESS';
+
+const SERVICE = 'com.github.sidorares.dbusnative.Defined';
+const PATH = '/com/github/sidorares/dbusnative/Defined';
+const IFACE = 'com.github.sidorares.dbusnative.DefinedIface';
+
+const settle = (ms = 120) => new Promise(resolve => setTimeout(resolve, ms));
+
+describe(
+  'integration: defineInterface',
+  { timeout: 20000, skip: NO_BUS },
+  () => {
+    let serviceBus, clientBus, greeter, proxy, registration;
+    let volume = 0.5;
+    let callers = [];
+
+    const whenReady = bus =>
+      new Promise((resolve, reject) =>
+        bus.getId(err => (err ? reject(err) : resolve()))
+      );
+
+    before(async () => {
+      serviceBus = sessionBus();
+      clientBus = sessionBus();
+      await Promise.all([whenReady(serviceBus), whenReady(clientBus)]);
+      await new Promise((resolve, reject) =>
+        serviceBus.requestName(SERVICE, 0, err =>
+          err ? reject(err) : resolve()
+        )
+      );
+
+      greeter = dbus.defineInterface({
+        name: IFACE,
+        methods: {
+          Hello: {
+            in: { name: 's' },
+            out: { greeting: 's' },
+            handler: ({ name }, { sender }) => {
+              callers.push(sender);
+              return `Hello ${name}`;
+            }
+          },
+          Split: {
+            in: { text: 's' },
+            out: { head: 's', tail: 's' },
+            handler: ({ text }) => ({
+              head: text.slice(0, 1),
+              tail: text.slice(1)
+            })
+          },
+          Fail: {
+            handler: () => {
+              const err = new Error('as declared');
+              err.dbusName = 'com.example.Error.Declared';
+              throw err;
+            }
+          }
+        },
+        properties: {
+          Volume: {
+            type: 'd',
+            get: () => volume,
+            set: v => {
+              volume = v;
+            }
+          },
+          Version: { type: 's', access: 'read', get: () => '1.2.3' },
+          Secret: { type: 's', access: 'write', set: () => {} }
+        },
+        signals: { Greeted: { args: { who: 's' } } }
+      });
+
+      registration = await serviceBus.export(PATH, greeter);
+      proxy = await clientBus.proxy(SERVICE, PATH, { interface: IFACE });
+    });
+
+    after(async () => {
+      if (registration) await registration.remove();
+      for (const bus of [serviceBus, clientBus]) if (bus) await bus.close();
+    });
+
+    describe('methods', () => {
+      it('answers, with arguments arriving by name', async () => {
+        assert.strictEqual(await proxy.Hello('world'), 'Hello world');
+      });
+
+      it('tells the handler who called, which closes #230', async () => {
+        callers = [];
+        await proxy.Hello('again');
+        assert.strictEqual(callers.length, 1);
+        assert.strictEqual(callers[0], clientBus.name);
+        assert.match(callers[0], /^:\d+\.\d+$/);
+      });
+
+      it('returns several values, in declaration order', async () => {
+        // The handler returns { head, tail }; the wire wants them positional.
+        assert.deepStrictEqual(await proxy.Split('abc'), ['a', 'bc']);
+      });
+
+      it('propagates a thrown error with its name', async () => {
+        await assert.rejects(() => proxy.Fail(), {
+          dbusName: 'com.example.Error.Declared',
+          message: 'as declared'
+        });
+      });
+    });
+
+    describe('properties', () => {
+      it('reads through the getter', async () => {
+        assert.strictEqual(await proxy.$props.Version, '1.2.3');
+        assert.strictEqual(await proxy.$props.Volume, 0.5);
+      });
+
+      it('writes through the setter', async () => {
+        await proxy.$props.$set('Volume', 0.75);
+        assert.strictEqual(volume, 0.75, 'the setter ran');
+        assert.strictEqual(await proxy.$props.Volume, 0.75);
+      });
+
+      it('enforces the declared access', async () => {
+        await assert.rejects(() => proxy.$props.$set('Version', 'nope'), {
+          dbusName: 'org.freedesktop.DBus.Error.PropertyReadOnly'
+        });
+        await assert.rejects(() => proxy.$props.Secret, {
+          dbusName: 'org.freedesktop.DBus.Error.AccessDenied'
+        });
+      });
+
+      it('omits the write-only one from GetAll', async () => {
+        const all = await proxy.$props.$all();
+        assert.deepStrictEqual(Object.keys(all).sort(), ['Version', 'Volume']);
+      });
+
+      it('emits PropertiesChanged on a write, without being asked', async () => {
+        const changed = new Promise(resolve => {
+          const key = clientBus.mangle(
+            PATH,
+            'org.freedesktop.DBus.Properties',
+            'PropertiesChanged'
+          );
+          clientBus.signals.once(key, body => resolve(body));
+        });
+        await clientBus.addMatch(
+          `type='signal',path='${PATH}',interface='org.freedesktop.DBus.Properties'`
+        );
+        await proxy.$props.$set('Volume', 0.25);
+        const [interfaceName, values] = await changed;
+        assert.strictEqual(interfaceName, IFACE);
+        assert.deepStrictEqual(require('../../lib/values').toPlain(values), {
+          Volume: 0.25
+        });
+      });
+    });
+
+    describe('signals', () => {
+      it('emits by name', async () => {
+        const seen = [];
+        const sub = await proxy.$watch('Greeted', who => seen.push(who));
+        greeter.emit.Greeted('world');
+        await settle();
+        assert.deepStrictEqual(seen, ['world']);
+        await sub.remove();
+      });
+    });
+
+    describe('introspection', () => {
+      it('advertises the arguments with the names they were given', async () => {
+        const xml = await clientBus.invoke({
+          destination: SERVICE,
+          path: PATH,
+          interface: 'org.freedesktop.DBus.Introspectable',
+          member: 'Introspect'
+        });
+        assert.match(xml, new RegExp(`<interface name="${IFACE}">`));
+        assert.match(
+          xml,
+          /<arg type="s" name="name" direction="in" ?\/>/,
+          'the in argument keeps its name'
+        );
+        assert.match(
+          xml,
+          /<arg type="s" name="greeting" direction="out" ?\/>/,
+          'and so does the out one'
+        );
+        assert.match(xml, /<property name="Version" type="s" access="read"\/>/);
+        assert.match(xml, /<property name="Secret" type="s" access="write"\/>/);
+        assert.match(xml, /<signal name="Greeted">/);
+        assert.match(xml, /<arg type="s" name="who" ?\/>/);
+      });
+    });
+
+    describe('the registration', () => {
+      it('unexports, and the object stops answering', async () => {
+        const iface = dbus.defineInterface({
+          name: 'com.github.sidorares.dbusnative.Temporary',
+          methods: { Knock: { out: { answer: 's' }, handler: () => 'pong' } }
+        });
+        const temp = `${PATH}/temp`;
+        const reg = await serviceBus.export(temp, iface);
+
+        const scoped = await clientBus.proxy(SERVICE, temp);
+        assert.strictEqual(await scoped.Knock(), 'pong');
+
+        await reg.remove();
+        assert.strictEqual(reg.removed, true);
+        await assert.rejects(() => scoped.Knock(), {
+          dbusName: 'org.freedesktop.DBus.Error.UnknownMethod'
+        });
+      });
+
+      it('releases through Symbol.asyncDispose', async () => {
+        const iface = dbus.defineInterface({
+          name: 'com.github.sidorares.dbusnative.Disposed',
+          methods: { Knock: { handler: () => {} } }
+        });
+        const reg = await serviceBus.export(`${PATH}/disposed`, iface);
+        await reg[Symbol.asyncDispose]();
+        assert.strictEqual(reg.removed, true);
+      });
+
+      it('rejects something that is not a definition', async () => {
+        await assert.rejects(
+          () => serviceBus.export(`${PATH}/nope`, { name: 'x' }),
+          /expects an interface from defineInterface/
+        );
+      });
+    });
+  }
+);


### PR DESCRIPTION
[BIG_FUTURE_PLANS §7](https://github.com/sidorares/dbus-native/blob/master/BIG_FUTURE_PLANS.md).

The classic descriptor is `Echo: ['s', 's', ['input'], ['output']]` — four slots whose meaning has to be memorised, in an order nothing reminds you of, and with no room for anything else. That is why `access` arrived as a *second accepted spelling* for the property value, and why a handler's only route to its caller's name is that the raw message happens to be passed after the arguments.

```js
const greeter = defineInterface({
  name: 'com.example.Greeter',
  methods: {
    Hello: {
      in: { name: 's' },
      out: { greeting: 's' },
      handler: ({ name }, { sender }) => `Hello ${name}, from ${sender}`
    }
  },
  properties: {
    Volume: { type: 'd', get: () => volume, set: v => (volume = v) }
  },
  signals: { Greeted: { args: { who: 's' } } }
});

await using reg = await bus.export('/com/example/Greeter', greeter);
greeter.emit.Greeted('world');
```

## Additive, which turned out to be the whole of it

§6 listed this under *"breaking, needs the major"*, on the assumption it would **replace** the positional form. It compiles **to** the positional form instead — so `exportInterface` is untouched, nothing downstream knows which spelling was used, and nothing needed to break. That is one fewer item on the major.

## What it has that the arrays do not

- **Arguments have names in the source**, not just in the introspection XML, and the handler receives them as an object. `in: { name: 's', count: 'u' }` says what `'su'` meant.
- **A handler is told who called it** — `{ sender, path, interface, member, message }`. That closes [#230](https://github.com/sidorares/dbus-native/issues/230), and it cost nothing: `bus.js` already passed the message after the arguments, so what was missing was a *shape* around it rather than the data.
- **A property can be computed.** `get`/`set` become accessors on the impl, which is exactly how `stdifaces` reads and writes one — so a derived value works, and a `set` still gets `PropertiesChanged` emitted automatically.
- **Mistakes are caught where they were written**: an unknown key (a typo in a declaration is otherwise silent forever), a `set` on a read-only property, an invalid member name.

## Two decisions worth recording

**One `out` returns the value; several return an object keyed by name.** The asymmetry is deliberate and mirrors how a reply is *read* — `invoke` hands back the value for a one-value reply and an array for several. Requiring `{ greeting: x }` for the overwhelmingly common single-value case would be ceremony.

**The impl is an EventEmitter.** `exportInterface` only patches `emit` if there is one to patch, so a plain object would have exported methods and properties fine and then silently never emitted a signal. For the same reason `greeter.emit.Greeted()` *throws* before export rather than reaching EventEmitter's own `emit` and going nowhere near the bus — detected by whether `emit` is an own property, since the patch makes it one and the prototype's is not.

## Verification

26 unit tests on the compilation and what it refuses — the descriptor is the contract with the rest of the library, so none of that needs a daemon. 14 integration tests on a service actually answering, including the introspection XML a client builds a proxy from.

Two of those integration tests failed first time and both were my own: the library emits `<arg … />` with a space before the slash, and I named a test method `Ping`, which collides with `org.freedesktop.DBus.Peer.Ping` — so `bus.proxy()` correctly refused to guess between them. An unplanned check that #367's ambiguity rule works.

| | dbus-daemon | broker |
|---|---|---|
| classic | 256/256 | 256/256 |
| `2.0` | 256/256 | 256/256 |
| `2.0-wrap` | 256/256 | 256/256 |

888 unit tests on Node 20.20, 22.16 and 26; integration green on the older two.
