### PR TITLE
fix!: unixexec addresses use the argv keys the spec defines

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -108,8 +108,16 @@ socket other processes can reach.
 | `reconnect`      | `boolean \| object`       | `false`                                         | reconnect when the transport goes away — see below             |
 
 Address forms understood by `busAddress`: `unix:path=…`, `unix:abstract=…`,
-`unix:socket=…`, `tcp:host=…,port=…`, `unixexec:path=…,arg1=…`, and
+`unix:socket=…`, `tcp:host=…,port=…`, `unixexec:path=…,argv1=…`, and
 `launchd:env=…`.
+
+**`unixexec:`** runs the bus as a child process and speaks to it over its stdio.
+`path` is the binary, `argv1`, `argv2`, … are its arguments, and the optional
+`argv0` sets the program name the binary sees rather than being an argument
+itself. A missing `argvX` ends the list, so `argv3` without `argv2` is not read.
+Up to 0.14.0 these were read as `arg1`, `arg2`, … — a spelling no address
+generator produces, so a conformant address ran the binary with no arguments at
+all.
 
 **`launchd:env=VAR`** is how macOS advertises its session bus. The address names
 an environment variable rather than a path; the socket is looked up with

--- a/index.js
+++ b/index.js
@@ -2,9 +2,8 @@
 
 const { EventEmitter } = require('events');
 const net = require('net');
-const { spawn, spawnSync } = require('child_process');
-const { Duplex } = require('stream');
 
+const { connectToAddress } = require('./lib/address');
 const constants = require('./lib/constants');
 const message = require('./lib/message');
 const clientHandshake = require('./lib/handshake');
@@ -15,92 +14,6 @@ const values = require('./lib/values');
 const errors = require('./lib/errors');
 const names = require('./lib/names');
 const { publishSend, publishReceive } = require('./lib/diagnostics');
-
-// A d-bus address is `family:key=value,key=value`, and DBUS_SESSION_BUS_ADDRESS
-// may hold several of them separated by `;`. See
-// https://dbus.freedesktop.org/doc/dbus-specification.html#addresses
-function parseAddressParams(address) {
-  const [family, paramString = ''] = address.split(':');
-  const params = {};
-  for (const pair of paramString.split(',')) {
-    if (!pair) continue;
-    const [key, value] = pair.split('=');
-    params[key] = value;
-  }
-  return { family: family.toLowerCase(), params };
-}
-
-/**
- * The socket path behind a `launchd:env=VAR` address.
- *
- * macOS keeps the session bus socket in the *launchd* environment, which is
- * not necessarily ours -- a process that was not started from a shell holding
- * the variable still needs to find it. So the spec names a variable to look up
- * with `launchctl getenv` rather than a path.
- * https://dbus.freedesktop.org/doc/dbus-specification.html#transports-launchd
- */
-function launchdSocketPath(varName) {
-  // spawnSync blocks, which is acceptable exactly once during connection setup
-  // and before any I/O has happened. The alternative is making createStream()
-  // async, which would make createConnection() -- and so sessionBus() -- async
-  // for every caller on every platform, to fix one transport on one of them.
-  //
-  // No shell is involved (args are passed as an array), so the variable name
-  // out of the address string cannot turn into a command.
-  const result = spawnSync('launchctl', ['getenv', varName], {
-    encoding: 'utf8'
-  });
-  const fromLaunchd =
-    !result.error && result.status === 0 ? result.stdout.trim() : '';
-
-  // `launchctl getenv` exits 0 with no output for a variable that is not set,
-  // and off macOS it is not there at all. Either way our own environment is
-  // worth a look before giving up -- it is where the variable usually is when
-  // the process came from a shell.
-  return fromLaunchd || process.env[varName] || '';
-}
-
-function connectToAddress(address) {
-  const { family, params } = parseAddressParams(address);
-
-  switch (family) {
-    case 'tcp':
-      return net.createConnection(params.port, params.host || 'localhost');
-    case 'unix':
-      if (params.socket) return net.createConnection(params.socket);
-      if (params.abstract) {
-        // Node supports Linux abstract sockets natively since v20.8.0 by
-        // prefixing the path with a NUL byte - no native addon required.
-        return net.createConnection(`\0${params.abstract}`);
-      }
-      if (params.path) return net.createConnection(params.path);
-      throw new Error(
-        "not enough parameters for 'unix' connection - you need to specify 'socket' or 'abstract' or 'path' parameter"
-      );
-    case 'launchd': {
-      if (!params.env) {
-        throw new Error(
-          "not enough parameters for 'launchd' connection - you need to specify the 'env' parameter"
-        );
-      }
-      const path = launchdSocketPath(params.env);
-      if (!path) {
-        throw new Error(
-          `launchd address names ${params.env}, which is set neither in the launchd environment nor in this process. Is dbus running? (brew services start dbus)`
-        );
-      }
-      return net.createConnection(path);
-    }
-    case 'unixexec': {
-      const args = [];
-      for (let n = 1; params[`arg${n}`]; n++) args.push(params[`arg${n}`]);
-      const child = spawn(params.path, args);
-      return Duplex.from({ writable: child.stdin, readable: child.stdout });
-    }
-    default:
-      throw new Error(`unknown address type:${family}`);
-  }
-}
 
 // macOS does not set DBUS_SESSION_BUS_ADDRESS -- dbus there advertises the
 // session bus through launchd instead, which is what dbus's own client library

