### PR TITLE
docs: drop ESM-only from the plan, with a test to keep it decided

### DIFF
--- a/BIG_FUTURE_PLANS.md
+++ b/BIG_FUTURE_PLANS.md
@@ -39,7 +39,8 @@ The original §0 listed what was wrong with the library. Most of it is fixed.
 What is left from the original sketch: **`await using` (§1), proxies (§2), the
 value-shape flag day (§3), async-iterable signals (§5), `defineInterface` (§7),
 and ESM (§9).** That is the breaking window, and it is the subject of the rest
-of this document. Everything in it has now shipped except ESM.
+of this document. Everything in it has now shipped, except ESM — which §4.1
+argues should not be done at all.
 
 The single most important thing the sketch got right, and it is worth
 restating because it constrains everything below: **the wire layer is good and
@@ -367,11 +368,65 @@ Two of these change decisions the original made.
 | `AsyncDisposableStack`                 | ✅ from Node **24**       | §1, feature-detected                      |
 | `Promise.withResolvers()`              | ✅ native                 | simplifies the cookie table               |
 | `AbortSignal.timeout()`, `Error.cause` | ✅ native                 | shipped already                           |
-| **`require()` of an ESM module**       | ✅ **unflagged** (22.12+) | **weakens the ESM-only objection**        |
+| **`require()` of an ESM module**       | ✅ **unflagged** (22.12+) | §4.1 — and ESM-only turns out to be moot  |
 | **TypeScript type stripping**          | ✅ **unflagged**          | changes the codegen story, not decorators |
 | Sync iterator helpers                  | ✅ native                 | —                                         |
 | **Async iterator helpers**             | ❌ still absent           | §2.4 — callbacks lead                     |
 | **Decorators**                         | ❌ still a `SyntaxError`  | §7 stays `defineInterface`                |
+
+### 4.1 ESM-only: measured, and the answer is no
+
+**Correction, and the last one this document needs.** Everything below §4 was
+written from the cost side: how much would ESM-only hurt, now that
+`require(esm)` exists? That was the wrong question. The right one is what it
+_buys_, and the answer turns out to be nothing at all.
+
+The current CJS package was installed from its own tarball into a clean
+project and imported from ESM. Every consumption shape works today:
+
+```js
+import dbus from 'dbus-native'; // default
+import { sessionBus, Variant, toPlain } from 'dbus-native'; // named
+import { withClassicTypes } from 'dbus-native/compat'; // subpath
+import marshall from 'dbus-native/lib/marshall.js'; // deep subpath
+new Variant('s', 'x') instanceof dbus.Variant; // true, across the boundary
+```
+
+**All 23 runtime exports are visible as ESM named imports** — checked by
+diffing `Object.keys(require(…))` against `import * as ns`, not by spot-check,
+because `cjs-module-lexer` is a static analysis and the failure mode is a
+_silently missing_ named export. `index.js` assigns several exports after the
+initial object literal and the lexer finds those too.
+
+So the interop matrix has no hole in it either way:
+
+| package is   | CJS consumer                       | ESM consumer              |
+| ------------ | ---------------------------------- | ------------------------- |
+| CJS (today)  | native                             | ✅ works — verified above |
+| **ESM-only** | needs `require(esm)`, Node ≥ 22.12 | native                    |
+
+The asymmetry is the whole argument. Staying CJS costs an ESM consumer
+nothing. Going ESM-only costs **every CJS consumer on Node < 22.12**, plus
+anyone whose bundler or toolchain does not implement `require(esm)` — and the
+floor in `engines` does not help, because that constrains what _we_ run on
+while a consumer on Node 20 can `require()` this package perfectly well today.
+
+For an audience that is 61% Homebridge on Raspberry Pi, that is a real cost
+against a benefit `RELEASE_PLAN` already described as "the only break in the
+plan with no functional payoff". **Recommendation: do not do it.** Not "defer
+it" — the reason it looked worth doing was an interop gap that measurement
+says is not there.
+
+What survives from the original reasoning is the narrow bit: a **dual**
+package really would ship two copies of `Variant` and break `instanceof`
+across them. That remains a good reason never to publish one. It is not a
+reason to abandon CJS.
+
+If this is ever revisited, the one rule that must hold is **no top-level await
+in any entry point** — `ERR_REQUIRE_ASYNC_MODULE`, verified — since that is
+what makes `require(esm)` work at all.
+
+---
 
 **`require(esm)` is the significant one.** The original argued for ESM-only on
 the grounds that a dual package ships two copies of `Variant` and breaks
