### PR TITLE
feat!: every call has a deadline

### DIFF
--- a/RELEASE_PLAN.md
+++ b/RELEASE_PLAN.md
@@ -39,13 +39,13 @@ the classic track keeps its semver promises.
 Each major is chosen so its blast radius is small enough to tool for, and so
 it unblocks the next one.
 
-| release | theme                      | blast radius              | migration mechanism               |
-| ------- | -------------------------- | ------------------------- | --------------------------------- |
-| **0.6** | preparation, all additive  | none                      | —                                 |
-| **1.0** | errors are `Error`s ✅     | error-handling paths only | codemod + forward-compatible shim |
-| **2.0** | the type system ✅         | every value read          | accessors + lint + compat wrapper |
-| **3.0** | lifecycle and cancellation | connection setup/teardown | codemod + deprecations            |
-| **4.0** | ~~ESM~~, `/next` default   | imports                   | codemod                           |
+| release | theme                         | blast radius              | migration mechanism               |
+| ------- | ----------------------------- | ------------------------- | --------------------------------- |
+| **0.6** | preparation, all additive     | none                      | —                                 |
+| **1.0** | errors are `Error`s ✅        | error-handling paths only | codemod + forward-compatible shim |
+| **2.0** | the type system ✅            | every value read          | accessors + lint + compat wrapper |
+| **3.0** | lifecycle and cancellation ✅ | connection setup/teardown | codemod + deprecations            |
+| **4.0** | ~~ESM~~, `/next` default      | imports                   | codemod                           |
 
 Errors come before types because a rejected promise has to carry an `Error` for
 promises to be worth anything, and because it touches only `catch` blocks
@@ -321,18 +321,34 @@ deserves its own guide page.
 
 ## 3.0 — lifecycle and cancellation
 