--- a/lib/address.js
+++ b/lib/address.js
@@ -1,0 +1,124 @@
+// Bus addresses and the transports behind them.
+// https://dbus.freedesktop.org/doc/dbus-specification.html#addresses
+
+const net = require('net');
+const { spawn, spawnSync } = require('child_process');
+const { Duplex } = require('stream');
+
+// A d-bus address is `family:key=value,key=value`, and DBUS_SESSION_BUS_ADDRESS
+// may hold several of them separated by `;`.
+function parseAddressParams(address) {
+  const [family, paramString = ''] = address.split(':');
+  const params = {};
+  for (const pair of paramString.split(',')) {
+    if (!pair) continue;
+    const [key, value] = pair.split('=');
+    params[key] = value;
+  }
+  return { family: family.toLowerCase(), params };
+}
+
+/**
+ * The socket path behind a `launchd:env=VAR` address.
+ *
+ * macOS keeps the session bus socket in the *launchd* environment, which is
+ * not necessarily ours -- a process that was not started from a shell holding
+ * the variable still needs to find it. So the spec names a variable to look up
+ * with `launchctl getenv` rather than a path.
+ * https://dbus.freedesktop.org/doc/dbus-specification.html#transports-launchd
+ */
+function launchdSocketPath(varName) {
+  // spawnSync blocks, which is acceptable exactly once during connection setup
+  // and before any I/O has happened. The alternative is making createStream()
+  // async, which would make createConnection() -- and so sessionBus() -- async
+  // for every caller on every platform, to fix one transport on one of them.
+  //
+  // No shell is involved (args are passed as an array), so the variable name
+  // out of the address string cannot turn into a command.
+  const result = spawnSync('launchctl', ['getenv', varName], {
+    encoding: 'utf8'
+  });
+  const fromLaunchd =
+    !result.error && result.status === 0 ? result.stdout.trim() : '';
+
+  // `launchctl getenv` exits 0 with no output for a variable that is not set,
+  // and off macOS it is not there at all. Either way our own environment is
+  // worth a look before giving up -- it is where the variable usually is when
+  // the process came from a shell.
+  return fromLaunchd || process.env[varName] || '';
+}
+
+/**
+ * The child process behind a `unixexec:` address, and the arguments it gets.
+ *
+ * The keys are `argv0` and `argv1`, `argv2`, ... -- not `arg0`/`arg1`, which is
+ * what this read until 0.14.0 and meant a spec-conformant address had every
+ * argument silently dropped. `argv0` is the *program name* (execlp's second
+ * argument), not the first real argument, so it does not belong in the list.
+ * https://dbus.freedesktop.org/doc/dbus-specification.html#transports-exec
+ */
+function unixexecArgs(params) {
+  const args = [];
+  // "If a specific argvX is not specified no further argvY for Y > X are taken
+  // into account" -- so a gap ends the list rather than being skipped over.
+  for (let n = 1; params[`argv${n}`] !== undefined; n++) {
+    args.push(params[`argv${n}`]);
+  }
+  return args;
+}
+
+function connectToAddress(address) {
+  const { family, params } = parseAddressParams(address);
+
+  switch (family) {
+    case 'tcp':
+      return net.createConnection(params.port, params.host || 'localhost');
+    case 'unix':
+      if (params.socket) return net.createConnection(params.socket);
+      if (params.abstract) {
+        // Node supports Linux abstract sockets natively since v20.8.0 by
+        // prefixing the path with a NUL byte - no native addon required.
+        return net.createConnection(`\0${params.abstract}`);
+      }
+      if (params.path) return net.createConnection(params.path);
+      throw new Error(
+        "not enough parameters for 'unix' connection - you need to specify 'socket' or 'abstract' or 'path' parameter"
+      );
+    case 'launchd': {
+      if (!params.env) {
+        throw new Error(
+          "not enough parameters for 'launchd' connection - you need to specify the 'env' parameter"
+        );
+      }
+      const path = launchdSocketPath(params.env);
+      if (!path) {
+        throw new Error(
+          `launchd address names ${params.env}, which is set neither in the launchd environment nor in this process. Is dbus running? (brew services start dbus)`
+        );
+      }
+      return net.createConnection(path);
+    }
+    case 'unixexec': {
+      if (!params.path) {
+        throw new Error(
+          "not enough parameters for 'unixexec' connection - you need to specify the 'path' parameter"
+        );
+      }
+      // Node defaults argv[0] to the command when the option is left out,
+      // which is what the spec asks for when argv0 is absent.
+      const child = spawn(params.path, unixexecArgs(params), {
+        argv0: params.argv0
+      });
+      return Duplex.from({ writable: child.stdin, readable: child.stdout });
+    }
+    default:
+      throw new Error(`unknown address type:${family}`);
+  }
+}
+
+module.exports = {
+  parseAddressParams,
+  launchdSocketPath,
+  unixexecArgs,
+  connectToAddress
+};