@@ -441,7 +496,11 @@ The useful cut, now that the gate exists to verify it.
   it already did inside `a{sv}`.
 - the `{ bytes, fds }` message seam (§3.3) — the feature is additive, the seam
   is not
-- ESM-only, with the no-top-level-await rule (§4)
+- ~~ESM-only, with the no-top-level-await rule (§4)~~ — **dropped, §4.1.**
+  Measured rather than argued: an ESM consumer can already import the CJS
+  package completely, including every named export, subpaths and `instanceof`.
+  ESM-only would buy nothing and would break `require()` for every consumer on
+  Node < 22.12.
 - the Node floor (§4)
 - ~~dropping `long`, `ReturnLongjs`, `dbus2js`, and `lib/address-x11.js` — which
   is published in `lib/` and throws `Cannot find module 'x11'` on require~~ ✅

--- a/RELEASE_PLAN.md
+++ b/RELEASE_PLAN.md
@@ -39,20 +39,21 @@ the classic track keeps its semver promises.
 Each major is chosen so its blast radius is small enough to tool for, and so
 it unblocks the next one.
 
-| release | theme                        | blast radius              | migration mechanism               |
-| ------- | ---------------------------- | ------------------------- | --------------------------------- |
-| **0.6** | preparation, all additive    | none                      | —                                 |
-| **1.0** | errors are `Error`s ✅       | error-handling paths only | codemod + forward-compatible shim |
-| **2.0** | the type system ✅           | every value read          | accessors + lint + compat wrapper |
-| **3.0** | lifecycle and cancellation   | connection setup/teardown | codemod + deprecations            |
-| **4.0** | ESM, `/next` becomes default | imports                   | codemod                           |
+| release | theme                      | blast radius              | migration mechanism               |
+| ------- | -------------------------- | ------------------------- | --------------------------------- |
+| **0.6** | preparation, all additive  | none                      | —                                 |
+| **1.0** | errors are `Error`s ✅     | error-handling paths only | codemod + forward-compatible shim |
+| **2.0** | the type system ✅         | every value read          | accessors + lint + compat wrapper |
+| **3.0** | lifecycle and cancellation | connection setup/teardown | codemod + deprecations            |
+| **4.0** | ~~ESM~~, `/next` default   | imports                   | codemod                           |
 
 Errors come before types because a rejected promise has to carry an `Error` for
 promises to be worth anything, and because it touches only `catch` blocks
 rather than every value in the program. Types come before lifecycle because it
 is the highest-value change and the one people are actually waiting for. ESM
-comes last because it is the one break with no functional benefit — it is
-packaging, and it can wait until everything else has settled.
+came last because it is the one break with no functional benefit — and having
+got there, it turned out not to be worth doing at all: see §4.0 below and
+BIG_FUTURE_PLANS §4.1.
 
 ---
 
@@ -346,6 +347,16 @@ BIG_FUTURE_PLANS §4.
 ---
 
 ## 4.0 — ESM, and `/next` becomes the default
