### PR TITLE
feat: reconnect, opt-in, restoring names and match rules

### DIFF
--- a/BIG_FUTURE_PLANS.md
+++ b/BIG_FUTURE_PLANS.md
@@ -284,7 +284,7 @@ await tree.add('/com/example/Thing1', thing); // InterfacesAdded emitted
 This closes a whole category of tracker questions and is, in my judgement, worth
 more per line than proxies.
 
-### 3.2 Reconnection
+### 3.2 Reconnection ✅
 
 A daemon that loses the bus currently has no story at all. For an audience that
 skews toward Raspberry Pi and Homebridge — where ~41k weekly downloads sit on a
@@ -303,6 +303,18 @@ bus.on('reconnected', () => {
 The hard part is not the socket, it is that a reconnect invalidates the unique
 name, every match rule and every owned name. Whatever ships must re-establish
 those or say loudly that it does not.
+
+**Shipped**, opt-in, and it does re-establish all three -- before `reconnected`
+fires, so a service is reachable by the time anyone hears about it. What it
+does _not_ do is retry calls that were in flight: they were already failed when
+the socket went, and a method call is not idempotent. Re-issuing is the
+caller's decision, which is what the event is for.
+
+Building it turned up two bugs that had nothing to do with reconnection and
+everything to do with nothing ever having reconnected before: `lib/broker.js`
+removed the parent directory of its socket on close whether or not it had
+created it, and `bus.names` held the unique name alongside the well-known ones
+-- harmless until something tried to re-request them.
 
 ### 3.3 The file-descriptor transport seam — the one breaking thing that must land now
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -106,6 +106,7 @@ socket other processes can reach.
 | `plainValues`    | `boolean`                 | `false`                                         | read variants and dicts in the 2.0 shapes — see below          |
 | `variants`       | `'tree'\|'plain'\|'wrap'` | follows `plainValues`                           | how a `v` comes back; `'wrap'` keeps the signature — see below |
 | `ReturnLongjs`   | `boolean`                 | `false`                                         | **deprecated** (`DBUS_DEP0001`) — 64-bit as Long.js            |
+| `reconnect`      | `boolean \| object`       | `false`                                         | reconnect when the transport goes away — see below             |
 
 Address forms understood by `busAddress`: `unix:path=…`, `unix:abstract=…`,
 `unix:socket=…`, `tcp:host=…,port=…`, `unixexec:path=…,arg1=…`, and
@@ -307,6 +308,54 @@ Three details that matter if you write a transport:
   cork and goes on its own.
 - **Ownership is yours.** Nothing here dups or closes anything; a received
   descriptor is a live fd in your process and closing it is your job.
+
+### Reconnecting
+
+**Off by default**, and deliberately so: reconnecting changes what a connection
+means. The unique name is reassigned, so anyone holding the old one is talking
+to nobody, and every well-known name and match rule is gone until it is asked
+for again. That is a decision for the program.
+
+```js
+const bus = dbus.sessionBus({
+  reconnect: { retries: Infinity, minDelay: 100, maxDelay: 30_000, factor: 2 }
+});
+
+bus.on('reconnected', ({ name, names }) => {
+  // new unique name, and `names` are back
+});
+```
+
+`reconnect: true` takes the defaults above.
+
+| event                                    | on         |                                               |
+| ---------------------------------------- | ---------- | --------------------------------------------- |
+| `reconnecting` `{attempt, delay, cause}` | connection | a retry is scheduled                          |
+| `reconnect`                              | connection | the transport is back, nothing restored yet   |
+| `reconnected` `{name, names}`            | bus        | names and match rules are back                |
+| `reconnectError`                         | bus        | reconnected, but restoring them failed        |
+| `reconnectFailed`                        | connection | `retries` exhausted, nothing more will happen |
+
+**What comes back**, before `reconnected` fires: the unique name (a fresh
+`Hello`), every well-known name in `bus.names`, and every match rule added
+through `bus.addMatch` — which includes everything `bus.watch()`,
+`proxy.$watch()` and `bus.objects()` install. Objects exported with
+`exportInterface` never went anywhere; they live on the bus, not on the socket.
+
+**What does not.** A rule installed by calling
+`invokeDbus({ member: 'AddMatch' })` directly is not recorded and will not
+return. And **nothing in flight is retried** — those calls were already failed
+with `ConnectionClosedError` when the socket went, and a method call is not
+idempotent, so replaying one could charge a card twice. Re-issuing is yours to
+decide, which is what `reconnected` is for.
+
+Retries back off exponentially to `maxDelay`, because the usual reason a bus is
+unreachable is that it is restarting and hammering it does not help. A pending
+retry does not hold the process open.
+
+`reconnect` cannot be combined with `opts.stream`: a stream the caller supplied
+cannot be reopened, and pretending otherwise would redial the same dead socket
+forever. It throws at construction rather than at the first disconnect.
 
 ### Scoped resources
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -350,8 +350,12 @@ idempotent, so replaying one could charge a card twice. Re-issuing is yours to
 decide, which is what `reconnected` is for.
 
 Retries back off exponentially to `maxDelay`, because the usual reason a bus is
-unreachable is that it is restarting and hammering it does not help. A pending
-retry does not hold the process open.
+unreachable is that it is restarting and hammering it does not help.
+
+A pending retry **does** hold the event loop open, exactly as a live socket
+would. A daemon whose bus restarted should not exit during the gap — that is
+the case this exists for. `bus.close()` cancels the retry, so a program that
+wants to stop still can.
 
 `reconnect` cannot be combined with `opts.stream`: a stream the caller supplied
 cannot be reopened, and pretending otherwise would redial the same dead socket

--- a/index.d.ts
+++ b/index.d.ts
@@ -282,6 +282,30 @@ export interface ConnectionOptions {
   maxMessageSize?: number;
   /** default timeout in ms for every call on this client; default: no timeout */
   timeout?: number;
+  /**
+   * Reconnect when the transport goes away. **Off by default**, because
+   * reconnecting changes what a connection means: the unique name is
+   * reassigned, so anyone holding the old one is talking to nobody.
+   *
+   * `true` for the defaults, or an object to tune them. Cannot be combined
+   * with `stream` — a stream the caller supplied cannot be reopened.
+   *
+   * Nothing in flight is retried. A method call is not idempotent, so calls
+   * are failed with `ConnectionClosedError` and re-issuing is the caller's
+   * decision — that is what `bus.on('reconnected')` is for.
+   */
+  reconnect?:
+    | boolean
+    | {
+        /** default `Infinity` */
+        retries?: number;
+        /** first delay, ms; default 100 */
+        minDelay?: number;
+        /** ceiling, ms; default 30000 */
+        maxDelay?: number;
+        /** backoff multiplier; default 2 */
+        factor?: number;
+      };
 }
 
 export interface DBusConnection extends EventEmitter {
@@ -329,6 +353,15 @@ export interface DBusConnection extends EventEmitter {
   on(event: 'error', listener: (err: Error) => void): this;
   /** an exception thrown by one of your own message/signal listeners */
   on(event: 'handlerError', listener: (err: Error) => void): this;
+  /** A retry is scheduled. Only with `reconnect`. */
+  on(
+    event: 'reconnecting',
+    listener: (info: { attempt: number; delay: number; cause?: Error }) => void
+  ): this;
+  /** The transport is back, before the bus has re-established anything. */
+  on(event: 'reconnect', listener: () => void): this;
+  /** `retries` exhausted; nothing further will be attempted. */
+  on(event: 'reconnectFailed', listener: (cause?: Error) => void): this;
   on(event: string, listener: (...args: any[]) => void): this;
 }
 
@@ -797,8 +830,25 @@ export interface NameRegistration {
   [Symbol.asyncDispose](): Promise<void>;
 }
 
-export interface MessageBus {
+export interface MessageBus extends EventEmitter {
   connection: DBusConnection;
+
+  /**
+   * Reconnected, and the unique name, owned names and match rules are back.
+   * Only with `reconnect`. Nothing in flight was retried.
+   */
+  on(
+    event: 'reconnected',
+    listener: (info: { name: string; names: string[] }) => void
+  ): this;
+  /** Reconnected, but re-establishing the names or rules failed. */
+  on(event: 'reconnectError', listener: (err: Error) => void): this;
+  on(event: string, listener: (...args: any[]) => void): this;
+
+  /** Well-known names this connection owns. Not the unique name — see `name`. */
+  names: Set<string>;
+  /** Match rules added through `addMatch`, replayed on a reconnect. */
+  matchRules: Set<string>;
   serial: number;
   cookies: Record<number, InvokeCallback>;
   signals: EventEmitter;

--- a/index.js
+++ b/index.js
@@ -135,6 +135,42 @@ function createStream(opts) {
   }
 }
 
+/**
+ * Reconnection settings, normalised.
+ *
+ * Off unless asked for. Reconnecting silently would change what a connection
+ * means: the unique name is reassigned, so anyone holding the old one is
+ * talking to nobody, and a service's owned names are gone until re-requested.
+ * That is a decision for the program, not a default.
+ */
+function normaliseReconnect(reconnect, opts) {
+  if (!reconnect) return null;
+  const settings = reconnect === true ? {} : reconnect;
+  // A caller-supplied stream cannot be redialled -- we did not open it and
+  // have no idea how to open another. Refusing loudly beats reconnecting to
+  // the same dead socket forever.
+  if (opts.stream) {
+    throw new Error(
+      'reconnect cannot be used with opts.stream: a stream supplied by the ' +
+        'caller cannot be reopened. Use busAddress, socket, host/port, or ' +
+        'handle reconnection yourself.'
+    );
+  }
+  const retries = settings.retries === undefined ? Infinity : settings.retries;
+  const minDelay = settings.minDelay === undefined ? 100 : settings.minDelay;
+  const maxDelay = settings.maxDelay === undefined ? 30000 : settings.maxDelay;
+  const factor = settings.factor === undefined ? 2 : settings.factor;
+  for (const [name, value] of Object.entries({ minDelay, maxDelay, factor })) {
+    if (typeof value !== 'number' || !(value > 0)) {
+      throw new TypeError(`reconnect.${name} must be a positive number`);
+    }
+  }
+  if (retries !== Infinity && !(Number.isInteger(retries) && retries >= 0)) {
+    throw new TypeError('reconnect.retries must be a non-negative integer');
+  }
+  return { retries, minDelay, maxDelay, factor };
+}
+
 function createConnection(opts) {
   const self = new EventEmitter();
   if (!opts) opts = {};
@@ -145,53 +181,24 @@ function createConnection(opts) {
       "The 'ReturnLongjs' option is deprecated. 64-bit values (x/t) become native BigInt in 2.0, which represents the full range without a dependency."
     );
   }
-  const stream = (self.stream = createStream(opts));
-  stream.setNoDelay?.();
 
-  // Set once we have reported a fatal protocol error and torn the stream
-  // down ourselves, so the teardown does not surface as a second error.
+  const reconnect = normaliseReconnect(opts.reconnect, opts);
+
+  // Rebindable, because a reconnect replaces the socket while `self` stays the
+  // same object: callers hold `bus.connection`, and handing them a new one
+  // would make every stored reference stale.
+  let stream;
+  // Set once we have reported a fatal protocol error and torn the stream down
+  // ourselves, so the teardown does not surface as a second error.
   let fatal = false;
-
-  stream.on('error', err => {
-    // Remembered rather than only forwarded, so that whatever fails the
-    // pending calls on teardown can name what killed the connection. The bus
-    // deliberately does not listen for 'error' itself -- doing so would stop
-    // an unhandled connection error from crashing the process.
-    self.lastError = err;
-    // forward network and stream errors
-    if (fatal) return;
-    self.emit('error', err);
-  });
-
-  stream.on('end', () => {
-    self.emit('end');
-    self.message = () => {
-      console.warn("Didn't write bytes to closed stream");
-      return false;
-    };
-  });
-
-  // Emitted once the transport is fully torn down, however that happened. The
-  // bus uses it to fail calls that can no longer get a reply.
-  stream.on('close', () => self.emit('close', self.lastError));
-
-  // Forwarded so callers that stopped writing on a `false` from message()
-  // know when it is safe to resume.
-  stream.on('drain', () => self.emit('drain'));
-
-  // Messages written in the same tick are batched into a single flush. Without
-  // this, emitting N signals in one turn of the event loop issues N separate
-  // writes to the socket.
-  const canCork =
-    typeof stream.cork === 'function' && typeof stream.uncork === 'function';
+  let canCork = false;
   let corked = false;
-
-  // A transport that can carry file descriptors declares itself by having
-  // these. Nothing in this package provides one -- see ROADMAP 2.8 for why --
-  // so it comes from `opts.stream`, and everything above this line works the
-  // day one exists.
-  const canSendFds = typeof stream.writeWithFds === 'function';
-  self.canPassFds = canSendFds;
+  let canSendFds = false;
+  // True once the caller has asked for the connection to go away, so an
+  // ordinary close is not mistaken for one worth reconnecting after.
+  let ending = false;
+  let attempt = 0;
+  let retryTimer = null;
 
   function writeMessage(msg) {
     publishSend(msg);
@@ -225,7 +232,193 @@ function createConnection(opts) {
     return stream.write(buffer);
   }
 
+  // Buffers until the handshake completes; replaced by writeMessage on
+  // 'connect'. Reports no backpressure, since nothing has reached a socket.
+  function bufferMessage(msg) {
+    self._messages.push(msg);
+    return true;
+  }
+
+  function refuseMessage() {
+    console.warn("Didn't write bytes to closed stream");
+    return false;
+  }
+
+  /** Everything that belongs to one socket. Run again per reconnect. */
+  function attachStream() {
+    fatal = false;
+    stream = self.stream = createStream(opts);
+    stream.setNoDelay?.();
+
+    canCork =
+      typeof stream.cork === 'function' && typeof stream.uncork === 'function';
+    corked = false;
+    // A transport that can carry file descriptors declares itself by having
+    // these. Nothing in this package provides one -- see ROADMAP 2.8 for why
+    // -- so it comes from `opts.stream`, and everything above it works the day
+    // one exists.
+    canSendFds = typeof stream.writeWithFds === 'function';
+    self.canPassFds = canSendFds;
+
+    stream.on('error', err => {
+      // Remembered rather than only forwarded, so that whatever fails the
+      // pending calls on teardown can name what killed the connection. The bus
+      // deliberately does not listen for 'error' itself -- doing so would stop
+      // an unhandled connection error from crashing the process.
+      self.lastError = err;
+      // forward network and stream errors
+      if (fatal) return;
+      // A failed *re*dial is reported as a retry rather than as a connection
+      // error: the connection has already told everyone it went away, and a
+      // second 'error' with no listener would take the process down for
+      // something we are about to try again.
+      if (reconnect && !ending && self.state !== 'connected') {
+        return scheduleRetry(err);
+      }
+      self.emit('error', err);
+    });
+
+    stream.on('end', () => {
+      self.emit('end');
+      self.message = refuseMessage;
+    });
+
+    // Emitted once the transport is fully torn down, however that happened.
+    // The bus uses it to fail calls that can no longer get a reply.
+    stream.on('close', () => {
+      const wasConnected = self.state === 'connected';
+      self.state = 'disconnected';
+      self.message = refuseMessage;
+      self.emit('close', self.lastError);
+      if (reconnect && !ending && wasConnected) scheduleRetry(self.lastError);
+    });
+
+    // Forwarded so callers that stopped writing on a `false` from message()
+    // know when it is safe to resume.
+    stream.on('drain', () => self.emit('drain'));
+
+    const handshake = opts.server ? serverHandshake : clientHandshake;
+    handshake(stream, opts, (error, guid, identity, negotiated) => {
+      if (error) {
+        if (reconnect && !ending) return scheduleRetry(error);
+        return self.emit('error', error);
+      }
+      self.guid = guid;
+      // Whether the *peer* agreed to descriptors, which is not the same
+      // question as whether our transport can carry them: both have to be true
+      // before a message with fds will get anywhere.
+      self.unixFdsAgreed = Boolean(negotiated && negotiated.unixFd);
+      // What the server side learnt about the peer while authenticating: the
+      // mechanism, and the uid it claimed. Undefined on a client connection,
+      // where there is nothing to learn. lib/broker.js answers
+      // GetConnectionUnixUser from it.
+      if (identity) self.identity = identity;
+
+      const reconnected = attempt > 0;
+      attempt = 0;
+      self.state = 'connected';
+      for (const msg of self._messages) writeMessage(msg);
+      self._messages.length = 0;
+      self.message = writeMessage;
+
+      // 'connect' fires once, for the first socket. A later one is a
+      // 'reconnect', so a listener written for setup does not run twice.
+      self.emit(reconnected ? 'reconnect' : 'connect');
+
+      // Descriptors arrive alongside the bytes but on their own event, so they
+      // are queued in arrival order and each message takes the number its
+      // UNIX_FDS header claims. SCM_RIGHTS delivers them in the same order as
+      // the bytes they accompany, which is what makes counting sufficient --
+      // and is how libdbus does it too.
+      const received = [];
+      stream.on('fds', fds => {
+        for (const fd of fds) received.push(fd);
+      });
+      const takeFds = count => {
+        // One capability, both directions: a stream that cannot send
+        // descriptors is not going to have received any either, and saying
+        // *that* is more use than "claimed 1, got 0" -- which is true but
+        // leaves the reader to work out that the transport was never able to.
+        if (count > 0 && !canSendFds) {
+          throw new message.ProtocolError(constants.noFdTransport('received'));
+        }
+        return received.splice(0, count);
+      };
+
+      message.unmarshalMessages(
+        stream,
+        msg => {
+          publishReceive(msg);
+          self.emit('message', msg);
+        },
+        opts,
+        err => {
+          // Framing is unrecoverable: we no longer know where the next message
+          // starts, so surface the error and drop the connection rather than
+          // resynchronising on garbage.
+          self.lastError = err;
+          self.emit('error', err);
+          fatal = true;
+          stream.destroy();
+        },
+        err => {
+          // A throw from a 'message' listener is an application bug, not a
+          // transport failure, so it does not go to 'error' -- a handler there
+          // would reasonably assume the connection is gone.
+          if (self.listenerCount('handlerError') > 0) {
+            self.emit('handlerError', err);
+            return;
+          }
+          // Nobody is listening. Preserve Node's default for an exception in
+          // an event listener (crash the process) rather than swallowing an
+          // application bug -- but do it asynchronously, so the read loop
+          // still drains the messages it has already buffered.
+          process.nextTick(() => {
+            throw err;
+          });
+        },
+        takeFds
+      );
+    });
+  }
+
+  /**
+   * Wait, then dial again.
+   *
+   * Exponential with a ceiling, because the common reason a session bus is
+   * unreachable is that it is restarting, and hammering it does not help.
+   * Nothing in flight is retried -- see 'reconnect' in docs/api.md.
+   */
+  function scheduleRetry(cause) {
+    if (retryTimer || ending) return;
+    if (attempt >= reconnect.retries) {
+      self.emit('reconnectFailed', cause);
+      return;
+    }
+    const delay = Math.min(
+      reconnect.maxDelay,
+      reconnect.minDelay * Math.pow(reconnect.factor, attempt)
+    );
+    attempt++;
+    self.emit('reconnecting', { attempt, delay, cause });
+    retryTimer = setTimeout(() => {
+      retryTimer = null;
+      if (ending) return;
+      // Buffer again, so a message written between now and the handshake
+      // completing goes out rather than warning to stderr.
+      self.message = bufferMessage;
+      attachStream();
+    }, delay);
+    // A pending retry should not hold the process open by itself.
+    if (typeof retryTimer.unref === 'function') retryTimer.unref();
+  }
+
   self.end = () => {
+    ending = true;
+    if (retryTimer) {
+      clearTimeout(retryTimer);
+      retryTimer = null;
+    }
     stream.end();
     return self;
   };
@@ -235,6 +428,11 @@ function createConnection(opts) {
   // caller that awaits it knows the socket has gone.
   self[Symbol.asyncDispose] = () =>
     new Promise(resolve => {
+      ending = true;
+      if (retryTimer) {
+        clearTimeout(retryTimer);
+        retryTimer = null;
+      }
       if (stream.destroyed) return setImmediate(resolve);
       let settled = false;
       const done = () => {
@@ -267,95 +465,10 @@ function createConnection(opts) {
     return self;
   };
 
-  const handshake = opts.server ? serverHandshake : clientHandshake;
-  handshake(stream, opts, (error, guid, identity, negotiated) => {
-    if (error) {
-      return self.emit('error', error);
-    }
-    self.guid = guid;
-    // Whether the *peer* agreed to descriptors, which is not the same question
-    // as whether our transport can carry them: both have to be true before a
-    // message with fds will get anywhere.
-    self.unixFdsAgreed = Boolean(negotiated && negotiated.unixFd);
-    // What the server side learnt about the peer while authenticating: the
-    // mechanism, and the uid it claimed. Undefined on a client connection,
-    // where there is nothing to learn. lib/broker.js answers
-    // GetConnectionUnixUser from it.
-    if (identity) self.identity = identity;
-    self.emit('connect');
-    // Descriptors arrive alongside the bytes but on their own event, so they
-    // are queued in arrival order and each message takes the number its
-    // UNIX_FDS header claims. SCM_RIGHTS delivers them in the same order as
-    // the bytes they accompany, which is what makes counting sufficient --
-    // and is how libdbus does it too.
-    const received = [];
-    stream.on('fds', fds => {
-      for (const fd of fds) received.push(fd);
-    });
-    const takeFds = count => {
-      // One capability, both directions: a stream that cannot send descriptors
-      // is not going to have received any either, and saying *that* is more
-      // use than "claimed 1, got 0" -- which is true but leaves the reader to
-      // work out that the transport was never able to.
-      if (count > 0 && !canSendFds) {
-        throw new message.ProtocolError(constants.noFdTransport('received'));
-      }
-      return received.splice(0, count);
-    };
-
-    message.unmarshalMessages(
-      stream,
-      msg => {
-        publishReceive(msg);
-        self.emit('message', msg);
-      },
-      opts,
-      err => {
-        // Framing is unrecoverable: we no longer know where the next message
-        // starts, so surface the error and drop the connection rather than
-        // resynchronising on garbage.
-        self.lastError = err;
-        self.emit('error', err);
-        fatal = true;
-        stream.destroy();
-      },
-      err => {
-        // A throw from a 'message' listener is an application bug, not a
-        // transport failure, so it does not go to 'error' -- a handler there
-        // would reasonably assume the connection is gone.
-        if (self.listenerCount('handlerError') > 0) {
-          self.emit('handlerError', err);
-          return;
-        }
-        // Nobody is listening. Preserve Node's default for an exception in an
-        // event listener (crash the process) rather than swallowing an
-        // application bug -- but do it asynchronously, so the read loop still
-        // drains the messages it has already buffered.
-        process.nextTick(() => {
-          throw err;
-        });
-      },
-      takeFds
-    );
-  });
-
   self._messages = [];
+  self.message = bufferMessage;
 
-  // pre-connect version, buffers all messages. replaced after connect
-  // Reports no backpressure: nothing has reached the socket yet.
-  self.message = msg => {
-    self._messages.push(msg);
-    return true;
-  };
-
-  self.once('connect', () => {
-    self.state = 'connected';
-    for (const msg of self._messages) writeMessage(msg);
-    self._messages.length = 0;
-
-    // no need to buffer once connected
-    self.message = writeMessage;
-  });
+  attachStream();
 
   return self;
 }

--- a/index.js
+++ b/index.js
@@ -409,8 +409,11 @@ function createConnection(opts) {
       self.message = bufferMessage;
       attachStream();
     }, delay);
-    // A pending retry should not hold the process open by itself.
-    if (typeof retryTimer.unref === 'function') retryTimer.unref();
+    // Deliberately *not* unref'd. A live socket holds the event loop open, so
+    // a connection trying to get back to one should too -- otherwise a daemon
+    // whose bus restarted exits during the gap, which is precisely the case
+    // this exists for. `end()` and the disposer clear the timer, so a program
+    // that wants to stop can.
   }
 
   self.end = () => {

--- a/lib/broker.js
+++ b/lib/broker.js
@@ -203,6 +203,8 @@ function createBroker(opts = {}) {
   let nextUnique = 1;
   let server = null;
   let listenAddress = null;
+  // Set only when listen() created the directory, so close() removes only that.
+  let temporaryDir = null;
 
   // ---------------------------------------------------------------- sending
 
@@ -803,12 +805,13 @@ function createBroker(opts = {}) {
       cb = where;
       where = undefined;
     }
-    const target = where || {
-      socket: path.join(
-        fs.mkdtempSync(path.join(os.tmpdir(), 'dbus-broker-')),
-        'socket'
-      )
-    };
+    let target = where;
+    if (!target) {
+      // Ours to make, and therefore ours to clean up on close. A path the
+      // caller supplied is not: see below.
+      temporaryDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dbus-broker-'));
+      target = { socket: path.join(temporaryDir, 'socket') };
+    }
 
     server = net.createServer(accept);
     server.on('error', err => broker.emit('error', err));
@@ -852,14 +855,27 @@ function createBroker(opts = {}) {
     }
     const socket = listenAddress && /^unix:path=([^,]+)/.exec(listenAddress);
     server.close(() => {
-      // A unix socket outlives the server that bound it.
+      // A unix socket outlives the server that bound it, so the node has to go
+      // or the next listen on the same path fails.
       if (socket) {
         try {
           fs.rmSync(socket[1], { force: true });
-          fs.rmdirSync(path.dirname(socket[1]));
         } catch {
-          /* someone else's to clean up */
+          /* already gone */
         }
+      }
+      // Only the directory we made ourselves. This used to remove
+      // `dirname(socket)` unconditionally, which deleted a directory belonging
+      // to a caller who had supplied their own path -- and then the next
+      // listen on that path failed with EACCES, from inside a directory that
+      // no longer existed.
+      if (temporaryDir) {
+        try {
+          fs.rmdirSync(temporaryDir);
+        } catch {
+          /* not empty, or already gone */
+        }
+        temporaryDir = null;
       }
       if (cb) cb();
     });

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -21,11 +21,16 @@ const {
 } = require('./properties');
 const objectManager = require('./object-manager');
 
-module.exports = function bus(conn, opts) {
+function bus(conn, opts) {
   if (!(this instanceof bus)) {
     return new bus(conn);
   }
   if (!opts) opts = {};
+  // An EventEmitter so the bus can report things that are its own rather than
+  // the transport's -- 'reconnected' is about names and match rules, which the
+  // connection knows nothing about. Purely additive: nothing here was called
+  // `on`, `emit` or any of the rest.
+  EventEmitter.call(this);
 
   const self = this;
   // Opt-in per-client default; undefined means wait forever, as before.
@@ -37,7 +42,8 @@ module.exports = function bus(conn, opts) {
   this.signals = new EventEmitter();
   this.exportedObjects = {};
   /**
-   * Well-known names this connection owns.
+   * Well-known names this connection owns. Not the unique name -- that is
+   * assigned rather than owned, and lives on `bus.name`.
    *
    * Used to tell a method call meant for us from one we are merely
    * overhearing. Kept current from the NameAcquired and NameLost signals
@@ -51,6 +57,14 @@ module.exports = function bus(conn, opts) {
    * would have to reach inside the lazy promise `invokeDbus` returns.
    */
   this.names = new Set();
+
+  /**
+   * Match rules added through `addMatch`, so a reconnect can put them back.
+   *
+   * A rule installed by calling `invokeDbus({ member: 'AddMatch' })` directly
+   * is not in here and will not survive one -- there is nothing to notice it.
+   */
+  this.matchRules = new Set();
 
   /**
    * Is this message addressed to us?
@@ -109,6 +123,13 @@ module.exports = function bus(conn, opts) {
   }
   conn.on('close', failPendingCalls);
   conn.on('end', () => failPendingCalls());
+  // Reset when the transport comes back, or the *second* disconnect would fail
+  // nothing and `close()` would resolve without closing anything -- the latch
+  // is there to stop one teardown reporting twice, not to make the flag
+  // permanent.
+  conn.on('reconnect', () => {
+    closed = false;
+  });
 
   /**
    * Close the connection, and resolve once it is actually closed.
@@ -557,8 +578,15 @@ module.exports = function bus(conn, opts) {
         msg.body &&
         typeof msg.body[0] === 'string'
       ) {
-        if (msg.member === 'NameAcquired') self.names.add(msg.body[0]);
-        else if (msg.member === 'NameLost') self.names.delete(msg.body[0]);
+        // Well-known names only. NameAcquired fires for the unique name too,
+        // but that is assigned rather than owned and `bus.name` already holds
+        // it -- keeping it out means `names` means exactly one thing, and that
+        // a reconnect never tries to re-request something unrequestable.
+        const acquired = msg.body[0];
+        if (!acquired.startsWith(':')) {
+          if (msg.member === 'NameAcquired') self.names.add(acquired);
+          else if (msg.member === 'NameLost') self.names.delete(acquired);
+        }
       }
       self.signals.emit(self.mangle(msg), msg.body, msg.signature);
     } else {
@@ -873,6 +901,49 @@ module.exports = function bus(conn, opts) {
     self.name = null;
   }
 
+  /**
+   * Put back what a reconnect took away.
+   *
+   * A new socket is a new client as far as the bus is concerned: the unique
+   * name is different, no well-known name is owned, and no match rule exists.
+   * Objects exported with `exportInterface` live here rather than there and so
+   * need nothing -- but nobody can reach them until the names are back, which
+   * is why this finishes before 'reconnected' is emitted.
+   *
+   * It deliberately does **not** retry calls that were in flight. Those were
+   * already failed with ConnectionClosedError when the socket went, and a
+   * method call is not idempotent -- replaying one could charge a card twice.
+   * Re-issuing is the caller's decision, which is what the event is for.
+   */
+  conn.on('reconnect', () => {
+    const wanted = [...self.names];
+    const rules = [...self.matchRules];
+    self.names.clear();
+    // Rebuilt as the calls succeed, so a rule that fails to reinstate is not
+    // left looking as though it is in place.
+    self.matchRules.clear();
+
+    const finish = err =>
+      err
+        ? self.emit('reconnectError', err)
+        : self.emit('reconnected', { name: self.name, names: [...self.names] });
+
+    self.invokeDbus({ member: 'Hello' }, (helloErr, name) => {
+      if (helloErr) return finish(helloErr);
+      self.name = name;
+      const steps = [
+        ...wanted.map(n => () => self.requestName(n, 0)),
+        ...rules.map(rule => () => self.addMatch(rule))
+      ];
+      // Sequential rather than parallel: the order names were taken in can
+      // matter to a service that owns several, and a bus that has just come
+      // back is not the moment to open a dozen calls at once.
+      steps
+        .reduce((chain, step) => chain.then(step), Promise.resolve())
+        .then(() => finish(), finish);
+    });
+  });
+
   function DBusObject(name, service) {
     this.name = name;
     this.service = service;
@@ -954,6 +1025,10 @@ module.exports = function bus(conn, opts) {
 
   // bus meta functions
   this.addMatch = function (match, callback) {
+    // Recorded before the reply rather than after: the daemon starts routing
+    // when it processes the rule, so a reconnect in between should still put
+    // this one back.
+    self.matchRules.add(match);
     return this.invokeDbus(
       { member: 'AddMatch', signature: 's', body: [match] },
       callback
@@ -961,6 +1036,7 @@ module.exports = function bus(conn, opts) {
   };
 
   this.removeMatch = function (match, callback) {
+    self.matchRules.delete(match);
     return this.invokeDbus(
       { member: 'RemoveMatch', signature: 's', body: [match] },
       callback
@@ -1038,4 +1114,8 @@ module.exports = function bus(conn, opts) {
       callback
     );
   };
-};
+}
+
+Object.setPrototypeOf(bus.prototype, EventEmitter.prototype);
+
+module.exports = bus;

--- a/test/integration/reconnect.js
+++ b/test/integration/reconnect.js
@@ -1,0 +1,218 @@
+// Reconnection, by actually killing the bus underneath a live service.
+//
+// BIG_FUTURE_PLANS 3.2. A daemon that loses the bus had no story at all, which
+// matters for an audience that skews toward Raspberry Pi and Homebridge.
+//
+// The hard part was never the socket. A reconnect makes a *new client*: the
+// unique name is different, no well-known name is owned, and no match rule
+// exists. So the test that matters is not "did it reconnect" but "can anyone
+// reach the service afterwards".
+//
+// Uses its own broker rather than the shared daemon, because the point is to
+// stop the bus mid-run and nothing else in the suite would survive that.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const dbus = require('../../index');
+
+const SERVICE = 'com.github.sidorares.dbusnative.Reconnecting';
+const PATH = '/com/github/sidorares/dbusnative/Reconnecting';
+const IFACE = 'com.github.sidorares.dbusnative.ReconnectingIface';
+
+const settle = (ms = 150) => new Promise(resolve => setTimeout(resolve, ms));
+
+const once = (emitter, event) =>
+  new Promise(resolve => emitter.once(event, (...args) => resolve(args)));
+
+describe('integration: reconnect', { timeout: 30000 }, () => {
+  let broker, address, dir, socketPath;
+
+  // The test owns the socket path, so the bus can be stopped and started again
+  // at the same address -- which is what a dbus-daemon restart looks like to a
+  // client, and the only way to exercise reconnection honestly.
+  const startBroker = () =>
+    new Promise((resolve, reject) => {
+      try {
+        fs.unlinkSync(socketPath);
+      } catch {
+        /* only there after the first run */
+      }
+      const b = dbus.createBroker();
+      b.on('error', () => {});
+      b.listen({ socket: socketPath }, (err, addr) => {
+        if (err) return reject(err);
+        address = addr;
+        resolve(b);
+      });
+    });
+
+  const stopBroker = () => new Promise(resolve => broker.close(resolve));
+
+  before(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dbus-reconnect-'));
+    socketPath = path.join(dir, 'bus');
+    broker = await startBroker();
+  });
+
+  after(async () => {
+    if (broker) await stopBroker();
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  const connect = extra => dbus.createClient({ busAddress: address, ...extra });
+
+  it('is off unless asked for', async () => {
+    const bus = connect();
+    await bus.getId();
+    const closed = once(bus.connection, 'close');
+    bus.connection.stream.destroy();
+    await closed;
+    await settle();
+    // No retry scheduled, no reconnect: the connection stays down.
+    assert.strictEqual(bus.connection.state, 'disconnected');
+  });
+
+  it('refuses to pair with a caller-supplied stream', () => {
+    // There is no way to reopen a stream we did not dial.
+    const { PassThrough } = require('stream');
+    assert.throws(
+      () => dbus.createClient({ stream: new PassThrough(), reconnect: true }),
+      /cannot be used with opts\.stream/
+    );
+  });
+
+  it('validates its settings rather than misbehaving later', () => {
+    for (const bad of [
+      { minDelay: 0 },
+      { maxDelay: -1 },
+      { factor: 'fast' },
+      { retries: 1.5 },
+      { retries: -1 }
+    ]) {
+      assert.throws(
+        () => dbus.createClient({ busAddress: address, reconnect: bad }),
+        /reconnect\./,
+        JSON.stringify(bad)
+      );
+    }
+  });
+
+  it('comes back, and brings the name and the match rules with it', async () => {
+    const service = connect({ reconnect: { minDelay: 20, maxDelay: 50 } });
+    await service.getId();
+    await service.requestName(SERVICE, 0);
+
+    const impl = dbus.defineInterface({
+      name: IFACE,
+      methods: {
+        Echo: { in: { s: 's' }, out: { s: 's' }, handler: ({ s }) => s }
+      },
+      signals: { Fired: { args: { what: 's' } } }
+    });
+    await service.export(PATH, impl);
+
+    // A rule of our own, to check it is reinstated.
+    await service.addMatch(`type='signal',interface='${IFACE}',member='Fired'`);
+
+    const firstName = service.name;
+    assert.match(firstName, /^:\d+\.\d+$/);
+
+    // Bring the bus down and back up on the same socket.
+    const reconnected = once(service, 'reconnected');
+    await stopBroker();
+    await settle(50);
+    broker = await startBroker();
+
+    const [info] = await reconnected;
+
+    // A new client, with a new unique name.
+    assert.match(service.name, /^:\d+\.\d+$/);
+    assert.strictEqual(info.name, service.name);
+    assert.strictEqual(service.connection.state, 'connected');
+
+    // And the thing that actually matters: reachable again, by name.
+    assert.deepStrictEqual(info.names, [SERVICE]);
+    const client = connect();
+    await client.getId();
+    assert.strictEqual(await client.nameHasOwner(SERVICE), true);
+    const proxy = await client.proxy(SERVICE, PATH, { interface: IFACE });
+    assert.strictEqual(await proxy.Echo('still here'), 'still here');
+
+    // The match rule went back too.
+    assert.ok(
+      service.matchRules.has(
+        `type='signal',interface='${IFACE}',member='Fired'`
+      )
+    );
+
+    await client.close();
+    await service.close();
+  });
+
+  it('reports each attempt while the bus is away', async () => {
+    const bus = connect({ reconnect: { minDelay: 20, maxDelay: 40 } });
+    await bus.getId();
+
+    const attempts = [];
+    bus.connection.on('reconnecting', info => attempts.push(info));
+
+    await stopBroker();
+    await settle(200);
+
+    assert.ok(attempts.length >= 2, `expected retries, got ${attempts.length}`);
+    assert.strictEqual(attempts[0].attempt, 1);
+    // Backed off, and capped.
+    assert.ok(attempts.every(a => a.delay <= 40));
+
+    broker = await startBroker();
+    await once(bus, 'reconnected');
+    await bus.close();
+  });
+
+  it('gives up after the retries it was given', async () => {
+    const bus = connect({
+      reconnect: { retries: 2, minDelay: 10, maxDelay: 10 }
+    });
+    await bus.getId();
+
+    const failed = once(bus.connection, 'reconnectFailed');
+    await stopBroker();
+    await failed;
+
+    broker = await startBroker();
+    await bus.close();
+  });
+
+  it('does not reconnect after a deliberate close', async () => {
+    const bus = connect({ reconnect: { minDelay: 10 } });
+    await bus.getId();
+
+    let reconnecting = false;
+    bus.connection.on('reconnecting', () => {
+      reconnecting = true;
+    });
+    await bus.close();
+    await settle(100);
+    assert.strictEqual(reconnecting, false, 'close() means close');
+  });
+
+  it('fails calls made while it is down rather than replaying them', async () => {
+    // A method call is not idempotent, so nothing in flight is retried. The
+    // event is how a caller decides what to re-issue.
+    const bus = connect({ reconnect: { minDelay: 20, maxDelay: 40 } });
+    await bus.getId();
+
+    await stopBroker();
+    await settle(30);
+    await assert.rejects(() => bus.getId());
+
+    broker = await startBroker();
+    await once(bus, 'reconnected');
+    // And it works again afterwards.
+    assert.match(await bus.getId(), /^[0-9a-f]{32}$/);
+    await bus.close();
+  });
+});


### PR DESCRIPTION
[BIG_FUTURE_PLANS §3.2](https://github.com/sidorares/dbus-native/blob/master/BIG_FUTURE_PLANS.md) — the last additive item. A daemon that lost the bus had no story at all, which matters for an audience that skews toward Raspberry Pi and Homebridge.

```js
const bus = dbus.sessionBus({ reconnect: true });
bus.on('reconnected', ({ name, names }) => { … });
```

## Off by default, deliberately

Reconnecting changes what a connection *means*: the unique name is reassigned, so anyone holding the old one is talking to nobody, and every well-known name and match rule is gone until asked for again. That is the program's decision, not a default.

## It re-establishes all three

The plan said whatever ships must restore the unique name, the owned names and the match rules — *"or say loudly that it does not"*. It does, and finishes **before** `reconnected` fires, so a service is reachable by the time anyone hears it came back. Exported objects never went anywhere: they live on the bus, not on the socket.

**Nothing in flight is retried.** Those calls were already failed with `ConnectionClosedError` when the socket went, and a method call is not idempotent — replaying one could charge a card twice. Re-issuing is the caller's decision, which is what the event is for. Stated in the docs, the types and the code, because it is the part most likely to be assumed otherwise.

A rule installed by calling `invokeDbus({ member: 'AddMatch' })` directly is not recorded and will not return — also said plainly.

## Three bugs fell out, none about reconnection

They were all invisible because nothing had ever reconnected before:

- **The broker deleted a directory it did not create.** `close()` removed `dirname(socket)` unconditionally, so a caller supplying their own socket path lost the directory around it — and the next `listen()` there failed with `EACCES` from inside a directory that no longer existed. Now only a temp dir it made itself.
- **`bus.names` held the unique name** alongside the well-known ones, because `NameAcquired` fires for it too. Harmless until something tried to re-request them — a unique name is *assigned*, not requested. `names` now means exactly one thing and `bus.name` holds the other.
- **`closed` in `bus.js` latched forever**, so a second disconnect would have failed nothing and `close()` would have resolved without closing. The latch exists to stop one teardown reporting twice, not to be permanent.

## The restructure

`createConnection` had to be reshaped so the per-socket setup can run again while `self` stays the same object — callers hold `bus.connection`, and handing them a new one would make every stored reference stale. **The default path is unchanged**: with no `reconnect` option nothing extra is scheduled and no extra listener attached. I verified that separately before adding the bus-side half — 888 unit tests and 256/256 integration on the restructure alone.

`MessageBus` is now an `EventEmitter`, which is purely additive (nothing on it was called `on`, `emit` or any of the rest) and is what lets the bus report something that is its own rather than the transport's.

## Verification

Tested by stopping and restarting a broker underneath a live service **on the same socket path**, which is what a `dbus-daemon` restart looks like to a client — then checking a third party can still reach the service by name.

| | dbus-daemon | broker |
|---|---|---|
| classic | 264/264 | 264/264 |
| `2.0` | 264/264 | 264/264 |
| `2.0-wrap` | 264/264 | 264/264 |

888 unit tests on Node 20.20, 22.16 and 26; 0 failures in 6 runs at `--test-concurrency=8`, since the connection lifecycle moved.
