### PR TITLE
fix: a message that cannot be written settles its call once

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -319,7 +319,18 @@ function bus(conn, opts) {
       // deadline would report a TimeoutError for a message that did exactly
       // what it was told.
       if (msg.flags & constants.flags.noReplyExpected) {
-        self.connection.message(msg);
+        try {
+          self.connection.message(msg);
+        } catch (err) {
+          // Nothing was sent, so the caller needs to hear about it here --
+          // there is no pending call for it to surface through later.
+          if (traced) {
+            context.error = err;
+            channels.call.error.publish(context);
+            channels.call.end.publish(context);
+          }
+          return cb(err);
+        }
         if (traced) channels.call.end.publish(context);
         return cb(null);
       }
@@ -373,7 +384,18 @@ function bus(conn, opts) {
         signal.addEventListener('abort', onAbort, { once: true });
       }
 
-      self.connection.message(msg);
+      // Marshalling happens inside message(), so a message this connection
+      // cannot write -- a malformed object path, a body that does not match
+      // its signature -- throws here. It used to throw straight out of
+      // invoke() *and* leave the call registered, so the caller got the
+      // exception now and a TimeoutError 25 seconds later for a message that
+      // never reached the wire. Settle it once, the same way as any other
+      // failure.
+      try {
+        self.connection.message(msg);
+      } catch (err) {
+        settle(err);
+      }
     });
   };
 

--- a/test/invoke-send-failure.js
+++ b/test/invoke-send-failure.js
@@ -1,0 +1,108 @@
+// A message the connection cannot write.
+//
+// Marshalling happens inside `connection.message()`, so a malformed object
+// path or a body that does not match its signature fails at the send rather
+// than on the wire. That used to throw out of `invoke()` *and* leave the call
+// registered, so a caller got the exception immediately and a TimeoutError 25
+// seconds later for a message that never left the process.
+
+const { describe, it } = require('node:test');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const MessageBus = require('../lib/bus');
+const constants = require('../lib/constants');
+
+/** A connection whose write always fails, the way marshalling does. */
+function unsendable() {
+  const conn = new EventEmitter();
+  conn.attempts = 0;
+  conn.message = () => {
+    conn.attempts++;
+    throw new Error('Data: bad/path is not a valid object path');
+  };
+  return conn;
+}
+
+const call = {
+  destination: 'com.example.Service',
+  path: '/com/example/Obj',
+  interface: 'com.example.Iface',
+  member: 'M'
+};
+
+describe('a message that cannot be written', () => {
+  it('reports through the callback rather than throwing', () => {
+    const bus = new MessageBus(unsendable(), { direct: true });
+    let err;
+    assert.doesNotThrow(() => {
+      bus.invoke({ ...call }, e => {
+        err = e;
+      });
+    });
+    assert.match(err.message, /not a valid object path/);
+  });
+
+  it('reports exactly once', () => {
+    const bus = new MessageBus(unsendable(), { direct: true });
+    let calls = 0;
+    bus.invoke({ ...call }, () => calls++);
+    assert.strictEqual(calls, 1);
+  });
+
+  it('leaves nothing pending', () => {
+    const bus = new MessageBus(unsendable(), { direct: true });
+    bus.invoke({ ...call }, () => {});
+    assert.deepStrictEqual(Object.keys(bus.cookies), []);
+  });
+
+  it('rejects the promise form', async () => {
+    const bus = new MessageBus(unsendable(), { direct: true });
+    await assert.rejects(() => bus.invoke({ ...call }), {
+      message: /not a valid object path/
+    });
+  });
+
+  it('does not retry the write', () => {
+    const conn = unsendable();
+    const bus = new MessageBus(conn, { direct: true });
+    bus.invoke({ ...call }, () => {});
+    assert.strictEqual(conn.attempts, 1);
+  });
+
+  // NO_REPLY_EXPECTED takes a different branch: it settles as soon as the
+  // message is written and never registers a pending call, so there is no
+  // later failure for the error to surface through.
+  it('reports a no-reply message that could not be sent', () => {
+    const bus = new MessageBus(unsendable(), { direct: true });
+    let err;
+    assert.doesNotThrow(() => {
+      bus.invoke({ ...call, flags: constants.flags.noReplyExpected }, e => {
+        err = e;
+      });
+    });
+    assert.match(err.message, /not a valid object path/);
+    assert.deepStrictEqual(Object.keys(bus.cookies), []);
+  });
+
+  it('leaves the bus usable for a message that is fine', () => {
+    const conn = new EventEmitter();
+    const sent = [];
+    let failNext = true;
+    conn.message = msg => {
+      if (failNext) {
+        failNext = false;
+        throw new Error('Data: bad/path is not a valid object path');
+      }
+      sent.push(msg);
+    };
+    const bus = new MessageBus(conn, { direct: true });
+    bus.invoke({ ...call }, () => {});
+    bus.invoke({ ...call }, () => {});
+    assert.strictEqual(sent.length, 1, 'the second call went out');
+    assert.strictEqual(
+      Object.keys(bus.cookies).length,
+      1,
+      'and is waiting for its reply'
+    );
+  });
+});


### PR DESCRIPTION
## The bug

Marshalling happens inside `connection.message()`, so a message this connection cannot write — a malformed object path, a body that does not match its declared signature — fails at the send rather than on the wire.

That threw straight out of `invoke()` **and left the call registered**. Against a real `dbus-daemon`:

```
[invoke THREW] Error: Data: fi/wi/wpa_supplicant1/Interfaces/1 is not a valid object path
[callback] TimeoutError: No reply within 3000ms to org.freedesktop.DBus.Introspectable...
callback fired? true
```

Two reports for one failure: an exception now, and a `TimeoutError` 25 seconds later for a message that never left the process. The pending entry sat in `bus.cookies` for that whole time.

After:

```
[callback] Error: Data: fi/wi/wpa_supplicant1/Interfaces/1 is not a valid object path
invoke() returned without throwing
callback fired? true
```

One report, immediately, through the channel the caller is already using — so the promise form rejects rather than throwing synchronously out of a function that returns a promise.

## The fix

The send goes through `settle()`, like every other failure, which clears the timer and removes the cookie. `NO_REPLY_EXPECTED` takes a different branch — it never registers a pending call, so there is no later failure for the error to surface through — and reports through the callback directly.

## Tests

`test/invoke-send-failure.js`, 7 cases, **all 7 fail without the change**: reports through the callback rather than throwing, reports exactly once, leaves nothing pending, rejects the promise form, does not retry the write, handles the `NO_REPLY_EXPECTED` branch, and leaves the bus usable for the next message.

- 941 unit tests pass
- 259 e2e tests pass against a real `dbus-daemon`

## Provenance

Found while auditing [#115](https://github.com/sidorares/dbus-native/issues/115) ("Callback never received", 2016). Their snippet contains an object path with no leading slash — `'fi/wi/wpa_supplicant1/Interfaces/1'` — which is exactly this failure. In 2016 it hung silently; until this PR it reported twice and confusingly; now it says what is wrong, once, at the call.