+
+> **The ESM half is dropped.** Not deferred — measured. An ESM consumer can
+> already import the CJS package completely: default import, every named
+> export, subpaths, deep subpaths, and `instanceof` across the boundary. So
+> ESM-only buys nothing, while costing `require()` for every consumer on
+> Node < 22.12 and anyone whose bundler does not implement `require(esm)`.
+> See BIG_FUTURE_PLANS §4.1 for the measurements.
+>
+> The dual-package hazard below is still real and is still a good reason never
+> to publish one. It was never a reason to abandon CJS.
 
 - `dbus-native` resolves to the modern API; the classic surface moves to
   `dbus-native/classic` and stays supported for a defined period.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,11 +15,11 @@ module.exports = [
       globals: {
         ...globals.node,
         // Explicit resource management. Measured, not assumed:
-        // `Symbol.asyncDispose` exists from Node 20, but these two stacks only
-        // from Node 24 -- so code using them has to feature-detect on our floor
-        // of 20.8. The `using` *keyword* also needs 24 and must not appear in
-        // source or tests: it is a syntax error on the older two, which fails
-        // the file before any skip can run.
+        // `Symbol.asyncDispose` predates our floor, but these two stacks only
+        // arrive in Node 24 -- so code using them has to feature-detect. The
+        // `using` *keyword* also needs 24 and must not appear in source or
+        // tests: it is a syntax error on 22, which fails the file before any
+        // skip can run.
         DisposableStack: 'readonly',
         AsyncDisposableStack: 'readonly'
       }
@@ -37,6 +37,13 @@ module.exports = [
       'no-useless-concat': 'error',
       'no-unused-vars': ['error', { argsIgnorePattern: '^_' }]
     }
+  },
+  {
+    // The package is CommonJS, so `sourceType: 'commonjs'` above is right for
+    // everything except the one file that deliberately is not: the ESM interop
+    // check, which has to be real ESM to be worth anything.
+    files: ['**/*.mjs'],
+    languageOptions: { sourceType: 'module' }
   }
 ];
 // No test-globals block: node:test has no globals, so describe/it/before are

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "npm run lint && npm run format:check && npm run test:types && npm run test:raw",
-    "test:raw": "node --test --test-reporter=spec test/*.js",
+    "test:raw": "node --test --test-reporter=spec test/*.js test/*.mjs",
     "test:integration": "node scripts/with-dbus.js -- npm run test:integration:raw",
     "test:integration:raw": "node --test --test-reporter=spec test/integration/*.js",
     "test:integration:broker": "node scripts/with-broker.js -- npm run test:integration:raw",

--- a/test/esm-interop.mjs
+++ b/test/esm-interop.mjs
@@ -1,0 +1,96 @@
+// The package is CommonJS. This asserts that costs an ESM consumer nothing.
+//
+// BIG_FUTURE_PLANS 4.1 decided against ESM-only on the strength of these
+// facts, so they need to keep being facts. The one that can rot silently is
+// the named-import list: `import { sessionBus }` from a CJS module works
+// because `cjs-module-lexer` statically finds the assignments in index.js, and
+// a refactor that assigns exports some way it cannot follow would drop them
+// from the ESM surface with nothing failing here or anywhere else.
+//
+// A .mjs file, so it is ESM regardless of what package.json says. Run by
+// `npm run test:raw` along with everything else -- node:test picks up .mjs.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import dbus from '../index.js';
+import * as namespace from '../index.js';
+import {
+  sessionBus,
+  systemBus,
+  createClient,
+  createConnection,
+  createBroker,
+  defineInterface,
+  Variant,
+  variantValue,
+  variantSignature,
+  toPlain,
+  messageType
+} from '../index.js';
+import { withClassicTypes, toClassicError } from '../lib/compat.js';
+import marshall from '../lib/marshall.js';
+import unmarshall from '../lib/unmarshall.js';
+
+describe('ESM interop with the CommonJS package', () => {
+  it('has a usable default import', () => {
+    assert.strictEqual(typeof dbus.sessionBus, 'function');
+    assert.strictEqual(typeof dbus.Variant, 'function');
+  });
+
+  it('exposes every runtime export as a named import', () => {
+    // The assertion that matters: not "the ones I remembered to list", but
+    // every key the CommonJS object actually has.
+    const runtime = Object.keys(dbus).sort();
+    const named = Object.keys(namespace).filter(k => k !== 'default');
+    const missing = runtime.filter(k => !named.includes(k));
+    assert.deepStrictEqual(
+      missing,
+      [],
+      `not importable by name from ESM: ${missing.join(', ')}`
+    );
+    assert.ok(
+      runtime.length > 15,
+      `expected the full surface, got ${runtime.length}`
+    );
+  });
+
+  it('binds the named imports to the same functions', () => {
+    for (const [name, fn] of Object.entries({
+      sessionBus,
+      systemBus,
+      createClient,
+      createConnection,
+      createBroker,
+      defineInterface,
+      Variant,
+      variantValue,
+      variantSignature,
+      toPlain
+    })) {
+      assert.strictEqual(fn, dbus[name], name);
+    }
+    assert.deepStrictEqual(messageType, dbus.messageType);
+  });
+
+  it('resolves subpath exports', () => {
+    assert.strictEqual(typeof withClassicTypes, 'function');
+    assert.strictEqual(typeof toClassicError, 'function');
+  });
+
+  it('resolves deep lib/ subpaths', () => {
+    assert.strictEqual(typeof marshall, 'function');
+    assert.strictEqual(typeof unmarshall, 'function');
+  });
+
+  it('keeps instanceof working across the boundary', () => {
+    // Two module systems, one class. This is the property a dual package
+    // would destroy, and the reason never to publish one.
+    assert.ok(new Variant('s', 'x') instanceof dbus.Variant);
+  });
+
+  it('round-trips a value through the imported functions', () => {
+    const [dict] = unmarshall(marshall('a{sv}', [{ n: 7n }]), 'a{sv}');
+    assert.deepStrictEqual(toPlain(dict), { n: 7n });
+  });
+});


