### PR TITLE
fix: exported signals follow the export, and stop when it ends

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -684,6 +684,81 @@ function bus(conn, opts) {
     self.methodCallHandlers[key] = handler;
   };
 
+  /**
+   * Emitting a signal is done by emitting an ordinary event on the exported
+   * object, so `emit` is wrapped to put the matching D-Bus signal on the wire.
+   *
+   * One wrapper per object, holding a list of the (path, interface) pairs it
+   * is currently exported under, rather than one wrapper per export. Wrapping
+   * per export meant the object accumulated a wrapper for every call: the same
+   * interface exported twice sent every signal twice, and nothing ever removed
+   * a wrapper, so an object went on emitting signals for an interface after it
+   * had been unexported. Keyed on a WeakMap so an object exported on two buses
+   * gets one registration per bus, and so nothing is added to the user's
+   * object.
+   */
+  const signalHooks = new WeakMap();
+
+  function hookSignals(obj, path, iface) {
+    if (typeof obj.emit !== 'function') return;
+
+    let hook = signalHooks.get(obj);
+    if (!hook) {
+      hook = { original: obj.emit, entries: [], wrapper: null };
+      hook.wrapper = function (...args) {
+        const [signalName] = args;
+        if (!signalName) throw new Error('Trying to emit undefined signal');
+
+        for (const { path: signalPath, iface: signalIface } of hook.entries) {
+          const signal = signalIface.signals && signalIface.signals[signalName];
+          if (!signal) continue;
+          const signalMsg = {
+            type: constants.messageType.signal,
+            serial: self.nextSerial(),
+            interface: signalIface.name,
+            path: signalPath,
+            member: signalName
+          };
+          if (signal[0]) {
+            signalMsg.signature = signal[0];
+            signalMsg.body = args.slice(1);
+          }
+          self.connection.message(signalMsg);
+        }
+        // note that local emit is likely to be called before signal arrives
+        // to remote subscriber
+        return hook.original.apply(obj, args);
+      };
+      obj.emit = hook.wrapper;
+      signalHooks.set(obj, hook);
+    }
+
+    // Re-exporting the same interface at the same path replaces its entry.
+    // Appending a second one would send every signal twice.
+    const existing = hook.entries.findIndex(
+      e => e.path === path && e.iface.name === iface.name
+    );
+    if (existing === -1) hook.entries.push({ path, iface });
+    else hook.entries[existing] = { path, iface };
+  }
+
+  function unhookSignals(obj, path, interfaceNames) {
+    const hook = signalHooks.get(obj);
+    if (!hook) return;
+
+    hook.entries = hook.entries.filter(
+      e => !(e.path === path && interfaceNames.includes(e.iface.name))
+    );
+    if (hook.entries.length > 0) return;
+
+    // Nothing left to announce, so get out of the object's way -- unless
+    // somebody wrapped `emit` on top of ours, in which case removing it would
+    // take theirs with it. An empty entry list makes the wrapper a no-op
+    // anyway.
+    if (obj.emit === hook.wrapper) obj.emit = hook.original;
+    signalHooks.delete(obj);
+  }
+
   this.exportInterface = function (obj, path, iface) {
     // Checked here rather than at the first method call: an object exported
     // under a name a peer cannot route to is unreachable, and the useful place
@@ -710,36 +785,7 @@ function bus(conn, opts) {
       entry = self.exportedObjects[path];
     }
     entry[iface.name] = [iface, obj];
-    // monkey-patch obj.emit()
-    if (typeof obj.emit === 'function') {
-      const oldEmit = obj.emit;
-      obj.emit = function () {
-        const args = Array.prototype.slice.apply(arguments);
-        const signalName = args[0];
-        if (!signalName) throw new Error('Trying to emit undefined signal');
-
-        //send signal to bus
-        let signal;
-        if (iface.signals && iface.signals[signalName]) {
-          signal = iface.signals[signalName];
-          const signalMsg = {
-            type: constants.messageType.signal,
-            serial: self.nextSerial(),
-            interface: iface.name,
-            path,
-            member: signalName
-          };
-          if (signal[0]) {
-            signalMsg.signature = signal[0];
-            signalMsg.body = args.slice(1);
-          }
-          self.connection.message(signalMsg);
-        }
-        // note that local emit is likely to be called before signal arrives
-        // to remote subscriber
-        oldEmit.apply(obj, args);
-      };
-    }
+    hookSignals(obj, path, iface);
 
     // Tell anyone watching a manager above this path. Only the new interface
     // is announced, not everything at the path: re-exporting one interface on
@@ -799,18 +845,26 @@ function bus(conn, opts) {
     if (!entry) return false;
 
     let removed;
+    // The objects behind the interfaces going away, before the entries are
+    // gone: each needs its signal registration removed, or it carries on
+    // putting signals on the wire for a path it no longer serves.
+    let unhooked;
     if (interfaceName === undefined) {
       removed = Object.keys(entry);
+      unhooked = removed.map(name => entry[name][1]);
       delete self.exportedObjects[path];
     } else {
       if (!Object.hasOwn(entry, interfaceName)) return false;
       removed = [interfaceName];
+      unhooked = [entry[interfaceName][1]];
       delete entry[interfaceName];
       // An object with no interfaces left is not an object. Leaving the empty
       // entry would keep it in Introspect and in GetManagedObjects as a path
       // with nothing on it.
       if (Object.keys(entry).length === 0) delete self.exportedObjects[path];
     }
+
+    for (const obj of new Set(unhooked)) unhookSignals(obj, path, removed);
 
     self.emitInterfacesRemoved(path, removed);
     return true;

--- a/test/signal-lifecycle.js
+++ b/test/signal-lifecycle.js
@@ -1,0 +1,183 @@
+// A signal is emitted by emitting an ordinary event on the exported object, so
+// `emit` is wrapped. The wrapper has to follow the export: one per object
+// rather than one per exportInterface call, and gone once the object is no
+// longer exported.
+
+const { describe, it } = require('node:test');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const MessageBus = require('../lib/bus');
+
+const IFACE = 'com.example.Iface';
+
+const ifaceDesc = (name = IFACE) => ({
+  name,
+  methods: {},
+  signals: { Pinged: ['s'], Other: ['s'] },
+  properties: {}
+});
+
+function fixture() {
+  const conn = new EventEmitter();
+  const sent = [];
+  conn.message = msg => sent.push(msg);
+  const bus = new MessageBus(conn, { direct: true });
+  return {
+    bus,
+    obj: new EventEmitter(),
+    /** The signals emitted since the last call, then reset. */
+    drain(member = 'Pinged') {
+      const out = sent.filter(m => m.member === member);
+      sent.length = 0;
+      return out;
+    }
+  };
+}
+
+describe('an exported signal goes out once per export', () => {
+  it('once for one export', () => {
+    const { bus, obj, drain } = fixture();
+    bus.exportInterface(obj, '/p', ifaceDesc());
+    obj.emit('Pinged', 'a');
+    assert.strictEqual(drain().length, 1);
+  });
+
+  // The regression: exportInterface wrapped `emit` every time it was called,
+  // so a second export of the same interface put a second wrapper on top and
+  // every signal went out twice.
+  it('still once when the same interface is exported again', () => {
+    const { bus, obj, drain } = fixture();
+    bus.exportInterface(obj, '/p', ifaceDesc());
+    bus.exportInterface(obj, '/p', ifaceDesc());
+    obj.emit('Pinged', 'a');
+    assert.strictEqual(drain().length, 1);
+  });
+
+  it('once per path when the object is exported at two', () => {
+    const { bus, obj, drain } = fixture();
+    bus.exportInterface(obj, '/p', ifaceDesc());
+    bus.exportInterface(obj, '/q', ifaceDesc());
+    drain(); // clear the InterfacesAdded traffic
+    obj.emit('Pinged', 'a');
+    assert.deepStrictEqual(
+      drain()
+        .map(m => m.path)
+        .sort(),
+      ['/p', '/q']
+    );
+  });
+
+  it('once per interface when an object serves two that declare it', () => {
+    const { bus, obj, drain } = fixture();
+    bus.exportInterface(obj, '/p', ifaceDesc('com.example.One'));
+    bus.exportInterface(obj, '/p', ifaceDesc('com.example.Two'));
+    obj.emit('Pinged', 'a');
+    assert.deepStrictEqual(
+      drain()
+        .map(m => m.interface)
+        .sort(),
+      ['com.example.One', 'com.example.Two']
+    );
+  });
+
+  it('carries the signature and body', () => {
+    const { bus, obj, drain } = fixture();
+    bus.exportInterface(obj, '/p', ifaceDesc());
+    obj.emit('Pinged', 'hello');
+    const [signal] = drain();
+    assert.strictEqual(signal.signature, 's');
+    assert.deepStrictEqual(signal.body, ['hello']);
+  });
+
+  it('says so when asked to emit nothing', () => {
+    const { bus, obj } = fixture();
+    bus.exportInterface(obj, '/p', ifaceDesc());
+    assert.throws(() => obj.emit(''), /Trying to emit undefined signal/);
+  });
+});
+
+describe('and stops when the export does', () => {
+  // The regression: nothing ever removed the wrapper, so an object went on
+  // putting signals on the wire for an interface it no longer served.
+  it('no signal after the interface is unexported', () => {
+    const { bus, obj, drain } = fixture();
+    bus.exportInterface(obj, '/p', ifaceDesc());
+    bus.unexportInterface('/p', IFACE);
+    obj.emit('Pinged', 'a');
+    assert.deepStrictEqual(drain(), []);
+  });
+
+  it('no signal after the whole path is unexported', () => {
+    const { bus, obj, drain } = fixture();
+    bus.exportInterface(obj, '/p', ifaceDesc());
+    bus.unexportInterface('/p');
+    obj.emit('Pinged', 'a');
+    assert.deepStrictEqual(drain(), []);
+  });
+
+  it('the other path keeps working when one is unexported', () => {
+    const { bus, obj, drain } = fixture();
+    bus.exportInterface(obj, '/p', ifaceDesc());
+    bus.exportInterface(obj, '/q', ifaceDesc());
+    bus.unexportInterface('/q', IFACE);
+    obj.emit('Pinged', 'a');
+    assert.deepStrictEqual(
+      drain().map(m => m.path),
+      ['/p']
+    );
+  });
+
+  it('gives the object its own emit back once nothing is exported', () => {
+    const { bus, obj } = fixture();
+    const original = obj.emit;
+    bus.exportInterface(obj, '/p', ifaceDesc());
+    assert.notStrictEqual(obj.emit, original, 'wrapped while exported');
+    bus.unexportInterface('/p', IFACE);
+    assert.strictEqual(obj.emit, original, 'and given back afterwards');
+  });
+
+  it('can be exported again afterwards', () => {
+    const { bus, obj, drain } = fixture();
+    bus.exportInterface(obj, '/p', ifaceDesc());
+    bus.unexportInterface('/p', IFACE);
+    bus.exportInterface(obj, '/p', ifaceDesc());
+    obj.emit('Pinged', 'a');
+    assert.strictEqual(drain().length, 1);
+  });
+
+  it('leaves a wrapper somebody else added on top alone', () => {
+    const { bus, obj, drain } = fixture();
+    bus.exportInterface(obj, '/p', ifaceDesc());
+    let seen = 0;
+    const ours = obj.emit;
+    obj.emit = function (...args) {
+      seen++;
+      return ours.apply(this, args);
+    };
+    bus.unexportInterface('/p', IFACE);
+    obj.emit('Pinged', 'a');
+    assert.strictEqual(seen, 1, "the caller's own wrapper still runs");
+    assert.deepStrictEqual(drain(), [], 'but no signal goes out');
+  });
+});
+
+describe('the local listener is unaffected throughout', () => {
+  it('still hears the event, with its arguments', () => {
+    const { bus, obj } = fixture();
+    const heard = [];
+    obj.on('Pinged', arg => heard.push(arg));
+    bus.exportInterface(obj, '/p', ifaceDesc());
+    obj.emit('Pinged', 'a');
+    bus.unexportInterface('/p', IFACE);
+    obj.emit('Pinged', 'b');
+    assert.deepStrictEqual(heard, ['a', 'b']);
+  });
+
+  it('emit still reports whether anyone was listening', () => {
+    const { bus, obj } = fixture();
+    bus.exportInterface(obj, '/p', ifaceDesc());
+    assert.strictEqual(obj.emit('Pinged', 'a'), false, 'nobody listening');
+    obj.on('Pinged', () => {});
+    assert.strictEqual(obj.emit('Pinged', 'a'), true, 'somebody listening');
+  });
+});


### PR DESCRIPTION
Third PR out of the fork audit, after #380 and #382. Half of this is a bug the `@homebridge/dbus-native` fork found and fixed; the other half is ours alone, because they have no `unexportInterface` to leak through.

## The shape of it

A signal is sent by emitting an ordinary event on the exported object, so `exportInterface` wraps `obj.emit`. It wrapped **on every call**, each wrapper closing over its own `iface` and `path` and delegating to the one below.

That chain dispatches correctly for *different* interfaces, which is why it survived this long. It does two wrong things otherwise.

### Exporting the same interface twice sent every signal twice

```
after 1 export:  signals sent = 1
after re-export: signals sent = 2
```

Both wrappers close over the same interface, so both put a message on the wire.

### Unexporting left the object still emitting

```
after unexport:  signals sent = 2   (expected 0)
still exported?  []
```

The object is gone from `exportedObjects`, out of introspection and out of `GetManagedObjects` — and still announcing itself on a path it no longer serves. This reaches the disposable form too, which is the one most likely to be hit:

```js
{
  await using reg = await bus.export('/com/example/Device', device);
  // ...
}                       // registration disposed, signals keep coming
```

## The fix

One wrapper per object, holding the `(path, interface)` pairs it is currently exported under:

- re-exporting a pair **replaces** its entry rather than appending a second
- `unexportInterface` **removes** the entries it retires, for one interface or a whole path
- the last one out **restores** the object's own `emit` — unless somebody else wrapped on top of ours, in which case theirs is left alone and an empty entry list makes ours a no-op

Kept in a `WeakMap` on the bus rather than a property on the object (the fork uses `obj.__dbusInterfaces`). That way an object exported on two buses gets one registration per bus, and nothing is added to the user's object where it would show up in `Object.keys` or `JSON.stringify`.

One more thing while in here: the wrapper discarded `emit`'s return value, so an exported object reported `false` — no listeners — for every event. It returns it now.

## Tests

`test/signal-lifecycle.js`, 14 cases. **Eight fail without this change**:

```
✖ still once when the same interface is exported again
✖ no signal after the interface is unexported
✖ no signal after the whole path is unexported
✖ the other path keeps working when one is unexported
✖ gives the object its own emit back once nothing is exported
✖ can be exported again afterwards
✖ leaves a wrapper somebody else added on top alone
✖ emit still reports whether anyone was listening
```

The six that pass either way are the controls — one export sends one signal, two paths send two, two interfaces send two, the signature and body are carried, emitting nothing still throws, and the local listener still hears everything.

Full suite: 924 pass.

## Audit status

That closes out the audit. Real gaps found and fixed: `unixexec` argument keys (#380), options dropped when `bus()` is called without `new` and the `__proto__` dispatch crash (#382), and this. Everything else on their list is either already fixed here or not applicable — the detail is in #382's description.