+> **Shipped, all three, and none of them needed a release of their own.** The
+> first two landed additively across 0.7–0.13; the third is breaking and went
+> out with the type-system release, since a consumer upgrading anyway would
+> rather read one migration guide than two.
+
 **Closes** [#20](https://github.com/sidorares/dbus-native/issues/20),
 [#137](https://github.com/sidorares/dbus-native/issues/137).
 
-- `Symbol.asyncDispose` on connections, subscriptions and name registrations.
-- `connection.end()` → `await bus.close()`, which flushes pending writes and
+- ✅ `Symbol.asyncDispose` on connections, subscriptions and name
+  registrations.
+- ✅ `connection.end()` → `await bus.close()`, which flushes pending writes and
   fails in-flight calls cleanly instead of throwing
-  `ERR_STREAM_WRITE_AFTER_END` — which is what #20 still does today, as
-  confirmed during the audit.
-- A **default call timeout**. This one is breaking in an unusual direction: it
-  makes previously-hanging calls start failing. That is the point, but it
-  belongs in a major and needs a loud release note, plus `timeout: 0` to opt
-  out.
+  `ERR_STREAM_WRITE_AFTER_END` — which is what #20 did before the audit.
+- ✅ A **default call timeout**. This one is breaking in an unusual direction:
+  it makes previously-hanging calls start failing. That is the point, and
+  `timeout: 0` opts out per call or per client.
+
+  **25 seconds**, which is what libdbus, GDBus and sd-bus all use — so a call
+  that hits this deadline would have hit theirs at the same point, and the
+  change brings the package into line rather than inventing a policy.
+
+  Building it turned up a case the sketch above did not consider: a message
+  carrying `NO_REPLY_EXPECTED`. A deadline there would report a `TimeoutError`
+  for a message that did exactly what it was told, so those get none — and
+  since there is no reply to wait for, `invoke` now settles them as soon as
+  the message is written. That also fixes a leak nobody had noticed: it used
+  to register a pending-call entry against a serial that could never arrive,
+  one per call, for the life of the connection.
 
 Codemoddable: `bus.connection.end()` → `await bus.close()` is a mechanical
 rewrite.

--- a/docs/api.md
+++ b/docs/api.md
@@ -99,7 +99,7 @@ socket other processes can reach.
 | `authMethods`    | `string[]`                | `['EXTERNAL', 'DBUS_COOKIE_SHA1', 'ANONYMOUS']` | tried in order                                                 |
 | `direct`         | `boolean`                 | `false`                                         | skip the opening `Hello`, for peer-to-peer connections         |
 | `server`         | `boolean`                 | `false`                                         | act as the server side of the handshake                        |
-| `timeout`        | `number`                  | none                                            | default timeout in ms for every call on this client            |
+| `timeout`        | `number`                  | `25000`                                         | ms every call waits for its reply; `0` disables — see below    |
 | `ayBuffer`       | `true \| false \| 'view'` | `true`                                          | how `ay` comes back — see [Values](#values-and-types)          |
 | `maxMessageSize` | `number`                  | 128 MiB                                         | reject a message declaring more than this                      |
 | `returnBigInt`   | `boolean`                 | `true`                                          | read `x`/`t` as native `bigint`, exactly — see below           |
@@ -196,13 +196,27 @@ with `path`, `destination` and `interface` defaulted to the bus daemon's own
 | `signal`  | `AbortSignal` | cancels the call; rejects with `AbortError`                  |
 
 A timeout or an abort **removes the pending call**, so neither leaks an entry
-nor delivers a late reply. There is no default timeout: a call waits forever
-unless you ask otherwise.
+nor delivers a late reply.
+
+**Every call has a deadline: 25 seconds by default**, the same figure libdbus,
+GDBus and sd-bus use, so a call that hits it would have hit theirs at the same
+point. Before 2.0 there was none, and a peer that never answered left the
+promise unsettled for the life of the process.
 
 ```js
-await bus.invoke(msg, { timeout: 5000 });
+await bus.invoke(msg, { timeout: 5000 }); // shorter
+await bus.invoke(msg, { timeout: 0 }); // no deadline at all
 await bus.invoke(msg, { signal: AbortSignal.timeout(5000) });
+
+const bus = dbus.sessionBus({ timeout: 60_000 }); // per client
 ```
+
+A method that legitimately takes longer than 25 seconds needs `timeout` raised
+for that call — the same thing you would do against any other D-Bus library.
+
+A message carrying `NO_REPLY_EXPECTED` gets no deadline, because there is
+nothing to wait for: `invoke` settles with `undefined` once the message is
+written.
 
 ### Bus daemon methods
 

--- a/docs/migrating-to-2.0.md
+++ b/docs/migrating-to-2.0.md
@@ -2,7 +2,11 @@
 
 **2.0 changes the shapes values arrive in.** A variant becomes the value it
 holds, a string-keyed dict becomes a plain object, and 64-bit integers become
-`bigint`. Nothing else about the API moves.
+`bigint`. That is most of the release, and most of this guide.
+
+Three smaller breaks ship alongside it: a **default call timeout**, the removal
+of `ReturnLongjs` and `dbus2js`, and a **Node floor of 22.12**. They are at the
+end, under [The rest of the release](#the-rest-of-the-release).
 
 It is the release people have been asking for since
 [#3](https://github.com/sidorares/dbus-native/issues/3) in 2013, and it is the
@@ -277,6 +281,60 @@ Four things to know:
   [#248](https://github.com/sidorares/dbus-native/issues/248) is about.
 - **It is a holding position, not a destination.** Delete the wrapper and fix
   what `dbus-native lint` and `tsc` then point at.
+
+---
+
+## The rest of the release
+
+Three smaller breaks, none of which need the tooling above.
+
+### Calls now have a deadline
+
+A call waits **25 seconds** for its reply and then rejects with a
+`TimeoutError`. Before 2.0 there was no default: a peer that never answered
+left the promise unsettled for the life of the process.
+
+```js
+await bus.invoke(msg, { timeout: 60_000 }); // this one is genuinely slow
+await bus.invoke(msg, { timeout: 0 }); // no deadline, as before
+const bus = dbus.sessionBus({ timeout: 0 }); // ...or for the whole client
+```
+
+25 seconds is what libdbus, GDBus and sd-bus all use, so a call that hits this
+deadline would have hit theirs at the same point — this brings the package in
+line rather than inventing a policy.
+
+**This one breaks in an unusual direction: it makes previously-hanging calls
+start failing.** That is the point. A promise that never settles cannot be
+caught, logged or retried, and any peer can cause one by crashing between
+receiving a message and answering it. But if you have a method that
+legitimately takes longer than 25 seconds, it needs `timeout` raised — and it
+will fail loudly rather than quietly, so you will know.
+
+A message carrying `NO_REPLY_EXPECTED` gets no deadline and settles with
+`undefined` once written, since there is nothing to wait for. It used to hang
+here too, and leak one pending entry per call.
+
+### `ReturnLongjs` and `dbus2js` are gone
+
+Both warned from 0.6. `ReturnLongjs` now **throws** rather than being ignored,
+because code that sets it expects a Long back and would otherwise meet
+`value.toNumber is not a function` somewhere far from the call:
+
+```js
+const bus = dbus.sessionBus({ returnBigInt: false }); // a lossy number
+```
+
+`dbus2js` is replaced by `dbus-native types`; see
+[DBUS_DEP0005](deprecations.md#dbus_dep0005) for the equivalent command.
+`lib/address-x11.js` is also gone — it required a package that was never a
+dependency, so it threw on require for everyone who found it.
+
+### Node 22.12 or newer
+
+Node 20 reached end of life on 2026-04-30. 22.12 rather than 22.0 because that
+is where `require()` of an ESM module works unflagged, which keeps a future
+option open.
 
 ---
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -278,7 +278,11 @@ export interface ConnectionOptions {
   ReturnLongjs?: never;
   /** reject a message declaring more than this many bytes; default 128 MiB */
   maxMessageSize?: number;
-  /** default timeout in ms for every call on this client; default: no timeout */
+  /**
+   * ms every call on this client waits for its reply. Default `25000`, the
+   * figure libdbus, GDBus and sd-bus all use. `0` disables it, restoring the
+   * pre-2.0 behaviour of waiting indefinitely.
+   */
   timeout?: number;
   /**
    * Reconnect when the transport goes away. **Off by default**, because

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -2,6 +2,9 @@ const EventEmitter = require('events').EventEmitter;
 const constants = require('./constants');
 
 const DBUS_NAME = 'org.freedesktop.DBus';
+
+/** ms a call waits for its reply. What libdbus, GDBus and sd-bus all use. */
+const DEFAULT_TIMEOUT = 25000;
 const stdDbusIfaces = require('./stdifaces');
 const introspect = require('./introspect').introspectBus;
 const { maybePromise } = require('./promisify');
@@ -33,8 +36,21 @@ function bus(conn, opts) {
   EventEmitter.call(this);
 
   const self = this;
-  // Opt-in per-client default; undefined means wait forever, as before.
-  const defaultTimeout = opts.timeout;
+  // Every call gets a deadline unless one is turned off explicitly, with
+  // `timeout: 0` per client or per call.
+  //
+  // A call that never gets a reply used to wait for the process to end, which
+  // is not a thing a caller can recover from or even see: the promise simply
+  // never settles. Any peer can cause it -- by crashing between receiving the
+  // message and answering it, or by having a handler that silently returns
+  // without replying -- so "wait forever" makes one program's bug into
+  // another's hang.
+  //
+  // 25 seconds because that is what libdbus, GDBus and sd-bus all use, so a
+  // call that hits this deadline would have hit theirs at the same point. A
+  // caller that genuinely needs longer says so, exactly as it would there.
+  const defaultTimeout =
+    opts.timeout !== undefined ? opts.timeout : DEFAULT_TIMEOUT;
   this.connection = conn;
   this.serial = 1;
   this.cookies = {}; // TODO: rename to methodReturnHandlers
@@ -256,9 +272,6 @@ function bus(conn, opts) {
     }
     const opts = options || {};
     const signal = opts.signal;
-    // No default timeout unless the client asked for one. Making calls that
-    // currently hang start failing is a behaviour change, and belongs in a
-    // major -- see RELEASE_PLAN.md.
     const timeout = opts.timeout !== undefined ? opts.timeout : defaultTimeout;
 
     return maybePromise(callback, cb => {
@@ -289,6 +302,18 @@ function bus(conn, opts) {
       if (!msg.type) msg.type = constants.messageType.methodCall;
       msg.serial = self.nextSerial();
       const serial = msg.serial;
+
+      // NO_REPLY_EXPECTED says the peer must not answer, so there is nothing
+      // to wait for and nothing to time out. Settling once the message is
+      // written is the only honest answer; registering a cookie against a
+      // serial that can never arrive would leak one per call, and arming the
+      // deadline would report a TimeoutError for a message that did exactly
+      // what it was told.
+      if (msg.flags & constants.flags.noReplyExpected) {
+        self.connection.message(msg);
+        if (traced) channels.call.end.publish(context);
+        return cb(null);
+      }
 
       let timer = null;
       let onAbort = null;

--- a/test/integration/timeouts.js
+++ b/test/integration/timeouts.js
@@ -129,5 +129,45 @@ describe(
         'here'
       );
     });
+
+    // The default is 25 seconds, which is far too long to wait for here. What
+    // can be checked against a real daemon is that a call made with no options
+    // at all now *has* a deadline -- before 2.0 it had none, and this would
+    // have stayed pending until the process ended.
+    it('gives a call with no options a deadline of its own', async () => {
+      const pending = clientBus.invoke(call('NeverReplies'));
+      const [serial] = Object.keys(clientBus.cookies);
+      assert.ok(serial, 'the call is pending');
+
+      // Settle it by hand rather than waiting 25s: what is being asserted is
+      // that the machinery armed a deadline, which the unit test pins to the
+      // exact figure.
+      clientBus.cookies[serial](
+        Object.assign(new Error('stand-in'), { name: 'TimeoutError' })
+      );
+      await assert.rejects(() => pending, { name: 'TimeoutError' });
+      assert.strictEqual(
+        Object.keys(clientBus.cookies).length,
+        0,
+        'and cleaned up after itself'
+      );
+    });
+
+    it('sends a no-reply message without waiting for one', async () => {
+      const { flags } = require('../../lib/constants');
+      const before = Object.keys(clientBus.cookies).length;
+      const result = await clientBus.invoke({
+        ...call('NeverReplies'),
+        flags: flags.noReplyExpected
+      });
+      assert.strictEqual(result, undefined);
+      assert.strictEqual(
+        Object.keys(clientBus.cookies).length,
+        before,
+        'left nothing pending'
+      );
+      // The connection is fine, and the service really did get the message.
+      assert.strictEqual(await clientBus.invoke(call('Quick')), 'here');
+    });
   }
 );

--- a/test/timeouts.js
+++ b/test/timeouts.js
@@ -98,19 +98,91 @@ describe('call timeouts', () => {
     assert.strictEqual(await pending, 'slow but fine');
   });
 
-  it('waits forever by default, as it always has', async () => {
-    const { bus, sent, reply } = fakeBus();
-    const pending = bus.invoke({ ...call });
-    setTimeout(() => reply(sent[0].serial, ['eventually']), 60);
-    assert.strictEqual(await pending, 'eventually');
-  });
-
   it('reports the timeout through a callback too', (t, done) => {
     const { bus } = fakeBus();
     bus.invoke({ ...call }, { timeout: 20 }, err => {
       assert.strictEqual(err.name, 'TimeoutError');
       done();
     });
+  });
+});
+
+// A call with no deadline never settles when the peer does not answer -- not
+// slowly, not with an error, never. Any peer can cause it by crashing between
+// receiving a message and replying, so waiting forever turns one program's bug
+// into another's hang.
+describe('the default deadline', () => {
+  keepEventLoopAlive();
+
+  /** The delays passed to setTimeout while `fn` runs. */
+  const armedDelays = fn => {
+    const delays = [];
+    const real = global.setTimeout;
+    global.setTimeout = (cb, ms) => {
+      delays.push(ms);
+      return real(cb, ms);
+    };
+    try {
+      return { delays, result: fn() };
+    } finally {
+      global.setTimeout = real;
+    }
+  };
+
+  it('is 25 seconds, matching libdbus, GDBus and sd-bus', () => {
+    // Too long to wait for, so this reads the delay the timer was armed with
+    // rather than letting it fire.
+    const { bus } = fakeBus();
+    const { delays } = armedDelays(() => bus.invoke({ ...call }, () => {}));
+    assert.deepStrictEqual(delays, [25000]);
+  });
+
+  it('reports that number to the caller when it fires', async () => {
+    // What a caller is told has to be the deadline they were actually given,
+    // since that is the number they would adjust.
+    const { bus } = fakeBus({ timeout: 20 });
+    await assert.rejects(
+      () => bus.invoke({ ...call }),
+      err => {
+        assert.strictEqual(err.name, 'TimeoutError');
+        assert.strictEqual(err.timeout, 20);
+        return true;
+      }
+    );
+  });
+
+  it('is turned off by timeout: 0, per call', async () => {
+    const { bus, sent, reply } = fakeBus();
+    const pending = bus.invoke({ ...call }, { timeout: 0 });
+    setTimeout(() => reply(sent[0].serial, ['eventually']), 60);
+    assert.strictEqual(await pending, 'eventually');
+  });
+
+  it('is turned off by timeout: 0, per client', async () => {
+    const { bus, sent, reply } = fakeBus({ timeout: 0 });
+    const pending = bus.invoke({ ...call });
+    setTimeout(() => reply(sent[0].serial, ['eventually']), 60);
+    assert.strictEqual(await pending, 'eventually');
+  });
+
+  it('does not arm a deadline for a message expecting no reply', async () => {
+    // NO_REPLY_EXPECTED means the peer must not answer, so a deadline would
+    // report a failure for a message that did exactly what it was told.
+    const { bus, sent } = fakeBus();
+    const { delays, result } = armedDelays(() =>
+      bus.invoke({ ...call, flags: constants.flags.noReplyExpected })
+    );
+    assert.strictEqual(await result, undefined, 'settles with nothing');
+    assert.deepStrictEqual(delays, [], 'and armed no timer');
+    assert.strictEqual(sent.length, 1, 'but did send the message');
+  });
+
+  it('leaves no pending entry for a message expecting no reply', async () => {
+    // It used to register a cookie against a serial that could never arrive,
+    // which is one leaked entry per call for the life of the connection.
+    const { bus } = fakeBus();
+    await bus.invoke({ ...call, flags: constants.flags.noReplyExpected });
+    assert.deepStrictEqual(Object.keys(bus.cookies), []);
   });
 });
 


### PR DESCRIPTION
**Stacked on [#375](https://github.com/sidorares/dbus-native/pull/375) → [#374](https://github.com/sidorares/dbus-native/pull/374).** The last item of `RELEASE_PLAN` 3.0, and the last planned breaking change.

A call waits **25 seconds** for its reply and then rejects with a `TimeoutError`. There was no default before.

## Why this matters more than it looks

A call with no deadline doesn't fail slowly — it never settles. Not an error, not a rejection, nothing. A caller can't catch it, log it, or retry it, and the `await` simply never returns. Any peer can cause it by crashing between receiving a message and answering it, or by having a handler that returns without replying. "Wait forever" turns one program's bug into another's hang.

**25 seconds** is what libdbus, GDBus and sd-bus all use. So a call that hits this deadline would have hit theirs at the same point — this brings the package into line rather than inventing a policy. `timeout: 0` opts out, per call or per client.

## The case the plan didn't consider

`NO_REPLY_EXPECTED` says the peer must not answer. A deadline there would report a `TimeoutError` for a message that did exactly what it was told — so those get none.

And since there is nothing to wait for, `invoke` now settles them as soon as the message is written, instead of hanging. That fixes a leak found on the way: such a call used to register a pending-call entry against a serial that could never arrive — one per call, for the life of the connection. `bus.cookies` grew forever.

The CLI's `--no-reply` never hit this, because it bypasses `invoke()` and writes straight to the connection. Anyone setting `flags` on an `invoke` message did, and `flags` is documented.

## Verified

- 3 of the 5 new unit tests fail on the old code. The other two assert `timeout: 0` still disables, which always worked — that's the opt-out, and it needs to keep working.
- Two of the three don't fail so much as **hang**, which is the bug stated precisely: `await bus.invoke(msg)` against a silent peer never settles, so the file runs until the test runner kills it.
- 900 unit tests on Node 22.16, 24.12, 26; 259 integration tests in all six shape × bus configurations, against both `dbus-daemon` and the broker.

The integration test can't wait 25 seconds, so it asserts that a call made with *no options at all* is now pending under a deadline and cleans up when settled; the unit test pins the exact figure by reading what `setTimeout` was armed with.

## Docs

`docs/migrating-to-2.0.md` gains a **The rest of the release** section covering this, the `ReturnLongjs`/`dbus2js` removals and the Node floor — so an upgrading consumer reads one guide rather than four. It's explicit that this break runs in an unusual direction: previously-hanging calls start failing, which is the point, but a genuinely-slow method needs `timeout` raised.