### PR TITLE
fix: defineInterface refuses positional in/out rather than indexing them

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -319,7 +319,18 @@ function bus(conn, opts) {
       // deadline would report a TimeoutError for a message that did exactly
       // what it was told.
       if (msg.flags & constants.flags.noReplyExpected) {
-        self.connection.message(msg);
+        try {
+          self.connection.message(msg);
+        } catch (err) {
+          // Nothing was sent, so the caller needs to hear about it here --
+          // there is no pending call for it to surface through later.
+          if (traced) {
+            context.error = err;
+            channels.call.error.publish(context);
+            channels.call.end.publish(context);
+          }
+          return cb(err);
+        }
         if (traced) channels.call.end.publish(context);
         return cb(null);
       }
@@ -373,7 +384,18 @@ function bus(conn, opts) {
         signal.addEventListener('abort', onAbort, { once: true });
       }
 
-      self.connection.message(msg);
+      // Marshalling happens inside message(), so a message this connection
+      // cannot write -- a malformed object path, a body that does not match
+      // its signature -- throws here. It used to throw straight out of
+      // invoke() *and* leave the call registered, so the caller got the
+      // exception now and a TimeoutError 25 seconds later for a message that
+      // never reached the wire. Settle it once, the same way as any other
+      // failure.
+      try {
+        self.connection.message(msg);
+      } catch (err) {
+        settle(err);
+      }
     });
   };
 

--- a/lib/define-interface.js
+++ b/lib/define-interface.js
@@ -48,8 +48,32 @@ function checkKeys(what, name, given, allowed) {
   }
 }
 
+// An array or a bare signature string has to be refused rather than read:
+// `Object.keys(['s', 'u'])` is `['0', '1']`, so both produce a correct wire
+// signature with the arguments named "0" and "1" -- and a handler written to
+// take them positionally silently receives `{ 0: … }` instead. Nothing fails
+// until a call is made, and then it fails somewhere else. This is the class of
+// mistake defineInterface() exists to catch, so it belongs here.
+function rejectPositional(what, member, field, args) {
+  const types = Array.isArray(args) ? args : [...args];
+  const suggestion = types
+    .map((type, i) => `arg${i + 1}: '${type}'`)
+    .join(', ');
+  throw new Error(
+    `${what} "${member}" declares ${field} as ${
+      Array.isArray(args) ? 'an array' : 'a signature string'
+    }. It takes an object of named arguments, so a handler can read them by ` +
+      `name: { ${suggestion} }. Handlers always receive one object of those ` +
+      'names, never positional arguments. For the positional form, use ' +
+      'exportInterface() with a classic descriptor.'
+  );
+}
+
 /** `{ name: 's', count: 'u' }` -> `['su', ['name', 'count']]`. */
