### PR TITLE
docs: cite the versions that shipped, not the ones that were planned

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ options:
     4 MB alive. Only use it if you consume the value and drop it promptly.
   - `false` returns a plain array of numbers.
 - returnBigInt - boolean (default:true): 64 bit dbus fields (x/t) are read out as
-  native `bigint`, which covers the whole range exactly. Set `false` for the 1.x
+  native `bigint`, which covers the whole range exactly. Set `false` for the classic
   behaviour, a `number` that loses precision above 2^53.
 
 connection has only one method, `message(msg)`
@@ -185,15 +185,15 @@ const devices = await nm.GetDevices(); // string[], checked
 Methods, properties and signals are all emitted, with argument names taken
 from the introspection data where the service provides them.
 
-| flag                  |                                                          |
-| --------------------- | -------------------------------------------------------- |
-| `--service`, `--path` | what to introspect                                       |
-| `--system`            | use the system bus (default: session)                    |
-| `--xml <file>`        | read saved introspection XML instead of a live bus       |
-| `--out <file>`        | write to a file instead of stdout                        |
-| `--target classic`    | emit the 1.x value shapes (`number`, arrays of pairs)    |
-| `--all`               | include the standard `org.freedesktop.DBus.*` interfaces |
-| `--module <name>`     | module specifier for the type import                     |
+| flag                  |                                                           |
+| --------------------- | --------------------------------------------------------- |
+| `--service`, `--path` | what to introspect                                        |
+| `--system`            | use the system bus (default: session)                     |
+| `--xml <file>`        | read saved introspection XML instead of a live bus        |
+| `--out <file>`        | write to a file instead of stdout                         |
+| `--target classic`    | emit the classic value shapes (`number`, arrays of pairs) |
+| `--all`               | include the standard `org.freedesktop.DBus.*` interfaces  |
+| `--module <name>`     | module specifier for the type import                      |
 
 `dbus-native introspect` prints the raw XML, which is handy for checking a
 service's shape or for saving a fixture to generate from later.
@@ -203,7 +203,7 @@ regenerating after upgrading is one command. The default `plain` target
 describes the default value shapes; use `classic` for a connection reading with
 `plainValues: false, returnBigInt: false`.
 
