### PR TITLE
docs: note the stacked-squash changelog trap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,18 @@ docker run --rm -it -v "$PWD":/app -w /app node:24 \
   (`feat:`, `fix:`, `deps:`, `docs:`, `chore:`). release-please derives the
   changelog and the version bump from them, so a mislabelled commit ships the
   wrong version.
+- **Check the changelog after squash-merging a stacked PR.** GitHub's default
+  squash message concatenates every commit on the branch — including commits
+  from a base PR that already landed separately. The squashed commit then
+  carries _two_ `BREAKING CHANGE:` footers, release-please takes one per
+  commit, and the other is silently dropped. That is how 0.14.0 nearly shipped
+  a changelog listing `ReturnLongjs` twice and the Node floor raise not at all,
+  and a missing breaking-change entry reads exactly like a release that had
+  none. Either trim the squash message to the PR's own commit, or correct
+  `CHANGELOG.md` afterwards — and note that fixing the file is not enough on
+  its own, because release-please builds the GitHub Release notes from the
+  release PR's **body**. Both need the correction, and both are reverted if
+  anything else lands on `master` before the release PR is merged.
 
 ## Landmines
 


### PR DESCRIPTION
**Draft on purpose — do not merge until [#377](https://github.com/sidorares/dbus-native/pull/377) is merged and 0.14.0 is out.**

Any push to `master` regenerates the release PR, which would revert the changelog correction I just made by hand. Merging this first would re-break the thing it documents, which would be a poor advertisement for it.

---

Six lines in `AGENTS.md` recording the trap that nearly shipped a wrong 0.14.0 changelog.

GitHub's default squash message concatenates every commit on the branch, including commits from a base PR that already landed separately. So the squashed commit carries **two** `BREAKING CHANGE:` footers:

```bash
git log -1 --format=%B 7a35321 | grep -c 'BREAKING CHANGE'   # 2  (#375)
git log -1 --format=%B 1af463b | grep -c 'BREAKING CHANGE'   # 1  (#374)
```

release-please takes one per commit. It took the first — duplicating #374's entry and dropping #375's Node floor raise entirely. **A missing breaking-change entry reads exactly like a release that had none**, which is why this is worth writing down rather than rediscovering.

The note also records the half of the fix that is easy to miss: correcting `CHANGELOG.md` is not sufficient, because release-please builds the **GitHub Release notes from the release PR's body**. Both need it, and both are reverted by anything landing on `master` first — which is why this PR is a draft.