-function splitArgs(what, member, args) {
+function splitArgs(what, member, args, field = 'its arguments') {
+  if (Array.isArray(args) || typeof args === 'string') {
+    rejectPositional(what, member, field, args);
+  }
   const names = Object.keys(args || {});
   let signature = '';
   for (const name of names) {
@@ -74,8 +98,8 @@ function defineMethod(name, spec, methods, impl) {
     throw new Error(`Method "${name}" needs a handler function`);
   }
 
-  const [inSignature, inNames] = splitArgs('Method', name, spec.in);
-  const [outSignature, outNames] = splitArgs('Method', name, spec.out);
+  const [inSignature, inNames] = splitArgs('Method', name, spec.in, '`in`');
+  const [outSignature, outNames] = splitArgs('Method', name, spec.out, '`out`');
   methods[name] = [inSignature, outSignature, inNames, outNames];
 
   const handler = spec.handler;
@@ -169,7 +193,7 @@ function defineSignal(name, spec, signals) {
     throw new Error(`Signal "${name}" must be an object`);
   }
   checkKeys('Signal', name, spec, SIGNAL_KEYS);
-  const [signature, names] = splitArgs('Signal', name, spec.args);
+  const [signature, names] = splitArgs('Signal', name, spec.args, '`args`');
   signals[name] = [signature, ...names];
 }
 

--- a/test/define-interface.js
+++ b/test/define-interface.js
@@ -244,6 +244,70 @@ describe('defineInterface: what it refuses', () => {
     assert.throws(() => defineInterface(), /needs a definition object/);
   });
 
+  // The trap this closes: `Object.keys(['s', 'u'])` is `['0', '1']`, so an
+  // array produces the right wire signature with the arguments named "0" and
+  // "1", and a handler written to take them positionally receives `{ 0: … }`.
+  // Nothing failed until a call was made, and then it failed somewhere else.
+  describe('the positional forms, which used to be read as indexed names', () => {
+    const method = (io, value) => ({
+      name: 'com.example.I',
+      methods: {
+        Hello: {
+          in: { a: 's' },
+          out: { b: 's' },
+          handler: () => 'x',
+          [io]: value
+        }
+      }
+    });
+
+    it('refuses an array for `in`', () => {
+      bad(method('in', ['s', 'u']), /declares `in` as an array/);
+    });
+
+    it('refuses an array for `out`', () => {
+      bad(method('out', ['s']), /declares `out` as an array/);
+    });
+
+    it('refuses a bare signature string', () => {
+      bad(method('in', 'su'), /declares `in` as a signature string/);
+    });
+
+    it('refuses an array of signal args', () => {
+      bad(
+        { name: 'com.example.I', signals: { Pinged: { args: ['s'] } } },
+        /declares `args` as an array/
+      );
+    });
+
+    it('suggests the object form, with the types it was given', () => {
+      assert.throws(
+        () => defineInterface(method('in', ['s', 'u'])),
+        /\{ arg1: 's', arg2: 'u' \}/
+      );
+    });
+
+    it('says handlers never receive positional arguments', () => {
+      assert.throws(
+        () => defineInterface(method('in', ['s'])),
+        /never positional arguments/
+      );
+    });
+
+    it('still accepts the object form, empty or omitted', () => {
+      assert.ok(
+        defineInterface({
+          name: 'com.example.I',
+          methods: {
+            A: { in: { t: 's' }, out: { r: 's' }, handler: ({ t }) => t },
+            B: { in: {}, out: {}, handler: () => {} },
+            C: { handler: () => {} }
+          }
+        })
+      );
+    });
+  });
+
   it('needs a handler on every method', () => {
     bad(
       { name: 'com.example.I', methods: { Hello: { in: { a: 's' } } } },

--- a/test/invoke-send-failure.js
+++ b/test/invoke-send-failure.js
@@ -1,0 +1,108 @@
+// A message the connection cannot write.
+//
+// Marshalling happens inside `connection.message()`, so a malformed object
+// path or a body that does not match its signature fails at the send rather
+// than on the wire. That used to throw out of `invoke()` *and* leave the call
+// registered, so a caller got the exception immediately and a TimeoutError 25
+// seconds later for a message that never left the process.
+
+const { describe, it } = require('node:test');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const MessageBus = require('../lib/bus');
+const constants = require('../lib/constants');
+
+/** A connection whose write always fails, the way marshalling does. */
+function unsendable() {
+  const conn = new EventEmitter();
+  conn.attempts = 0;
+  conn.message = () => {
+    conn.attempts++;
+    throw new Error('Data: bad/path is not a valid object path');
+  };
+  return conn;
+}
+
+const call = {
+  destination: 'com.example.Service',
+  path: '/com/example/Obj',
+  interface: 'com.example.Iface',
+  member: 'M'
+};
+
+describe('a message that cannot be written', () => {
+  it('reports through the callback rather than throwing', () => {
+    const bus = new MessageBus(unsendable(), { direct: true });
+    let err;
+    assert.doesNotThrow(() => {
+      bus.invoke({ ...call }, e => {
+        err = e;
+      });
+    });
+    assert.match(err.message, /not a valid object path/);
+  });
+
+  it('reports exactly once', () => {
+    const bus = new MessageBus(unsendable(), { direct: true });
+    let calls = 0;
+    bus.invoke({ ...call }, () => calls++);
+    assert.strictEqual(calls, 1);
+  });
+
+  it('leaves nothing pending', () => {
+    const bus = new MessageBus(unsendable(), { direct: true });
+    bus.invoke({ ...call }, () => {});
+    assert.deepStrictEqual(Object.keys(bus.cookies), []);
+  });
+
+  it('rejects the promise form', async () => {
+    const bus = new MessageBus(unsendable(), { direct: true });
+    await assert.rejects(() => bus.invoke({ ...call }), {
+      message: /not a valid object path/
+    });
+  });
+
+  it('does not retry the write', () => {
+    const conn = unsendable();
+    const bus = new MessageBus(conn, { direct: true });
+    bus.invoke({ ...call }, () => {});
+    assert.strictEqual(conn.attempts, 1);
+  });
+
+  // NO_REPLY_EXPECTED takes a different branch: it settles as soon as the
+  // message is written and never registers a pending call, so there is no
+  // later failure for the error to surface through.
+  it('reports a no-reply message that could not be sent', () => {
+    const bus = new MessageBus(unsendable(), { direct: true });
+    let err;
+    assert.doesNotThrow(() => {
+      bus.invoke({ ...call, flags: constants.flags.noReplyExpected }, e => {
+        err = e;
+      });
+    });
+    assert.match(err.message, /not a valid object path/);
+    assert.deepStrictEqual(Object.keys(bus.cookies), []);
+  });
+
+  it('leaves the bus usable for a message that is fine', () => {
+    const conn = new EventEmitter();
+    const sent = [];
+    let failNext = true;
+    conn.message = msg => {
+      if (failNext) {
+        failNext = false;
+        throw new Error('Data: bad/path is not a valid object path');
+      }
+      sent.push(msg);
+    };
+    const bus = new MessageBus(conn, { direct: true });
+    bus.invoke({ ...call }, () => {});
+    bus.invoke({ ...call }, () => {});
+    assert.strictEqual(sent.length, 1, 'the second call went out');
+    assert.strictEqual(
+      Object.keys(bus.cookies).length,
+      1,
+      'and is waiting for its reply'
+    );
+  });
+});


### PR DESCRIPTION
## The trap

`splitArgs` read its argument list with `Object.keys(args)`. On an array that returns `['0', '1']`:

```js
defineInterface({
  name: 'com.example.I',
  methods: {
    Hello: { in: ['s', 'u'], out: ['s'], handler: (text, count) => text }
  }
});
```

That was **accepted**, and produced a perfectly correct wire signature — `["su", "s", ["0","1"], ["0"]]` — with the arguments named `"0"` and `"1"`. A bare signature string did the same, since `Object.keys('su')` is also `['0', '1']`.

Nothing failed at definition time. Nothing failed at export. The first call handed the handler:

```
array form handler got: [{"0":"hello"},{"message":7}]
```

So a handler written as `({ text }) => …` got `undefined`, and one written as `text => …` got an object — reported as a signature mismatch from `bus.js`, somewhere well away from the line that was actually wrong.

## Why here

`defineInterface()` already rejects an unknown key, a `set` on a read-only property, a `value` alongside an accessor, and an invalid member name — all at the point they were written. This is the same class of mistake and was the one gap in that story. The message carries the object form, built from the types it was given:

```
Method "Hello" declares `in` as an array. It takes an object of named
arguments, so a handler can read them by name: { arg1: 's', arg2: 'u' }.
Handlers always receive one object of those names, never positional
arguments. For the positional form, use exportInterface() with a classic
descriptor.
```

Covers `in`, `out` and a signal's `args`, since all three go through `splitArgs`.

## Not a break

The array form never worked as anyone writing it intended — it produced arguments named `"0"` and `"1"` and a handler contract nobody would choose. Anything relying on that was already broken at the first call. The object form, an empty object, and an omitted `in`/`out` all behave exactly as before.

## Tests

7 new cases in `defineInterface: what it refuses` — array `in`, array `out`, bare signature string, array signal args, the suggested object form appearing in the message, the "never positional arguments" wording, and a control confirming the object/empty/omitted forms still pass.

- 948 unit tests pass
- 259 e2e tests pass against a real `dbus-daemon`

## How it was found

I wrote the mistake myself, in code samples published on #141 and #297, and only caught it because verifying #251 made the library reject my own example. Both comments have been corrected and re-run against a real daemon. The library should have rejected it at the point I wrote it, which is what this does.