--- a/test/address-unixexec.js
+++ b/test/address-unixexec.js
@@ -1,0 +1,92 @@
+// The unixexec: transport, which runs the bus as a child process and talks to
+// it over its stdio.
+//
+// https://dbus.freedesktop.org/doc/dbus-specification.html#transports-exec
+//
+// The keys are `argv0` and `argv1`, `argv2`, ... Up to 0.14.0 this read `arg1`,
+// `arg2`, ... which no address generator produces, so every argument on a
+// conformant address was silently dropped and the binary ran bare.
+
+const { describe, it } = require('node:test');
+const assert = require('assert');
+const { connectToAddress, unixexecArgs } = require('../lib/address');
+
+/**
+ * Everything the child writes on stdout.
+ *
+ * These children print and exit immediately, which can tear the duplex down
+ * before its writable half has anything to flush. What is under test is the
+ * argument vector the child saw, so that race is not interesting here.
+ */
+const readAll = stream =>
+  new Promise((resolve, reject) => {
+    const chunks = [];
+    const done = () => resolve(Buffer.concat(chunks).toString());
+    stream.on('data', chunk => chunks.push(chunk));
+    stream.on('end', done);
+    stream.on('error', err =>
+      err.code === 'ERR_STREAM_PREMATURE_CLOSE' ? done() : reject(err)
+    );
+  });
+
+describe('unixexec: argument vectors', () => {
+  it('takes its arguments from argv1 onwards', () => {
+    assert.deepStrictEqual(unixexecArgs({ argv1: 'a', argv2: 'b' }), [
+      'a',
+      'b'
+    ]);
+  });
+
+  it('leaves argv0 out -- it is the program name, not an argument', () => {
+    assert.deepStrictEqual(unixexecArgs({ argv0: 'zero', argv1: 'a' }), ['a']);
+  });
+
+  it('stops at the first gap, as the spec requires', () => {
+    // "If a specific argvX is not specified no further argvY for Y > X are
+    // taken into account."
+    assert.deepStrictEqual(unixexecArgs({ argv1: 'a', argv3: 'c' }), ['a']);
+  });
+
+  it('keeps an empty argument rather than ending the list on it', () => {
+    assert.deepStrictEqual(unixexecArgs({ argv1: '', argv2: 'b' }), ['', 'b']);
+  });
+
+  it('ignores the arg1/arg2 keys this read before 0.15', () => {
+    // Regression guard: they are not spec keys, and reading them was the bug.
+    assert.deepStrictEqual(unixexecArgs({ arg1: 'a', arg2: 'b' }), []);
+  });
+
+  it('passes no arguments when there are none', () => {
+    assert.deepStrictEqual(unixexecArgs({ path: '/bin/echo' }), []);
+  });
+});
+
+describe('unixexec: the child process', () => {
+  it('really does get the arguments', async () => {
+    const stream = connectToAddress(
+      'unixexec:path=/bin/echo,argv1=hello,argv2=world'
+    );
+    // Before the fix this was '\n' -- echo ran with no arguments at all.
+    assert.strictEqual(await readAll(stream), 'hello world\n');
+  });
+
+  it('runs under the program name argv0 asks for', async () => {
+    const stream = connectToAddress(
+      `unixexec:path=${process.execPath},argv0=pretend-name,argv1=-p,argv2=process.argv0`
+    );
+    assert.strictEqual((await readAll(stream)).trim(), 'pretend-name');
+  });
+
+  it('defaults the program name to path when argv0 is absent', async () => {
+    const stream = connectToAddress(
+      `unixexec:path=${process.execPath},argv1=-p,argv2=process.argv0`
+    );
+    assert.strictEqual((await readAll(stream)).trim(), process.execPath);
+  });
+
+  it('says what is missing when there is no path', () => {
+    assert.throws(() => connectToAddress('unixexec:argv1=hello'), {
+      message: /not enough parameters for 'unixexec' connection/
+    });
+  });
+});