-> **`dbus2js` was removed in 2.0** (`DBUS_DEP0005`), having warned since 0.6.
+> **`dbus2js` was removed in 0.14.0** (`DBUS_DEP0005`), having warned since 0.6.
 > It emitted untyped ES5, generated no properties, and gave signals an
 > over-broad match rule. `dbus-native types` is the replacement — see
 > [docs/deprecations.md](./docs/deprecations.md#dbus_dep0005) for the
@@ -427,7 +427,7 @@ way can be written straight back out. A dict whose keys are not strings
 (`a{us}`) stays as pairs, because a JavaScript object key is always a string
 and converting one would change the key's type.
 
-Both shapes changed in 2.0. Two helpers read either, so code written against
+Both shapes changed in 0.14.0. Two helpers read either, so code written against
 them behaves the same before and after:
 
 ```js
@@ -442,7 +442,7 @@ const props = toPlain(getAllResult); // { Greeting: 'hello', Count: 7 }
 
 `toPlain()` only converts arrays this library parsed as dicts, so an `a(ss)`
 (array of two-string structs) is left as an array rather than being guessed at.
-`dbus-native/compat` restores the 1.x shapes wholesale if you are not ready:
+`dbus-native/compat` restores the classic shapes wholesale if you are not ready:
 
 ```js
 const { withClassicTypes } = require('dbus-native/compat');
@@ -457,7 +457,7 @@ npx dbus-native lint src/
 
 ```
 src/net.js:42  DBUS_DEP0002  variant index chain `[1][1][0]`
-    -> variantValue(), or a plain property read after 2.0
+    -> variantValue(), or a plain property read after 0.14.0
 ```
 
 It reports rather than rewrites — an index chain says nothing about what the
@@ -547,9 +547,9 @@ rest rather than guessing. See
 [`dbus-native/compat`](docs/migrating-to-0.7.md#the-escape-hatch) if you need the
 old shape while you migrate.
 
-### The 2.0 value shapes
+### The 0.14.0 value shapes
 
-2.0 changed what values look like: a variant is the value it holds, a
+0.14.0 changed what values look like: a variant is the value it holds, a
 string-keyed dict is a plain object, and `x`/`t` are `bigint`.
 
 Code written against `variantValue()` and `toPlain()` needed no change at all —
@@ -605,7 +605,7 @@ exactly:
 const size = await disk.Size(); // 2000398934016n
 ```
 
-Before 2.0 they were a `number`, which **loses precision above 2⁵³** —
+Before 0.14.0 they were a `number`, which **loses precision above 2⁵³** —
 `9223372036854775807` came back as `9223372036854776000`. `returnBigInt: false`
 restores that, per connection, so services and clients can be moved one at a
 time — though note a service reads its _arguments_ through the same parser, so
@@ -628,7 +628,7 @@ These can be **written** to a 64-bit field, whatever the read option:
 - `string`, decimal or `0x`-prefixed hex, over the full range
 - Long.js objects, or anything with compatible `low`/`high`/`unsigned`
 
-`ReturnLongjs` was removed in 2.0 and now throws, rather than quietly handing
+`ReturnLongjs` was removed in 0.14.0 and now throws, rather than quietly handing
 back a type it was not asked for; `returnBigInt: false` is the way to a
 `number`. [Long.js](https://github.com/dcodeIO/long.js) is no longer a
 dependency at all, which also removes the ARMv6 crash that made downstream

--- a/RELEASE_PLAN.md
+++ b/RELEASE_PLAN.md
@@ -39,13 +39,20 @@ the classic track keeps its semver promises.
 Each major is chosen so its blast radius is small enough to tool for, and so
 it unblocks the next one.
 
-| release | theme                         | blast radius              | migration mechanism               |
-| ------- | ----------------------------- | ------------------------- | --------------------------------- |
-| **0.6** | preparation, all additive     | none                      | —                                 |
-| **1.0** | errors are `Error`s ✅        | error-handling paths only | codemod + forward-compatible shim |
-| **2.0** | the type system ✅            | every value read          | accessors + lint + compat wrapper |
-| **3.0** | lifecycle and cancellation ✅ | connection setup/teardown | codemod + deprecations            |
-| **4.0** | ~~ESM~~, `/next` default      | imports                   | codemod                           |
+> **None of these shipped under the names below.** Every one of them landed as
+> a `0.x` minor, because under semver a pre-1.0 minor is already the breaking
+> bump and 1.0.0 is a statement about stability worth making deliberately. The
+> planned names are kept here because the rest of this document argues in them;
+> the **shipped as** column is what actually exists. Anything user-facing should
+> cite the shipped version, not the planned one.
+
+| release | shipped as | theme                         | blast radius              | migration mechanism               |
+| ------- | ---------- | ----------------------------- | ------------------------- | --------------------------------- |
+| **0.6** | 0.6.0      | preparation, all additive     | none                      | —                                 |
+| **1.0** | **0.7.0**  | errors are `Error`s ✅        | error-handling paths only | codemod + forward-compatible shim |
+| **2.0** | **0.14.0** | the type system ✅            | every value read          | accessors + lint + compat wrapper |
+| **3.0** | **0.13.0** | lifecycle and cancellation ✅ | connection setup/teardown | codemod + deprecations            |
+| **4.0** | —          | ~~ESM~~, `/next` default      | imports                   | codemod                           |
 
 Errors come before types because a rejected promise has to carry an `Error` for
 promises to be worth anything, and because it touches only `catch` blocks

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,39 +8,61 @@ is a plan of record, not a promise of dates.
 
 ---
 
-## 0. The elephant in the room: positioning
+## 0. The elephant in the room: positioning — **resolved**
 
-Three packages now serve the same users:
+**[#263](https://github.com/sidorares/dbus-native/issues/263) is answered: work
+has restarted here, and the package is not being deprecated.** The rest of this
+section is the reasoning, kept because it is what the answer rests on.
 
-| package                                            | latest | published | downloads/week |
-| -------------------------------------------------- | ------ | --------- | -------------- |
-| `dbus-native` (this repo)                          | 0.4.0  | 2022-06   | ~7.4k          |
-| `dbus-next` (acrisci fork/rewrite)                 | 0.10.2 | 2022-04   | ~19k           |
-| `@homebridge/dbus-native` (soft fork of this repo) | 0.7.8  | 2026-07   | ~41k           |
+Three packages serve the same users:
 
-Two things stand out:
+| package                                            | latest | published  | downloads/week |
+| -------------------------------------------------- | ------ | ---------- | -------------- |
+| `@homebridge/dbus-native` (soft fork of this repo) | 0.7.8  | 2026-07-25 | 37.1k          |
+| `dbus-next` (acrisci fork/rewrite)                 | 0.10.2 | 2022-04-28 | 18.0k          |
+| `dbus-native` (this repo)                          | 0.15.0 | 2026-07-30 | 9.3k           |
+
+Downloads are the week ending 2026-07-28 — before any of this pass shipped, so
+they measure the position that had to be argued out of, not the one it created.
+
+Two things stood out:
 
 - **The Homebridge fork is the de-facto maintained `dbus-native`.** It is a
   light fork of this codebase (dropped `abstract-socket`, swapped `optimist` for
-  `minimist`, forked `long.js` for an ARMv6 crash) and it now has more downloads
+  `minimist`, forked `long.js` for an ARMv6 crash) and it has more downloads
   than this package and `dbus-next` combined. Its changes are a strict subset of
-  what this pass just did — this repo now has three runtime dependencies to
+  what this pass did — this repo is down to **one** runtime dependency against
   their six.
 - **[#263](https://github.com/sidorares/dbus-native/issues/263) ("Deprecate
   dbus-native") was agreed in principle in 2019 and never executed.** `dbus-next`
   was to take over the npm name; that never happened, and `dbus-next` has itself
   been dormant since 2022.
 
-**Recommendation:** do not deprecate. This repo is the most-forked, most-depended-on
-of the three and is now the most modern. Instead:
+**Decision: do not deprecate.** This repo is the most-forked, most-depended-on
+of the three and is now the most modern. What followed from it:
 
-1. Reach out to the Homebridge maintainers about folding their fork back in.
-   Their three deltas are already addressed here except the `long.js` ARMv6
-   workaround — which §3.2 (BigInt) removes the need for entirely.
-2. Close [#263](https://github.com/sidorares/dbus-native/issues/263) with a note
-   explaining the current state, rather than leaving it open and ambiguous.
-3. Ship a 0.5.0 from this modernisation pass so the ecosystem sees a signal of
-   life.
+1. ~~Reach out to the Homebridge maintainers about folding their fork back in.~~
+   **Outstanding**, and the case is stronger than it was. All three of their
+   deltas are addressed here now — abstract sockets come from Node, arguments
+   from `node:util.parseArgs`, and the `long.js` ARMv6 workaround has nothing
+   left to work around since the dependency was dropped in
+   [#374](https://github.com/sidorares/dbus-native/pull/374). Auditing their
+   fork also turned up three real bugs here
+   ([#380](https://github.com/sidorares/dbus-native/pull/380),
+   [#382](https://github.com/sidorares/dbus-native/pull/382),
+   [#383](https://github.com/sidorares/dbus-native/pull/383)), one of them a
+   remotely-triggerable crash — so the exchange runs both ways.
+2. ~~Close #263 with a note explaining the current state.~~ **Answered**
+   2026-07-30 with the progress since 2019 and the decision to restart work
+   here. Left open for comment rather than closed.
+3. ~~Ship a 0.5.0 so the ecosystem sees a signal of life.~~ **Done, and then
+   some** — 0.5.0 through 0.15.0 between 2026-07-28 and 2026-07-30, ending with
+   the value-shape flip this document's §3.2 and §4.1 were written for.
+
+`BIG_FUTURE_PLANS.md` §7 argued that #263 should be answered _before_ building
+anything, since every proposal in it is an argument that the answer is no. The
+building happened first. That did not change the answer, but it does mean the
+releases are the evidence for it rather than a promise of it.
 
 ---
 

--- a/bin/dbus-native.js
+++ b/bin/dbus-native.js
@@ -23,7 +23,7 @@ Commands:
   types        generate TypeScript declarations for a service
   introspect   print a service's raw introspection XML
   codemod      rewrite your source for a breaking change
-  lint         report reads of value shapes that change in 0.14.0
+  lint         report reads of value shapes that changed in 0.14.0
 
 Options for call/get/set/list:
   --dest <name>      bus name to talk to (call, get, set)
@@ -217,7 +217,7 @@ function runCodemod(name, paths, argv) {
 }
 
 /**
- * Report reads of the value shapes that change in 0.14.0.
+ * Report reads of the value shapes that changed in 0.14.0.
  *
  * Separate from `codemod` because these are the patterns a codemod *cannot*
  * safely rewrite: reading a variant is an index chain, and nothing in the

--- a/bin/dbus-native.js
+++ b/bin/dbus-native.js
@@ -23,7 +23,7 @@ Commands:
   types        generate TypeScript declarations for a service
   introspect   print a service's raw introspection XML
   codemod      rewrite your source for a breaking change
-  lint         report reads of value shapes that change in 2.0
+  lint         report reads of value shapes that change in 0.14.0
 
 Options for call/get/set/list:
   --dest <name>      bus name to talk to (call, get, set)
@@ -54,7 +54,7 @@ Options for types/introspect:
   --out <file>       write to a file instead of stdout
 
 Options for 'types':
-  --target <t>       'plain' (default) or 'classic' for the 1.x value shapes
+  --target <t>       'plain' (default) or 'classic' for the classic value shapes
   --module <name>    module specifier to import types from
                      (default: dbus-native)
   --all              include the standard org.freedesktop.DBus.* interfaces
@@ -217,13 +217,13 @@ function runCodemod(name, paths, argv) {
 }
 
 /**
- * Report reads of the value shapes that change in 2.0.
+ * Report reads of the value shapes that change in 0.14.0.
  *
  * Separate from `codemod` because these are the patterns a codemod *cannot*
  * safely rewrite: reading a variant is an index chain, and nothing in the
  * source says what the value is. Being honest about that matters -- the
  * tooling narrows the problem to a reviewed list of call sites, and there is
- * no complete codemod for 2.0.
+ * no complete codemod for 0.14.0.
  */
 function runLint(paths, argv) {
   if (paths.length === 0) fail(`Nothing to lint.\n\n${USAGE}`);

--- a/docs/api.md
+++ b/docs/api.md
@@ -208,7 +208,7 @@ nor delivers a late reply.
 
 **Every call has a deadline: 25 seconds by default**, the same figure libdbus,
 GDBus and sd-bus use, so a call that hits it would have hit theirs at the same
-point. Before 2.0 there was none, and a peer that never answered left the
+point. Before 0.14.0 there was none, and a peer that never answered left the
 promise unsettled for the life of the process.
 
 ```js
@@ -1149,7 +1149,7 @@ message instead of failing.
 ### Reading values: `plainValues`
 
 A variant reads as the value itself and a string-keyed dict as a plain object.
-`plainValues: false` reads the 1.x shapes instead.
+`plainValues: false` reads the classic shapes instead.
 
 | signature | `plainValues` (default)     | `plainValues: false`            |
 | --------- | --------------------------- | ------------------------------- |
@@ -1177,7 +1177,7 @@ method arguments through the same parser. If you change this, change it on both.
 
 `variantValue()` and `toPlain()` read either shape and are the identity under
 this one, so code written against them works whichever is in force. For code
-that cannot be migrated yet, `dbus-native/compat` restores the 1.x shapes
+that cannot be migrated yet, `dbus-native/compat` restores the classic shapes
 wholesale:
 
 ```js
@@ -1274,7 +1274,7 @@ const {
 
 ```js
 const udi = variantValue(entry); // 'tree': entry[1][0];  'plain': entry
-const props = toPlain(dict); // 1.x: array of pairs;  now: identity
+const props = toPlain(dict); // classic: array of pairs;  now: identity
 
 bus.invoke({
   /* … */ signature: 'ssv',
@@ -1425,15 +1425,15 @@ dc.subscribe('tracing:dbus:call:error', ctx =>
 
 ## CLI
 
-| command      |                                                      |
-| ------------ | ---------------------------------------------------- |
-| `call`       | call a method, the way `dbus-send` does              |
-| `get`, `set` | read or write a property                             |
-| `list`       | the names on the bus                                 |
-| `types`      | TypeScript declarations for a service                |
-| `introspect` | a service's raw introspection XML                    |
-| `codemod`    | rewrite your source for a breaking change            |
-| `lint`       | report reads of the value shapes that changed in 2.0 |
+| command      |                                                         |
+| ------------ | ------------------------------------------------------- |
+| `call`       | call a method, the way `dbus-send` does                 |
+| `get`, `set` | read or write a property                                |
+| `list`       | the names on the bus                                    |
+| `types`      | TypeScript declarations for a service                   |
+| `introspect` | a service's raw introspection XML                       |
+| `codemod`    | rewrite your source for a breaking change               |
+| `lint`       | report reads of the value shapes that changed in 0.14.0 |
 
 ### Talking to the bus
 
@@ -1511,7 +1511,7 @@ never rewrites — reading a variant is an index chain and nothing in the source
 says what the value is, so it narrows the problem to a reviewed list rather
 than guessing. Findings marked `(possible)` are heuristic.
 
-`dbus2js` was removed in 2.0 (`DBUS_DEP0005`).
+`dbus2js` was removed in 0.14.0 (`DBUS_DEP0005`).
 
 See [the README](../README.md#generating-types-for-a-service) for the full flag
 list, and [docs/deprecations.md](./deprecations.md) for every deprecation code.

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -27,7 +27,7 @@ npx dbus-native lint src/
 
 ```
 src/net.js:42  DBUS_DEP0002  variant index chain `[1][1][0]`
-    -> variantValue(), or a plain property read after 2.0
+    -> variantValue(), or a plain property read after 0.14.0
 ```
 
 It reports and never rewrites, because reading a variant is an index chain and
@@ -40,10 +40,10 @@ individual codes.
 
 ## DBUS_DEP0001
 
-**Removed in 2.0**, having warned since 0.6. The `ReturnLongjs` option.
+**Removed in 0.14.0**, having warned since 0.6. The `ReturnLongjs` option.
 
 64-bit values (`x` and `t`) come back as native `BigInt`, which represents the
-full 64-bit range with no dependency and no option. Before 2.0 they were a
+full 64-bit range with no dependency and no option. Before 0.14.0 they were a
 lossy `number`, or [long.js](https://github.com/dcodeIO/long.js) objects with
 `ReturnLongjs: true`.
 
@@ -85,7 +85,7 @@ this one.
 
 **Documentation.** Reading a variant as `[signature, [value]]`.
 
-Since **2.0** a variant unmarshals to the value itself. Before that it was a
+Since **0.14.0** a variant unmarshals to the value itself. Before that it was a
 two-element array of the _parsed signature tree_ and a one-element array
 holding the value, which `plainValues: false` still gives you.
 
@@ -93,11 +93,11 @@ holding the value, which `plainValues: false` still gives you.
 // the old shape, and the source of more issues than anything else here
 const udi = dict.find(([key]) => key === 'Udi')[1][1][0];
 
-// forward-compatible: identical behaviour before and after 2.0
+// forward-compatible: identical behaviour before and after 0.14.0
 import { variantValue } from 'dbus-native';
 const udi = variantValue(dict.find(([key]) => key === 'Udi')[1]);
 
-// 2.0
+// 0.14.0
 const { Udi } = await device.props.$all;
 ```
 
@@ -123,7 +123,7 @@ Related: [#3](https://github.com/sidorares/dbus-native/issues/3),
 
 **Documentation.** Reading a dict as an array of pairs.
 
-Since **2.0**, `a{sv}` and friends unmarshal to a plain object. Before that
+Since **0.14.0**, `a{sv}` and friends unmarshal to a plain object. Before that
 they were an array of `[key, value]` pairs, which `plainValues: false` still
 gives you.
 
@@ -136,7 +136,7 @@ for (const [key, variant] of result) props[key] = variant[1][0];
 import { toPlain } from 'dbus-native';
 const props = toPlain(result);
 
-// 2.0
+// 0.14.0
 const props = result;
 ```
 
@@ -198,7 +198,7 @@ Closed: [#39](https://github.com/sidorares/dbus-native/issues/39),
 
 ## DBUS_DEP0005
 
-**Removed in 2.0**, having warned since 0.6. The `dbus2js` command.
+**Removed in 0.14.0**, having warned since 0.6. The `dbus2js` command.
 
 It emitted untyped ES5, generated no properties at all, and gave generated
 signal handlers a match rule that asked the daemon for every signal of that

--- a/docs/migrating-to-2.0.md
+++ b/docs/migrating-to-2.0.md
@@ -1,12 +1,19 @@
-# Migrating to 2.0
+# Migrating to 0.14.0
 
-**2.0 changes the shapes values arrive in.** A variant becomes the value it
+**0.14.0 changed the shapes values arrive in.** A variant becomes the value it
 holds, a string-keyed dict becomes a plain object, and 64-bit integers become
 `bigint`. That is most of the release, and most of this guide.
 
-Three smaller breaks ship alongside it: a **default call timeout**, the removal
-of `ReturnLongjs` and `dbus2js`, and a **Node floor of 22.12**. They are at the
-end, under [The rest of the release](#the-rest-of-the-release).
+[RELEASE_PLAN.md](../RELEASE_PLAN.md) calls this release "2.0", and this file is
+still `migrating-to-2.0.md` because the 0.14.0 changelog and release notes link
+to it by that name. It shipped as 0.14.0 for the reason
+[the 0.7 guide gives](migrating-to-0.7.md): under semver a `0.x` minor is
+already the breaking bump, and 1.0.0 is a statement about stability worth making
+deliberately rather than as a side effect. Nothing about the content changed.
+
+Three smaller breaks shipped alongside it: a **default call timeout**, the
+removal of `ReturnLongjs` and `dbus2js`, and a **Node floor of 22.12**. They are
+at the end, under [The rest of the release](#the-rest-of-the-release).
 
 It is the release people have been asking for since
 [#3](https://github.com/sidorares/dbus-native/issues/3) in 2013, and it is the
@@ -25,7 +32,7 @@ first; if you have, and something broke, go to
 
 ## What changes
 
-| D-Bus type       | 1.x                                | 2.0                 |
+| D-Bus type       | classic                            | 0.14.0              |
 | ---------------- | ---------------------------------- | ------------------- |
 | `v`              | `[parsedSignatureTree, [value]]`   | the value           |
 | `a{sv}`, `a{ss}` | array of `[key, value]` pairs      | a plain object      |
@@ -74,8 +81,9 @@ const size = await iface.Size(); // keep it a bigint
 const pct = Number(await iface.Level()) / 100;
 ```
 
-`Number()` at the boundary is not a defeat. It is the same precision you had in
-1.x, made visible in one place instead of applied silently to everything.
+`Number()` at the boundary is not a defeat. It is the same precision you had
+before 0.14.0, made visible in one place instead of applied silently to
+everything.
 
 For JSON, convert at the edge:
 
@@ -100,7 +108,7 @@ dbus-native types --system --service org.freedesktop.UPower \
   --path /org/freedesktop/UPower --out upower.d.ts
 ```
 
-The default `plain` target emits the 2.0 shapes, so `tsc` reports every place a
+The default `plain` target emits the 0.14.0 shapes, so `tsc` reports every place a
 `bigint` meets a `number` before you have run anything. (Generate with
 `--target classic` first if you want to see the two side by side.)
 
@@ -109,20 +117,20 @@ The default `plain` target emits the 2.0 shapes, so `tsc` reports every place a
 ## Variants
 
 ```js
-// 1.x -- the shape behind more issues than anything else in this project
+// classic -- the shape behind more issues than anything else in this project
 const value = result[1][0];
 
-// 2.0
+// 0.14.0
 const value = result;
 ```
 
 Nested in a dict, which is where it usually appears:
 
 ```js
-// 1.x
+// classic
 const udi = dict.find(([key]) => key === 'Udi')[1][1][0];
 
-// 2.0
+// 0.14.0
 const { Udi } = dict;
 ```
 
@@ -134,7 +142,7 @@ const { variantValue } = require('dbus-native');
 const value = variantValue(result); // identical before and after
 ```
 
-`variantValue()` reads the 1.x wrapper and is the identity on a plain value, so
+`variantValue()` reads the classic wrapper and is the identity on a plain value, so
 a file converted to it is done — it needs no second pass at the flag day. This
 is what the accessors are for; see [DBUS_DEP0002](deprecations.md#dbus_dep0002).
 
@@ -144,7 +152,7 @@ is what the accessors are for; see [DBUS_DEP0002](deprecations.md#dbus_dep0002).
 does not:
 
 ```js
-variantSignature(result); // 's' in 1.x, undefined in 2.0
+variantSignature(result); // 's' before 0.14.0, undefined from it
 ```
 
 Almost nobody reads it. If you do — a tool that prints what came back, or a
@@ -162,7 +170,7 @@ variantValue(v); // 0.5, same as every other shape
 A `Variant` is what the tree should have been: it prints as `Variant('d', 0.5)`
 rather than a wall of parse-tree objects, and the marshaller accepts it, so a
 value read this way can be sent straight back out. **Do not migrate to
-`variants: 'tree'` to keep the signature** — it works, but it is the shape 2.0
+`variants: 'tree'` to keep the signature** — it works, but it is the shape 0.14.0
 exists to remove, and `withClassicTypes` is the supported way to stay on it.
 
 Writing variants is unaffected either way: `new Variant('u', 9)` and the
@@ -173,13 +181,13 @@ Writing variants is unaffected either way: `new Variant('u', 9)` and the
 ## Dicts
 
 ```js
-// 1.x
+// classic
 for (const [key, value] of dict) {
   console.log(key, variantValue(value));
 }
 const name = dict.find(([key]) => key === 'Name')[1][1][0];
 
-// 2.0
+// 0.14.0
 for (const [key, value] of Object.entries(dict)) {
   console.log(key, value);
 }
@@ -188,7 +196,7 @@ const { Name } = dict;
 
 **Write it once, for both**, with `toPlain()`, which converts a whole reply
 recursively — pairs to objects, variants unwrapped — and is the identity on a
-2.0 value:
+0.14.0 value:
 
 ```js
 const { toPlain } = require('dbus-native');
@@ -219,7 +227,7 @@ since 0.11, per connection:
 const bus = dbus.sessionBus({ plainValues: true, returnBigInt: true });
 ```
 
-That is the same code path 2.0 turns on by default — not a simulation of it.
+That is the same code path 0.14.0 turns on by default — not a simulation of it.
 So the migration that actually works is:
 
 1. **Convert reads to `variantValue()` and `toPlain()`** on your current
@@ -234,7 +242,7 @@ So the migration that actually works is:
    ```bash
    npx dbus-native lint src/
    src/net.js:42  DBUS_DEP0002  variant index chain `[1][1][0]`
-       -> variantValue(), or a plain property read after 2.0
+       -> variantValue(), or a plain property read after 0.14.0
    ```
 
    It exits non-zero when there are findings, so it can gate CI while you work
@@ -258,7 +266,7 @@ const { withClassicTypes } = require('dbus-native/compat');
 const bus = withClassicTypes(dbus.sessionBus());
 ```
 
-1.x shapes on a 2.0 connection: variants wrapped, dicts as pairs, `x`/`t` as
+classic shapes on a 0.14.0 connection: variants wrapped, dicts as pairs, `x`/`t` as
 `number`. For code with `result[1][1][0]` in three hundred places and a reason
 to upgrade that is not this.
 
@@ -270,7 +278,7 @@ Four things to know:
 
 - **It is scoped to the connection, not to the reference.** It configures the
   bus you hand it and returns that same bus. There is one parser per socket, so
-  an independent 2.0 view of the same connection is not something that can
+  an independent 0.14.0 view of the same connection is not something that can
   exist. Unrelated code with its own bus is unaffected.
 - **Call it before your first call goes out.** A reply that has already been
   parsed is already the new shape, and nothing can reach back and change it.
@@ -291,7 +299,7 @@ Three smaller breaks, none of which need the tooling above.
 ### Calls now have a deadline
 
 A call waits **25 seconds** for its reply and then rejects with a
-`TimeoutError`. Before 2.0 there was no default: a peer that never answered
+`TimeoutError`. Before 0.14.0 there was no default: a peer that never answered
 left the promise unsettled for the life of the process.
 
 ```js

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@
 // Hand-written and checked in CI against test/types/usage.ts, so they cannot
 // drift from the implementation without the build failing.
 //
-// Note the value shapes here describe the *current* API. The 2.0 type-system
+// Note the value shapes here describe the *current* API. The 0.14.0 type-system
 // change is documented in docs/deprecations.md and RELEASE_PLAN.md; the
 // forward-compatible helpers (variantValue, toPlain, Variant) are typed to
 // accept both shapes so code written against them keeps type-checking.
@@ -45,7 +45,7 @@ export interface SignatureNode {
 
 /**
  * A variant as it is unmarshalled today: the parsed signature, then a
- * one-element array holding the value. Changes in 2.0 -- read it with
+ * one-element array holding the value. Changes in 0.14.0 -- read it with
  * `variantValue()` rather than by index.
  */
 export type ClassicVariant = [SignatureNode[], unknown[]];
@@ -65,7 +65,7 @@ export class Variant<T = unknown> {
 }
 
 /**
- * Read the value out of a variant, in either the current or the 2.0 shape.
+ * Read the value out of a variant, in either the current or the 0.14.0 shape.
  * Returns the argument unchanged if it is already a plain value.
  */
 export function variantValue<T = unknown>(value: unknown): T;
@@ -228,17 +228,17 @@ export interface ConnectionOptions {
   ayBuffer?: boolean | 'view';
   /**
    * Read 64-bit values (`x`, `t`) as native `bigint`, exactly. Default `true`
-   * since 2.0.
+   * since 0.14.0.
    *
-   * Set `false` for the 1.x behaviour: a `number`, which loses precision above
+   * Set `false` for the classic behaviour: a `number`, which loses precision above
    * 2^53. Writing a `bigint` is accepted regardless of this option.
    */
   returnBigInt?: boolean;
   /**
    * Read the plain value shapes: a variant comes back as the value itself
    * rather than `[signatureTree, [value]]`, and a string-keyed dict as a plain
-   * object rather than an array of pairs. Default `true` since 2.0; set
-   * `false` for the 1.x shapes.
+   * object rather than an array of pairs. Default `true` since 0.14.0; set
+   * `false` for the classic shapes.
    *
    * Affects reading only. The marshaller accepts plain objects and `Variant`,
    * so a value read this way can be written straight back out.
@@ -254,7 +254,7 @@ export interface ConnectionOptions {
   /**
    * How a variant (`v`) comes back.
    *
-   * - `'tree'` — `[parsedSignatureTree, [value]]`, what 1.x handed back
+   * - `'tree'` — `[parsedSignatureTree, [value]]`, what classic handed back
    * - `'plain'` — the value, and the signature is gone
    * - `'wrap'` — a {@link Variant}, carrying both
    *
@@ -271,7 +271,7 @@ export interface ConnectionOptions {
   variants?: 'tree' | 'plain' | 'wrap';
   /**
    * @deprecated DBUS_DEP0001 -- removed. 64-bit values are `bigint`; pass
-   * `returnBigInt: false` for the lossy `number` 1.x returned. Passing `true`
+   * `returnBigInt: false` for the lossy `number` classic returned. Passing `true`
    * throws rather than silently handing back a different type. Declared only
    * so the type checker points at the replacement.
    */
@@ -281,7 +281,7 @@ export interface ConnectionOptions {
   /**
    * ms every call on this client waits for its reply. Default `25000`, the
    * figure libdbus, GDBus and sd-bus all use. `0` disables it, restoring the
-   * pre-2.0 behaviour of waiting indefinitely.
+   * pre-0.14.0 behaviour of waiting indefinitely.
    */
   timeout?: number;
   /**

--- a/lib/codegen/emit-types.js
+++ b/lib/codegen/emit-types.js
@@ -106,7 +106,7 @@ function emitTypes(description, options = {}) {
     options.path ? `// path:    ${options.path}` : null,
     `// target:  ${target}${
       target === 'classic'
-        ? ' (plainValues: false, returnBigInt: false -- the 1.x shapes)'
+        ? ' (plainValues: false, returnBigInt: false -- the classic shapes)'
         : ''
     }`,
     '',

--- a/lib/compat.d.ts
+++ b/lib/compat.d.ts
@@ -27,7 +27,7 @@ export interface ClassicDBusError extends Array<unknown> {
 export function toClassicError(err: unknown): ClassicDBusError | unknown;
 
 /**
- * Read 1.x value shapes on a 2.0 connection: a variant as
+ * Read classic value shapes on a 0.14.0 connection: a variant as
  * `[signatureTree, [value]]`, a string-keyed dict as an array of pairs, and
  * `x`/`t` as a lossy `number`.
  *

--- a/lib/compat.js
+++ b/lib/compat.js
@@ -47,14 +47,14 @@ function toClassicError(err) {
   return body;
 }
 
-// What 1.x handed back, spelled as options. `returnBigInt: false` is the lossy
-// path on purpose: a `t` above 2^53 came back rounded in 1.x, and code that
+// What classic handed back, spelled as options. `returnBigInt: false` is the lossy
+// path on purpose: a `t` above 2^53 came back rounded in classic, and code that
 // depends on getting a Number depends on that too.
 //
 // `variants: 'tree'` is stated rather than left to follow `plainValues`,
 // because a caller who opted into `variants: 'wrap'` would otherwise keep the
 // Variants -- and this function's whole promise is that nothing arrives in a
-// shape 1.x did not produce.
+// shape classic did not produce.
 const CLASSIC_TYPES = {
   plainValues: false,
   returnBigInt: false,
@@ -62,7 +62,7 @@ const CLASSIC_TYPES = {
 };
 
 /**
- * Read 1.x value shapes on a 2.0 connection.
+ * Read classic value shapes on a 0.14.0 connection.
  *
  *     const bus = withClassicTypes(dbus.sessionBus());
  *
@@ -76,7 +76,7 @@ const CLASSIC_TYPES = {
  * and the shape is decided as a message is read, so a second view with
  * different shapes is not a thing that can exist. The scope is therefore the
  * connection: unrelated code with its own bus is unaffected, which is the
- * property that matters, but two references to *this* bus both see 1.x shapes.
+ * property that matters, but two references to *this* bus both see classic shapes.
  *
  * Call it before the first call goes out. A reply already parsed is already the
  * wrong shape, and this cannot reach back and change it.

--- a/lib/dbus-buffer.js
+++ b/lib/dbus-buffer.js
@@ -10,7 +10,7 @@ const DEFAULT_OPTIONS = {
 
 // How a `v` comes back.
 //
-//   'tree'  [parsedSignatureTree, [value]] -- what 1.x hands back
+//   'tree'  [parsedSignatureTree, [value]] -- what classic hands back
 //   'plain' the value, and the signature is gone
 //   'wrap'  a Variant, carrying both
 //
@@ -52,7 +52,7 @@ function DBusBuffer(buffer, startPos, options, endianness) {
   // property the caller never set.
   this.ayBuffer =
     this.options.ayBuffer === undefined ? true : this.options.ayBuffer;
-  // The 2.0 value shapes, available now so code can be migrated on a released
+  // The 0.14.0 value shapes, available now so code can be migrated on a released
   // version rather than on a flag day. See RELEASE_PLAN.md.
   //
   // `plainValues` governs dicts; `variants` governs variants and defaults to
@@ -303,7 +303,7 @@ DBusBuffer.prototype.readSimpleType = function readSimpleType(t) {
     // able to reject one, a malformed path is not a memory-safety problem --
     // readString already bounds-checks -- and refusing one would break
     // interop with a sloppy peer over a name we can pass through harmlessly.
-    // 64-bit, exactly, unless the caller has asked for the 1.x lossiness back.
+    // 64-bit, exactly, unless the caller has asked for the classic lossiness back.
     case 'x':
       //signed
       if (this.returnBigInt) return this.readBigInt(false);

--- a/lib/deprecate.js
+++ b/lib/deprecate.js
@@ -6,7 +6,7 @@
 // their own codebase by running their test suite.
 //
 // Nothing calls this at the moment: both runtime deprecations reached the end
-// of their lives in 2.0, when `ReturnLongjs` (DBUS_DEP0001) and `dbus2js`
+// of their lives in 0.14.0, when `ReturnLongjs` (DBUS_DEP0001) and `dbus2js`
 // (DBUS_DEP0005) were removed. It stays because docs/deprecations.md documents
 // this format, these semantics and that workflow as the project's policy, and
 // the next deprecation should implement that policy rather than reinvent it.

--- a/lib/lint/deprecated-value-shapes.js
+++ b/lib/lint/deprecated-value-shapes.js
@@ -1,4 +1,4 @@
-// jscodeshift transform: find reads of the value shapes that change in 0.14.0.
+// jscodeshift transform: find reads of the value shapes that changed in 0.14.0.
 //
 // This is a *linter*, not a codemod -- it never modifies a file. Reading a
 // variant is `result[1][1][0]`, an index chain a codemod cannot safely rewrite

--- a/lib/lint/deprecated-value-shapes.js
+++ b/lib/lint/deprecated-value-shapes.js
@@ -1,4 +1,4 @@
-// jscodeshift transform: find reads of the value shapes that change in 2.0.
+// jscodeshift transform: find reads of the value shapes that change in 0.14.0.
 //
 // This is a *linter*, not a codemod -- it never modifies a file. Reading a
 // variant is `result[1][1][0]`, an index chain a codemod cannot safely rewrite
@@ -93,7 +93,7 @@ module.exports = function transform(fileInfo, api, options) {
         node,
         'DBUS_DEP0002',
         `variant index chain \`${indexChain(node)}\``,
-        'variantValue(), or a plain property read after 2.0',
+        'variantValue(), or a plain property read after 0.14.0',
         'high'
       );
     });
@@ -134,7 +134,7 @@ module.exports = function transform(fileInfo, api, options) {
         path.node,
         'DBUS_DEP0003',
         'iterating `[key, value]` pairs',
-        'toPlain(), or read it as an object after 2.0',
+        'toPlain(), or read it as an object after 0.14.0',
         'possible'
       );
     });
@@ -179,7 +179,7 @@ module.exports = function transform(fileInfo, api, options) {
         path.node,
         'DBUS_DEP0001',
         '`ReturnLongjs` option',
-        '64-bit values become native BigInt in 2.0; plan for the TypeError',
+        '64-bit values become native BigInt in 0.14.0; plan for the TypeError',
         'high'
       );
     });

--- a/lib/marshall.js
+++ b/lib/marshall.js
@@ -184,11 +184,11 @@ function numericKey(type, key) {
  * `['a', 'b']`, an ordinary `as`, which is the whole difficulty. The test is
  * therefore exact: a signature is a string, and a parse tree is an array of
  * nodes carrying a `type`. Everything else infers, which is what lets a value
- * read under the 2.0 shapes be written straight back out.
+ * read under the 0.14.0 shapes be written straight back out.
  *
  * The one case that stays ambiguous is a two-element array of strings, read as
  * `[signature, value]`. Write `new Variant('as', ['a', 'b'])` to mean the
- * array. This predates the 2.0 shapes and is the reason `Variant` is the
+ * array. This predates the 0.14.0 shapes and is the reason `Variant` is the
  * spelling to prefer.
  */
 function isClassicVariant(data) {
@@ -244,7 +244,7 @@ function write(writer, ele, data) {
         }
       } else {
         // A plain value, which is what `variants: 'plain'` -- the default
-        // since 2.0 -- hands back. Inferred exactly as a value inside `a{sv}`
+        // since 0.14.0 -- hands back. Inferred exactly as a value inside `a{sv}`
         // is, so a variant read off the wire can be written straight back.
         signature = inferSignature(data);
         value = data;

--- a/lib/values.js
+++ b/lib/values.js
@@ -1,8 +1,8 @@
 // Helpers for reading and writing d-bus values in a way that survives the
-// type-system change planned for 2.0.
+// type-system change planned for 0.14.0.
 //
 // Today a variant unmarshals as `[parsedSignatureTree, [value]]` and a dict as
-// an array of `[key, value]` pairs. In 2.0 they become the value itself and a
+// an array of `[key, value]` pairs. In 0.14.0 they become the value itself and a
 // plain object. Code written against `variantValue()` and `toPlain()` behaves
 // identically before and after, so it can be migrated now, on a released
 // version, with no flag day.
@@ -88,7 +88,7 @@ function looksLikeClassicVariant(value) {
  * Read the value out of a variant, whatever shape it is in.
  *
  * classic: [tree, [value]] -> value
- * 2.0:     value           -> value  (identity)
+ * 0.14.0:     value           -> value  (identity)
  */
 function variantValue(value) {
   if (value instanceof Variant) return value.value;
@@ -126,7 +126,7 @@ function dumpSignature(nodes) {
  * variants are unwrapped.
  *
  * classic: [['Udi', [tree, ['/sys/...']]]] -> { Udi: '/sys/...' }
- * 2.0:     { Udi: '/sys/...' }             -> unchanged
+ * 0.14.0:     { Udi: '/sys/...' }             -> unchanged
  *
  * Arrays that are not tagged as dicts are left as arrays, so `a(ss)` is not
  * mistaken for `a{ss}`.
@@ -145,7 +145,7 @@ function toPlain(value) {
     return value.map(toPlain);
   }
   // Recursed into rather than returned as-is: this is what a dict already
-  // looks like when it is read in the 2.0 shape, and the promise of this
+  // looks like when it is read in the 0.14.0 shape, and the promise of this
   // helper is that it is the identity there. Returning early would leave any
   // variant nested inside it unconverted -- which is exactly the half-migrated
   // state a mixed read shape produces.

--- a/lib/values.js
+++ b/lib/values.js
@@ -1,5 +1,5 @@
 // Helpers for reading and writing d-bus values in a way that survives the
-// type-system change planned for 0.14.0.
+// type-system change that landed in 0.14.0.
 //
 // Today a variant unmarshals as `[parsedSignatureTree, [value]]` and a dict as
 // an array of `[key, value]` pairs. In 0.14.0 they become the value itself and a

--- a/test/bigint.js
+++ b/test/bigint.js
@@ -1,4 +1,4 @@
-// BigInt for the 64-bit types -- the default since 2.0.
+// BigInt for the 64-bit types -- the default since 0.14.0.
 //
 // `x` and `t` cover the full signed/unsigned 64-bit range, which a JS `number`
 // cannot: everything above 2^53 used to come back approximated. These tests
@@ -211,7 +211,7 @@ describe('BigInt: diagnostics survive a bigint body', () => {
 });
 
 // The 64-bit paths have used `bigint` internally since 0.11, and Long.js
-// stopped being a dependency in 2.0. A Long is still *accepted* on input --
+// stopped being a dependency in 0.14.0. A Long is still *accepted* on input --
 // the check is structural, on {low, high, unsigned}, so it costs nothing --
 // which is what these cover. `long` is a devDependency now, only so the tests
 // can build the objects they are asserting about.

--- a/test/cli-shape.js
+++ b/test/cli-shape.js
@@ -3,7 +3,7 @@
 // `describe()` prints a variant as `variant u 501`, and it needs the signature
 // to do that. `variants: 'wrap'` is how it asks. Before that option existed the
 // only way to ask was `plainValues: false`, which got the signature by reading
-// the parser's internal tree -- so the CLI was pinned away from the 2.0 shapes
+// the parser's internal tree -- so the CLI was pinned away from the 0.14.0 shapes
 // to keep a feature it should not have had to trade for them.
 //
 // These tests are here to fail if the pin is ever dropped.

--- a/test/codegen.js
+++ b/test/codegen.js
@@ -252,7 +252,7 @@ describe('codegen: the --target flag', () => {
     assert.strictEqual(generate('--target', 'next'), generate());
   });
 
-  it("emits the 1.x shapes for 'classic'", () => {
+  it("emits the classic shapes for 'classic'", () => {
     const out = generate('--target', 'classic');
     assert.match(out, /target: {2}classic/);
     assert.match(out, /\[Array<\[string, ClassicVariant\]>, number\]/);

--- a/test/deprecations.js
+++ b/test/deprecations.js
@@ -40,7 +40,7 @@ describe('deprecate()', () => {
 });
 
 // DBUS_DEP0001 was the one deprecation that reached the end of its life. It
-// warned from 0.6 and the option it named was removed in 2.0, so the test that
+// warned from 0.6 and the option it named was removed in 0.14.0, so the test that
 // checked the warning is now a test that checks the error -- see
 // test/bigint.js, where it sits with the rest of the 64-bit behaviour.
 //

--- a/test/integration/compat-classic-types.js
+++ b/test/integration/compat-classic-types.js
@@ -1,10 +1,13 @@
 // `withClassicTypes` from dbus-native/compat, exercised against a real daemon.
 //
-// The interesting run is `npm run test:integration:2.0`, where the connection
-// would otherwise read the 2.0 shapes: that is the only configuration in which
-// this helper does anything at all. In the default run it is a no-op and these
-// tests are still worth having, because they say what the shapes are either
-// way.
+// The interesting run is the default one, where the connection would otherwise
+// read the plain shapes 0.14.0 made standard -- that is where this helper has
+// anything to undo. Under `npm run test:integration:classic` the connection is
+// already reading classic shapes, so it is a no-op, and these tests are still
+// worth having there because they say what the shapes are either way.
+//
+// That is the opposite way round from how it read before 0.14.0, when classic
+// was the default and the plain shapes were the opt-in.
 
 const { describe, it, before, after } = require('node:test');
 const assert = require('assert');
@@ -95,7 +98,7 @@ describe(
     it('hands back a variant as [signatureTree, [value]]', async () => {
       const value = await get(clientBus, 'Greeting');
       assert.ok(Array.isArray(value), 'expected the classic wrapper');
-      // The index chain 1.x code is full of, working verbatim.
+      // The index chain classic code is full of, working verbatim.
       assert.strictEqual(value[1][0], 'hello');
       // And the real signature, not one inferred from the value -- which is why
       // this asks the parser rather than converting after the fact.
@@ -113,7 +116,7 @@ describe(
       assert.strictEqual(greeting[1][1][0], 'hello');
     });
 
-    it("hands back 't' as a lossy number, as 1.x did", async () => {
+    it("hands back 't' as a lossy number, as it did before 0.14.0", async () => {
       const value = await clientBus.invoke({
         destination: SERVICE,
         path: OBJECT_PATH,

--- a/test/integration/future-shape.js
+++ b/test/integration/future-shape.js
@@ -1,4 +1,4 @@
-// The 2.0 read shape, on a real daemon, with `plainValues` actually on.
+// The 0.14.0 read shape, on a real daemon, with `plainValues` actually on.
 //
 // A variant unmarshals as the value itself and a string-keyed dict as a plain
 // object. The library reads its *own* messages through the same parser, so
@@ -32,7 +32,7 @@ const ifaceDesc = {
 };
 
 describe(
-  'integration: the 2.0 read shape',
+  'integration: the 0.14.0 read shape',
   { timeout: 10000, skip: NO_BUS },
   () => {
     let serviceBus, clientBus, impl, iface;

--- a/test/integration/timeouts.js
+++ b/test/integration/timeouts.js
@@ -132,7 +132,7 @@ describe(
 
     // The default is 25 seconds, which is far too long to wait for here. What
     // can be checked against a real daemon is that a call made with no options
-    // at all now *has* a deadline -- before 2.0 it had none, and this would
+    // at all now *has* a deadline -- before 0.14.0 it had none, and this would
     // have stayed pending until the process ended.
     it('gives a call with no options a deadline of its own', async () => {
       const pending = clientBus.invoke(call('NeverReplies'));

--- a/test/js-types.js
+++ b/test/js-types.js
@@ -1,6 +1,6 @@
 // Writing a plain JavaScript object where a dict is expected.
 //
-// Since 2.0 the read side returns an object too, so a round trip is an
+// Since 0.14.0 the read side returns an object too, so a round trip is an
 // identity. `toPlain()` stays in the helper below because it is the identity
 // on the current shape and still flattens the old one, which is what makes
 // these assertions readable either way. The skipped test this file replaces

--- a/test/lint.js
+++ b/test/lint.js
@@ -1,7 +1,7 @@
 // Fixtures for the deprecated-value-shapes linter.
 //
 // The rules that matter most here are the negative ones. A linter that flags
-// `for (const [k, v] of Object.entries(o))` -- ordinary JavaScript that 2.0
+// `for (const [k, v] of Object.entries(o))` -- ordinary JavaScript that 0.14.0
 // does not touch -- gets switched off, and then it protects nobody.
 
 const { describe, it } = require('node:test');

--- a/test/plain-values.js
+++ b/test/plain-values.js
@@ -1,4 +1,4 @@
-// The `plainValues` option: the 2.0 read shapes, and the default since 2.0.
+// The `plainValues` option: the 0.14.0 read shapes, and the default since 0.14.0.
 //
 // A variant reads as the value itself, and a string-keyed dict as a plain
 // object. Writing is unaffected -- the marshaller has taken plain objects and

--- a/test/unmarshall-basic.js
+++ b/test/unmarshall-basic.js
@@ -194,7 +194,7 @@ describe('marshall/unmarshall', () => {
       ['u', [1048576]],
       ['u', [0]],
       //['u', [-1], false]  // TODO validate input, should fail
-      // 64-bit values come back as BigInt since 2.0. Every spelling that was
+      // 64-bit values come back as BigInt since 0.14.0. Every spelling that was
       // accepted on the way in still is -- a number, a decimal or hex string,
       // a Long, a Long-shaped plain object -- so only the result changed.
       ['x', [9007199254740991], false, [9007199254740991n]],

--- a/test/utils/shape.js
+++ b/test/utils/shape.js
@@ -7,7 +7,7 @@
 //               object, and 64-bit is a bigint (the default when unset)
 //   wrap        the same, but a variant is a Variant -- the shape a caller
 //               opts into when it needs the type back (BIG_FUTURE_PLANS 2.1)
-//   classic     what 1.x handed back: a variant is [tree, [value]], a dict is
+//   classic     what classic handed back: a variant is [tree, [value]], a dict is
 //               pairs, and 64-bit is a lossy number. This is what
 //               `dbus-native/compat` configures, so it has to keep working.
 //

--- a/test/values.js
+++ b/test/values.js
@@ -1,5 +1,5 @@
-// Forward-compatible value helpers: the same call must work on the 1.x shapes
-// and on the 2.0 shapes, so each case is asserted against both.
+// Forward-compatible value helpers: the same call must work on the classic shapes
+// and on the 0.14.0 shapes, so each case is asserted against both.
 
 const { describe, it } = require('node:test');
 const assert = require('assert');
@@ -9,7 +9,7 @@ const unmarshall = require('../lib/unmarshall');
 const { Variant, variantValue, variantSignature, toPlain } = dbus;
 
 // The classic shapes are asked for explicitly. They stopped being the default
-// in 2.0, and a helper that just took the default would quietly stop reading
+// in 0.14.0, and a helper that just took the default would quietly stop reading
 // them -- turning most of the conversions below into identities that assert
 // nothing.
 const CLASSIC = { plainValues: false };
@@ -23,7 +23,7 @@ describe('variantValue', () => {
     assert.strictEqual(variantValue(value), 'hello');
   });
 
-  it('is the identity on an already-plain value (the 2.0 shape)', () => {
+  it('is the identity on an already-plain value (the 0.14.0 shape)', () => {
     assert.strictEqual(variantValue('hello'), 'hello');
     assert.strictEqual(variantValue(42), 42);
     assert.deepStrictEqual(variantValue([1, 2, 3]), [1, 2, 3]);
@@ -63,7 +63,7 @@ describe('variantSignature', () => {
     );
   });
 
-  it("reports it under variants: 'wrap' too, which is the 2.0 way", () => {
+  it("reports it under variants: 'wrap' too, which is the 0.14.0 way", () => {
     const wrap = { variants: 'wrap' };
     assert.strictEqual(
       variantSignature(roundTrip('v', [['s', 'x']], wrap)[0]),
@@ -132,7 +132,7 @@ describe('toPlain', () => {
     ]);
   });
 
-  it('is the identity on the 2.0 shape', () => {
+  it('is the identity on the 0.14.0 shape', () => {
     assert.deepStrictEqual(toPlain({ a: 1, b: 'two' }), { a: 1, b: 'two' });
     assert.deepStrictEqual(toPlain([1, 2, 3]), [1, 2, 3]);
     assert.strictEqual(toPlain('plain'), 'plain');


### PR DESCRIPTION
## The problem

`RELEASE_PLAN.md` sequenced four majors — **1.0** errors, **2.0** the type system, **3.0** lifecycle, **4.0** ESM. All of it shipped. None of it shipped under those names:

| planned | shipped as |
| --- | --- |
| 1.0 — errors are `Error`s | **0.7.0** |
| 2.0 — the type system | **0.14.0** |
| 3.0 — lifecycle and cancellation | **0.13.0** |
| 4.0 — ESM | dropped ([BIG_FUTURE_PLANS §4.1](../blob/master/BIG_FUTURE_PLANS.md)) |

The prose never caught up. So `README.md` tells a user running 0.14.0:

> **`dbus2js` was removed in 2.0**

which reads as *"not yet, then"* — for something removed in the version they are running. Same for every "the 2.0 value shapes" heading, "Before 2.0 they were a `number`", and "Since **2.0** a variant unmarshals to the value itself".

The repo had already solved this once, in [`docs/migrating-to-0.7.md`](../blob/master/docs/migrating-to-0.7.md): name the real version, then explain what the plan called it. This applies that everywhere else.

## What changed

**111 substitutions across 27 files.** `2.0` → `0.14.0`, and `1.x` → `classic` — the word the codebase already uses for those shapes in `withClassicTypes`, `--target classic` and `DBUS_TEST_SHAPE=classic`. There was never a 1.x either.

## What was deliberately left alone

A blind substitution here corrupts things, so:

- **`docs/migrating-to-2.0.md` keeps its filename.** The published 0.14.0 changelog and GitHub release notes link to it, and neither can be edited now. It gets a note at the top explaining the mismatch.
- **The introspection DTD** — `http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd` and `-//freedesktop//DTD D-BUS Object Introspection 1.0//EN`. Six occurrences, all load-bearing.
- **`:1.0` in test fixtures** — that is a D-Bus unique connection name, not a version.
- **`RELEASE_PLAN.md`'s own table**, which now carries a `shipped as` column and a note that none of them shipped under the planned names. The rest of that document argues in the planned names, so rewriting them would make it incoherent.

## Two things the sweep turned up

**A dead script reference, and a comment that was backwards.** `test/integration/compat-classic-types.js` pointed at `npm run test:integration:2.0`, renamed some releases ago — and described the run the wrong way round. Since the flip it is the **default** run where `withClassicTypes` has anything to undo; under `test:integration:classic` the connection already reads classic shapes, so it is a no-op. The comment claimed the opposite.

**ROADMAP §0 still listed #263 as an open recommendation.** It now records the decision, what followed from it, and that the Homebridge conversation is the one item still outstanding.

## Verification

- **934 unit tests** pass
- **e2e against a real `dbus-daemon` 1.14.10**: 259 tests in each of the six configurations — default, broker, wrap, wrap:broker, classic, classic:broker — **1554 total, 0 failures**
- Every `npm run` reference in the docs names a script that exists in `package.json` (11 referenced, all present)
- Every relative link and every in-repo anchor across all 13 markdown files resolves
- eslint and prettier clean