### PR DESCRIPTION
**Stacked on [#375](https://github.com/sidorares/dbus-native/pull/375) → [#374](https://github.com/sidorares/dbus-native/pull/374) → [#373](https://github.com/sidorares/dbus-native/pull/373).**

This is the last item in the breaking window, and my recommendation is **not to do it** — not "defer it", but drop it. Here is the measurement that changed my mind, so you can disagree with the evidence rather than with me.

## The question I was asking was wrong

`BIG_FUTURE_PLANS` §4 approached ESM-only from the cost side: how much would it hurt, now that `require(esm)` exists? The right question is what it *buys*. So I installed the current CJS package from its own tarball into a clean project and imported it from ESM:

```js
import dbus from 'dbus-native';                                   // ✅
import { sessionBus, Variant, toPlain } from 'dbus-native';        // ✅
import { withClassicTypes } from 'dbus-native/compat';             // ✅
import marshall from 'dbus-native/lib/marshall.js';                // ✅
new Variant('s','x') instanceof dbus.Variant;                      // ✅ true
```

**All 23 runtime exports are visible as ESM named imports.** I checked that by diffing `Object.keys(require(…))` against `import * as ns` rather than by spot-check, because `cjs-module-lexer` is a static analysis and its failure mode is a *silently missing* export. `index.js` assigns several exports after the initial object literal; the lexer finds those too.

## The asymmetry

| package is | CJS consumer | ESM consumer |
| --- | --- | --- |
| CJS (today) | native | ✅ verified above |
| ESM-only | needs `require(esm)`, **consumer** on Node ≥ 22.12 | native |

Staying CJS costs an ESM consumer nothing. Going ESM-only costs every CJS consumer below 22.12 — and the `engines` floor from #375 does **not** cover this, because that constrains what *we* run on, while a consumer on Node 20 can `require()` this package perfectly well today (I checked: the suite passes on 20.20.0). Add anyone whose bundler doesn't implement `require(esm)`.

For an audience that is 61% Homebridge on Raspberry Pi, that is a real cost against what `RELEASE_PLAN` already called *"the only break in the plan with no functional payoff"*.

## What survives

The narrow part of the original argument: a **dual** package really would ship two copies of `Variant` and break `instanceof` across them. That is a good reason never to publish one. It was never a reason to abandon CJS.

## The test

`test/esm-interop.mjs` — real ESM, run by `npm run test:raw` with everything else. A document saying "we measured this" rots; a test does not.

The assertion that matters is the export diff, because that is the one that can break silently. I verified it works by appending an export the lexer cannot statically follow:

```
not importable by name from ESM: lateExport
# fail 1
```

`eslint.config.js` gets a `**/*.mjs` override for `sourceType: 'module'` — the package is otherwise CJS, and that file has to be genuinely ESM to be worth anything.

## Verified

895 unit tests on Node 22.16, 24.12 and 26.

---

**If you want ESM-only anyway** — for positioning rather than mechanics, which is a legitimate reason I can't measure — say so and I'll do it. It is roughly 120 files and mechanical; the one hard rule is no top-level await in any entry point, or `require(esm)` fails with `ERR_REQUIRE_ASYNC_MODULE` and the CJS door shuts for good.