### PR TITLE
fix: a bus keeps the options it was given, and cannot be crashed by a path

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -26,7 +26,10 @@ const objectManager = require('./object-manager');
 
 function bus(conn, opts) {
   if (!(this instanceof bus)) {
-    return new bus(conn);
+    // `opts` has to be forwarded: without it `bus(conn, { direct: true })`
+    // built a bus that ignored every option it was given and sent Hello to a
+    // peer with no bus behind it.
+    return new bus(conn, opts);
   }
   if (!opts) opts = {};
   // An EventEmitter so the bus can report things that are its own rather than
@@ -56,7 +59,13 @@ function bus(conn, opts) {
   this.cookies = {}; // TODO: rename to methodReturnHandlers
   this.methodCallHandlers = {};
   this.signals = new EventEmitter();
-  this.exportedObjects = {};
+  // Keyed by a path that arrives in a message from someone else, so it must
+  // not inherit anything: `exportedObjects['__proto__']` on a plain object is
+  // Object.prototype, which is truthy, and dispatch then reads an interface
+  // off it and calls a member of undefined. A remote peer could stop the
+  // process with one malformed method call. Same for the per-path map below,
+  // which is keyed by interface name.
+  this.exportedObjects = Object.create(null);
   /**
    * Well-known names this connection owns. Not the unique name -- that is
    * assigned rather than owned, and lives on `bus.name`.
@@ -705,7 +714,7 @@ function bus(conn, opts) {
 
     let entry;
     if (!self.exportedObjects[path]) {
-      entry = self.exportedObjects[path] = {};
+      entry = self.exportedObjects[path] = Object.create(null);
     } else {
       entry = self.exportedObjects[path];
     }

--- a/test/bus-integrity.js
+++ b/test/bus-integrity.js
@@ -1,0 +1,120 @@
+// Two ways a bus could be left in a state it never agreed to: constructed
+// without the options it was handed, and dispatched into by a peer using a
+// path that names something on Object.prototype.
+//
+// Both found by auditing the @homebridge/dbus-native fork.
+
+const { describe, it } = require('node:test');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const MessageBus = require('../lib/bus');
+const constants = require('../lib/constants');
+
+function fakeConn() {
+  const conn = new EventEmitter();
+  conn.sent = [];
+  conn.message = msg => conn.sent.push(msg);
+  return conn;
+}
+
+const methodCall = (path, iface) => ({
+  type: constants.messageType.methodCall,
+  path,
+  interface: iface,
+  member: 'AnyMember',
+  serial: 1,
+  signature: '',
+  body: []
+});
+
+describe('a bus keeps the options it was given', () => {
+  it('forwards opts when called without new', () => {
+    const conn = fakeConn();
+    // `direct: true` is the observable one: without it the bus opens by
+    // sending Hello, which is wrong on a peer-to-peer connection.
+    MessageBus(conn, { direct: true });
+    assert.deepStrictEqual(
+      conn.sent.map(m => m.member),
+      [],
+      'a direct bus should not send Hello'
+    );
+  });
+
+  it('sends Hello when it really is not direct', () => {
+    const conn = fakeConn();
+    MessageBus(conn, {});
+    assert.deepStrictEqual(
+      conn.sent.map(m => m.member),
+      ['Hello']
+    );
+  });
+
+  it('is the same bus either way', () => {
+    const conn = fakeConn();
+    const made = MessageBus(conn, { direct: true });
+    assert.ok(made instanceof MessageBus);
+  });
+});
+
+describe('a method call cannot reach Object.prototype', () => {
+  it('exportedObjects inherits nothing', () => {
+    const bus = new MessageBus(fakeConn(), { direct: true });
+    assert.strictEqual(Object.getPrototypeOf(bus.exportedObjects), null);
+  });
+
+  it('a per-path interface map inherits nothing either', () => {
+    const bus = new MessageBus(fakeConn(), { direct: true });
+    bus.exportInterface(new EventEmitter(), '/p', {
+      name: 'a.b.C',
+      methods: {},
+      signals: {},
+      properties: {}
+    });
+    assert.strictEqual(Object.getPrototypeOf(bus.exportedObjects['/p']), null);
+  });
+
+  // The regression: `exportedObjects['__proto__']` used to be Object.prototype
+  // -- truthy -- so dispatch went on to read `['constructor']` off it, take
+  // element [1] of the Object constructor (undefined), and look up a member on
+  // that. One method call from any peer and the process was gone.
+  for (const [path, iface] of [
+    ['__proto__', 'constructor'],
+    ['__proto__', '__proto__'],
+    ['constructor', 'toString'],
+    ['valueOf', 'hasOwnProperty']
+  ]) {
+    it(`answers rather than throwing for path=${path} interface=${iface}`, () => {
+      const conn = fakeConn();
+      const bus = new MessageBus(conn, { direct: true });
+      assert.doesNotThrow(() => conn.emit('message', methodCall(path, iface)));
+      assert.strictEqual(conn.sent.length, 1, 'the caller gets a reply');
+      assert.strictEqual(conn.sent[0].type, constants.messageType.error);
+      void bus;
+    });
+  }
+
+  it('still serves an object that really is exported', () => {
+    const conn = fakeConn();
+    const bus = new MessageBus(conn, { direct: true });
+    const impl = Object.assign(Object.create(EventEmitter.prototype), {
+      Ping: () => 'pong'
+    });
+    EventEmitter.call(impl);
+    bus.exportInterface(impl, '/p', {
+      name: 'a.b.C',
+      methods: { Ping: ['', 's', [], ['out']] },
+      signals: {},
+      properties: {}
+    });
+    conn.emit('message', {
+      ...methodCall('/p', 'a.b.C'),
+      member: 'Ping'
+    });
+    return new Promise(resolve =>
+      setImmediate(() => {
+        assert.deepStrictEqual(conn.sent[0].body, ['pong']);
+        resolve();
+      })
+    );
+  });
+});


### PR DESCRIPTION
Two independent bugs, both found by auditing the `@homebridge/dbus-native` fork. Their fork carries a fix for each; ours had neither.

## 1. A method call can stop the process

`exportedObjects` was a plain `{}`, and it is keyed by **a path that arrives in a message from somebody else**:

```js
if ((obj = self.exportedObjects[msg.path])) {   // '__proto__' -> Object.prototype, truthy
  if ((iface = obj[msg['interface']])) {        // 'constructor' -> the Object ctor, truthy
    impl = iface[1];                            // Object[1] -> undefined
    const func = impl[msg.member];              // TypeError, uncaught
```

Any peer that can reach the connection can send one method call and take the process down:

```
CRASH: TypeError - Cannot read properties of undefined (reading 'anything')
```

`__proto__`, `constructor` and `valueOf` all reach it, as do the corresponding interface names. On a bus connection the daemon rejects most malformed paths, but a `direct: true` peer-to-peer connection has no daemon in front of it — and that is exactly the configuration used for the in-process bus and the server side.

Both maps — the path map and the per-path interface map — are now `Object.create(null)`, so a key can only ever match something really exported. Nothing else needed changing: the reads are all `Object.keys`, `for…in` and `Object.hasOwn`, none of which touch the prototype.

## 2. A bus built without `new` ignored every option

```js
if (!(this instanceof bus)) {
  return new bus(conn);   // opts dropped
}
```

So `bus(conn, { direct: true })` built a **non-direct** bus, which opens by sending `Hello` to a peer with no bus behind it:

```
asked for direct:true, but sent 1 message(s) on construction
member: Hello
```

`timeout`, `plainValues`, `returnBigInt`, `variants` and `reconnect` were dropped the same way — silently, so a connection would just behave as though you had asked for the defaults.

## Tests

`test/bus-integrity.js`, 10 cases. **Six fail without this change**, verified by stashing `lib/bus.js` and re-running:

```
✖ forwards opts when called without new
✖ exportedObjects inherits nothing
✖ a per-path interface map inherits nothing either
✖ answers rather than throwing for path=__proto__ interface=constructor
✖ answers rather than throwing for path=constructor interface=toString
✖ answers rather than throwing for path=valueOf interface=hasOwnProperty
```

The four that pass either way are the controls: a genuinely non-direct bus still sends Hello, a real exported object is still served, and `path=__proto__ interface=__proto__` was already answered correctly (that one resolves to `null`, which is falsy).

Full suite: 920 pass.

## Audit status

This is the second PR out of the fork audit, after #380. Checked and **already fixed here**: the double serial increment after a signal emit, `Properties.Set` writing the caller's value, the Windows platform regex (we use `os.homedir()`), `floatle` encoding (`lib/put.js` is gone), the introspect clone-before-mutate and first-sub-node bugs (#350 removed that misfeature outright), the emit-undefined-signal typo, endianness on receive, error bodies as `err.message`, multiple return values, `UnknownInterface`, and introspect parse errors via callback. Not applicable: `portforward`, `address-x11`, `dbus2js` — all removed here.

One more real gap remains, and it is ours alone rather than theirs — the signal wrapper does not follow the export lifecycle. Separate PR to follow.