### PR DESCRIPTION
## The bug

The [spec's keys](https://dbus.freedesktop.org/doc/dbus-specification.html#transports-exec) for a `unixexec:` address are:

| key | meaning |
| --- | --- |
| `path` | the binary (mandatory) |
| `argv0` | **the program name** — execlp's second argument, i.e. what the child sees as `argv[0]` |
| `argv1`, `argv2`, … | the arguments — execlp's third and later |

We read `arg1`, `arg2`, … — a spelling nothing generates. So on a conformant address every argument was silently dropped:

```js
// before this PR
connectToAddress('unixexec:path=/bin/echo,argv1=hello,argv2=world');
// the child printed "\n" -- echo ran with no arguments at all
```

`argv0` was never honoured either, so a bus expecting to be invoked under a particular program name never was.

## The fix

Read `argv1…N`, stop at the first gap (*"if a specific argvX is not specified no further argvY for Y > X are taken into account"*), and pass `argv0` through as `spawn`'s `argv0` option — which defaults to the command when absent, exactly as the spec asks.

A missing `path` now says so, matching what the `unix:` and `launchd:` cases already do, rather than failing somewhere inside `spawn()`.

## Why the diff is bigger than the fix

`parseAddressParams`, `launchdSocketPath` and `connectToAddress` move from `index.js` to a new `lib/address.js`, unchanged apart from the above. They were unexported locals, so a transport could only be tested by opening a real connection and running a handshake over it. `index.js`'s own exports are untouched — `test/exports.js` and `test/esm-interop.mjs` still pass.

## Tests

`test/address-unixexec.js`, 10 cases: the argument vector directly (argv1 onwards, argv0 excluded, gap stops the scan, empty argument kept, the old `arg1` keys ignored) and the child process end to end (it really does receive the arguments, `argv0` renames it, absent `argv0` defaults to `path`, missing `path` throws).

Verified the old implementation fails the new tests — it builds `[]` from `{path: '/bin/echo', argv1: 'hello', argv2: 'world'}`.

## Provenance

Found while auditing the `@homebridge/dbus-native` fork for fixes we are missing. They spotted the same loop in May and read it as an off-by-one, starting the scan at `arg0` — which passes the program name as the first argument. Neither spelling is the spec's, so this is a fix for both.

**That audit is worth finishing** — their fork has ~20 `fix(...)` commits from 2026-05-08 and this is the first one I checked in depth.

## Breaking

`unixexec:` addresses hand-written against the old `arg1` spelling now pass no arguments. Nothing generates that spelling, so the only way to be affected is to have written an address to match our bug — but that is a behaviour change, so it is marked and will show in the changelog.