### PR TITLE
feat(bun): a unix transport that carries file descriptors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,42 @@ jobs:
       - run: npm run test:raw
       - run: npm run test:integration
 
+  bun:
+    name: bun (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      # `scripts/with-dbus.js` starts the private bus the integration half
+      # talks to, and both clients in it are Bun processes.
+      - name: Install dbus (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y dbus
+
+      - name: Install dbus (macOS)
+        if: runner.os == 'macOS'
+        run: brew install dbus
+
+      - run: npm ci
+
+      # The fd transport is the only thing in this package that cannot run on
+      # Node -- sendmsg/recvmsg through bun:ffi, a worker thread in poll(2),
+      # and the msghdr/cmsghdr layouts, which differ between these two
+      # platforms in ways only both of them can catch.
+      - run: npm run test:bun
+      - run: npm run test:bun:integration
+
   shapes:
     name: value shapes
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ lib/
   signature.js        signature string -> tree
   writer.js           growable output buffer with a write cursor
   handshake.js        client SASL auth (EXTERNAL, DBUS_COOKIE_SHA1, ANONYMOUS)
+  transport-bun.js    unix socket that carries file descriptors, Bun only
   server-handshake.js server-side SASL auth, the same three mechanisms
   broker.js           an in-process message bus: org.freedesktop.DBus, routing
   match-rule.js       match rule parsing and evaluation
@@ -58,6 +59,7 @@ lib/cli/              the dbus-send shaped subcommands
 lib/codegen/          introspection -> TypeScript declarations
 scripts/              dev helpers for running a private session bus
 test/                 unit tests (node:test)
+test/bun/             the fd transport, run by `bun test` (bun:test)
 test/utils/           test helpers and data, not test files
 test/integration/     end-to-end tests against a real dbus-daemon
 examples/             runnable examples; linted, so keep them valid
@@ -71,7 +73,27 @@ npm run test:raw          # unit tests only
 npm run test:integration  # spins up a private dbus-daemon, runs test/integration
 npm run lint:fix          # eslint --fix
 npm run format            # prettier --write
+npm run test:bun          # the fd transport; needs bun, and only runs there
+npm run test:bun:integration   # the same, against a private dbus-daemon
 ```
+
+### The one thing Node cannot run
+
+`lib/transport-bun.js` is a unix socket this package drives itself with
+`sendmsg`/`recvmsg` through `bun:ffi`, so that a connection can carry file
+descriptors (ROADMAP §2.8). It is selected at runtime and is inert on Node, so
+the ordinary suite covers the "not available" half and `test/bun/` — written
+against `bun:test`, not `node:test` — covers the rest. If you touch it, run
+both: `npm test` and `npm run test:bun:integration`.
+
+Two rules for that file specifically:
+
+- **Never call a variadic libc function.** `fcntl` and `ioctl` are variadic,
+  and through a fixed FFI signature on arm64 their last argument comes from the
+  wrong place — `fcntl(F_SETFL, O_NONBLOCK)` returns 0 and does nothing.
+  Everything it needs has a non-variadic spelling.
+- **Do not assume `MSG_DONTWAIT` works.** Darwin ignores it for AF_UNIX, so a
+  large send blocks the event loop; `SO_SNDTIMEO` is what bounds it there.
 
 ### You need a bus for integration work
 

--- a/E2E_DOCKER_TESTING.md
+++ b/E2E_DOCKER_TESTING.md
@@ -188,8 +188,10 @@ due to security policies in the configuration file`. Tests that need to own
 
 ## What it cannot cover
 
-- **UNIX_FD passing.** Refusing it is checked; carrying one is not possible —
-  see ROADMAP §2.8.
+- **UNIX_FD passing, on Node.** Refusing it is checked; carrying one is not
+  possible there — see ROADMAP §2.8. Under Bun it is: `test/bun/` passes a
+  descriptor between two clients through a real dbus-daemon, and that runs in
+  CI on Linux and macOS.
 - **Big-endian messages.** Every peer here is little-endian. The unit suite
   covers big-endian reads with fixtures.
 - **systemd, logind, hostnamed.** They need PID 1. Running the container with

--- a/README.md
+++ b/README.md
@@ -635,12 +635,44 @@ dependency at all, which also removes the ARMv6 crash that made downstream
 forks vendor their own copy — a Long is still _accepted_ on the way in, since
 the check is on its `{low, high, unsigned}` shape and costs no import.
 
+### File descriptors (`h` / UNIX_FD)
+
+A descriptor does not travel inside a message — it rides beside it as ancillary
+data, and `h` is a uint32 index into what arrived. Node has no API for that, so
+on Node a message carrying one is refused with an error that says why.
+
+**Under Bun it just works.** A unix connection there is one this package drives
+itself with `sendmsg`/`recvmsg` through `bun:ffi` — still no dependency, no
+compiler, no build step:
+
+```js
+const bus = dbus.sessionBus(); // under Bun
+bus.connection.canPassFds; // true
+
+bus.connection.message({
+  destination: 'org.example.Sink',
+  path: '/org/example/Sink',
+  interface: 'org.example.Sink',
+  member: 'Take',
+  signature: 'sh',
+  body: ['a name', 0], //        ^ index into fds
+  fds: [fd]
+});
+```
+
+That is what makes systemd's `DumpByFileDescriptor`, the XDG portals'
+`OpenPipeWireRemote`, logind's `Inhibit` and `TakeDevice`, UDisks2's
+`LoopSetup` and BlueZ's `Acquire` reachable at all. See
+[docs/api.md](docs/api.md#file-descriptors) for the details, including how to
+supply your own transport on Node.
+
 Development
 -----------
 
 ```shell
 npm test                 # lint, format check and unit tests
 npm run test:integration # end-to-end tests against a real dbus-daemon
+npm run test:bun         # the Bun-only fd transport (needs bun)
 ```
 
 ### Running a bus locally (including on macOS)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -456,8 +456,56 @@ The package still depends on nothing, which was the point.
 - Header field 9 is in the tables. It was missing, so a peer that sent one
   produced `msg.undefined = 2` — latent only because we never negotiated.
 
+#### There is a built-in one now, for Bun
+
+**Landed.** The table above is a table of _Node_ options, and Bun is not on it:
+`bun:ffi` can `dlopen` `sendmsg(2)`/`recvmsg(2)` and call them directly, with
+no addon, no compiler and no install step -- so the dependency argument that
+rules out every row simply does not apply. `lib/transport-bun.js` is that
+transport, and `lib/address.js` uses it for every unix connection under Bun.
+Node is untouched: the module loads, answers `available() === false`, and hands
+back the ordinary socket it always did.
+
+It owns the connection descriptor rather than wrapping Bun's socket, and the
+reason is specific to d-bus. Bun's reader does a plain `read(2)`, which drops
+ancillary data silently -- fine for a protocol where descriptors only arrive in
+reply to a request that asked for one, fatal here: `NEGOTIATE_UNIX_FD` is
+per-connection, so once it is agreed _any_ peer may put a descriptor in _any_
+reply, and a message whose `UNIX_FDS` header says 1 when none arrived takes the
+connection down. Send-only would be a connection that dies the first time
+something hands it a descriptor. So reading happens on a worker thread in
+`poll(2)`, which costs a thread per connection and is what `fdTransport: false`
+turns off.
+
+Two things were measured rather than read about, both macOS:
+
+- **Darwin does not honour `MSG_DONTWAIT` for AF_UNIX.** A send larger than the
+  socket buffer blocks the calling thread -- the event loop. `SO_SNDTIMEO`
+  through `setsockopt(2)` bounds it instead, and BSD turns a timed-out send
+  that moved some bytes into a short write, which is the case the flush loop
+  already handled.
+- **`fcntl(F_SETFL, O_NONBLOCK)` cannot be used to fix that.** `fcntl` is
+  variadic, and through a fixed FFI signature on arm64 the third argument comes
+  from the wrong place: `F_SETFL` returns 0 and `F_GETFL` then shows the flag
+  was never set. Silently, which is why nothing here calls a variadic libc
+  function.
+
+What this turns on is the list this section opened with -- systemd
+(`DumpByFileDescriptor`), the XDG portals (`OpenPipeWireRemote`, `OpenFile`,
+`Spawn`), logind (`Inhibit`, `TakeDevice`), UDisks2 (`LoopSetup`), BlueZ
+(`Acquire`) -- for anyone running on Bun. `test/bun/` covers both directions
+against a hand-rolled peer, and passes a descriptor between two clients through
+a real dbus-daemon, which is the end-to-end case E2E_DOCKER_TESTING.md had
+listed as impossible.
+
+Still open: the **server** side. `lib/server.js` and `lib/broker.js` hand an
+accepted socket straight to `createConnection`, and Bun is reading it by then,
+so exporting a service that hands out descriptors needs an fd-capable listener
+too -- `socket`/`bind`/`listen`/`accept` through the same FFI, plus the poll
+thread. Worth doing; not needed by any client.
+
 The original text follows, because the transport findings are still why there
-is no built-in one.
+is no built-in one on Node.
 
 Do not build it; there is nothing safe to depend on. But **shape the transport
 seam**, because that is the part that would otherwise force a major later.

--- a/docs/api.md
+++ b/docs/api.md
@@ -292,21 +292,45 @@ bus.connection.on('message', msg => {
 });
 ```
 
-**Node has no ancillary-data API**, so nothing here provides a transport that
-can carry them — [nodejs/node#53391](https://github.com/nodejs/node/issues/53391)
-is closed as not planned, and every addon that does needs a compiler on every
-install, which is the property this package spent three releases acquiring. See
-[ROADMAP.md §2.8](../ROADMAP.md) for what was measured.
+#### Under Bun, this works out of the box
 
-**So the capability is a seam on the stream.** Supply your own transport as
-`opts.stream` implementing two things, and everything above it works:
+A unix connection opened under Bun is one this package drives itself, with
+`sendmsg(2)`/`recvmsg(2)` through `bun:ffi` — no dependency, no compiler, no
+build step. There is nothing to switch on: `sessionBus()`, `systemBus()`,
+`socket:` and `unix:`/`launchd:` addresses all get it.
+
+```js
+const bus = dbus.sessionBus();
+bus.connection.canPassFds; // true under Bun, false on Node
+```
+
+It costs one worker thread per connection, and that is what buys the half that
+matters: **receiving**. Bun's own socket reader does a plain `read(2)`, which
+silently drops ancillary data, so a connection that may be handed a descriptor
+cannot let Bun read it — the thread waits in `poll(2)` instead. Pass
+`fdTransport: false` to open an ordinary socket; the connection then cannot
+carry descriptors and does not negotiate `UNIX_FD`.
+
+**On Node it does not, and cannot.** There is no ancillary-data API —
+[nodejs/node#53391](https://github.com/nodejs/node/issues/53391) is closed as
+not planned — and every addon that does needs a compiler on every install,
+which is the property this package spent three releases acquiring. See
+[ROADMAP.md §2.8](../ROADMAP.md) for what was measured. The same code runs
+there; a message carrying descriptors is refused with an error that says why.
+
+#### Bringing your own transport
+
+The capability is a seam on the stream, which is how Bun's own transport
+attaches. Supply yours as `opts.stream`, implementing:
 
 | on the stream              |                                                     |
 | -------------------------- | --------------------------------------------------- |
 | `writeWithFds(bytes, fds)` | write, carrying descriptors; returns like `write()` |
 | `emit('fds', fds)`         | descriptors received, in arrival order              |
+| `closeFds(fds)` (optional) | close descriptors nobody claimed; see below         |
 
-`test/utils/fd-transport.js` is a working example, minus the kernel.
+`test/utils/fd-transport.js` is a working example minus the kernel, and
+`lib/transport-bun.js` is a real one.
 
 | on the connection          |                                                |
 | -------------------------- | ---------------------------------------------- |
@@ -318,7 +342,7 @@ sent when the transport can carry one — claiming the capability and then faili
 on the first `h` would leave the peer with no way to know to use a different
 call.
 
-Three details that matter if you write a transport:
+Three details that matter if you write one:
 
 - **Descriptors must arrive in the same order as their bytes.** That is what
   lets each message take the number its `UNIX_FDS` header claims, which is how
@@ -327,8 +351,13 @@ Three details that matter if you write a transport:
   _write_, not to a message, so a batched one would hand its descriptors to
   whichever message the kernel associated them with. Such a message flushes the
   cork and goes on its own.
-- **Ownership is yours.** Nothing here dups or closes anything; a received
-  descriptor is a live fd in your process and closing it is your job.
+- **Ownership.** A received descriptor is a live fd in your process and closing
+  it is your job — nothing here dups or closes what it hands you. Descriptors
+  you _send_ stay yours too: a transport that queues them (Bun's does) dups
+  first, so you may close your own as soon as the call returns. Descriptors
+  that arrived and that no message ever claimed are closed with the
+  connection, through the transport's `closeFds` if it has one, because by
+  then nothing else can.
 
 ### Reconnecting
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -344,9 +344,14 @@ call.
 
 Three details that matter if you write one:
 
-- **Descriptors must arrive in the same order as their bytes.** That is what
-  lets each message take the number its `UNIX_FDS` header claims, which is how
-  libdbus does it too. `SCM_RIGHTS` gives this for free.
+- **Descriptors must arrive in order, and never after their bytes.** That is
+  what lets each message take the number its `UNIX_FDS` header claims, which is
+  how libdbus does it too. `SCM_RIGHTS` gives it for free — though _early_ is
+  allowed and does happen: Linux glues queued messages into one `recvmsg` and
+  hands over the descriptors of the first one that carries any, so they can
+  turn up with bytes that precede their own message. macOS stops at the message
+  boundary instead. A queue popped by the message that declares them is right
+  on both.
 - **An fd-carrying message is never batched.** Ancillary data attaches to a
   _write_, not to a message, so a batched one would hand its descriptors to
   whichever message the kernel associated them with. Such a message flushes the

--- a/index.d.ts
+++ b/index.d.ts
@@ -193,7 +193,8 @@ export interface Message {
    * *indices* into this array, per the specification — not descriptors.
    *
    * The `UNIX_FDS` header field is derived from its length; do not set
-   * `unixFds` yourself. Sending requires a transport that can carry them.
+   * `unixFds` yourself. Sending requires a transport that can carry them,
+   * which `connection.canPassFds` reports.
    */
   fds?: number[];
   /** How many descriptors the message declared. Derived from `fds` on send. */
@@ -221,6 +222,15 @@ export interface ConnectionOptions {
   server?: boolean;
   /** skip the initial Hello, for peer-to-peer connections */
   direct?: boolean;
+  /**
+   * Use the file-descriptor-capable transport for unix connections where the
+   * runtime has one. Default `true`, which today means Bun and nothing else --
+   * see `lib/transport-bun.js`, and docs/api.md "File descriptors".
+   *
+   * Set `false` to open an ordinary socket instead. The connection then cannot
+   * carry descriptors and does not negotiate UNIX_FD.
+   */
+  fdTransport?: boolean;
   /**
    * How `ay` fields are returned. `true` (default) copies into a Buffer,
    * `'view'` shares memory with the message, `false` gives an array of numbers.
@@ -322,8 +332,8 @@ export interface DBusConnection extends EventEmitter {
   end(): this;
   /**
    * Whether this connection's transport can carry file descriptors — i.e.
-   * whether the stream implements `writeWithFds`. Nothing in this package
-   * provides one; supply your own as `opts.stream`.
+   * whether the stream implements `writeWithFds`. True for a unix connection
+   * under Bun; elsewhere, supply your own transport as `opts.stream`.
    */
   canPassFds: boolean;
   /** Whether the peer agreed to descriptors during the handshake. */

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const { EventEmitter } = require('events');
 const net = require('net');
 
-const { connectToAddress } = require('./lib/address');
+const { connectToAddress, unixConnection } = require('./lib/address');
 const constants = require('./lib/constants');
 const message = require('./lib/message');
 const clientHandshake = require('./lib/handshake');
@@ -27,7 +27,7 @@ const DEFAULT_SESSION_ADDRESS =
 function createStream(opts) {
   if (opts.stream) return opts.stream;
   const { host, port, socket } = opts;
-  if (socket) return net.createConnection(socket);
+  if (socket) return unixConnection({ path: socket }, opts);
   if (port) return net.createConnection(port, host);
 
   const busAddress =
@@ -39,7 +39,7 @@ function createStream(opts) {
   const addresses = busAddress.split(';');
   for (let i = 0; i < addresses.length; ++i) {
     try {
-      return connectToAddress(addresses[i]);
+      return connectToAddress(addresses[i], opts);
     } catch (e) {
       if (i === addresses.length - 1) throw e;
       console.warn(e.message);
@@ -179,6 +179,19 @@ function createConnection(opts) {
     canSendFds = typeof stream.writeWithFds === 'function';
     self.canPassFds = canSendFds;
 
+    // Descriptors arrive alongside the bytes but on their own event, so they
+    // are queued in arrival order and each message takes the number its
+    // UNIX_FDS header claims. SCM_RIGHTS delivers them in the same order as
+    // the bytes they accompany, which is what makes counting sufficient --
+    // and is how libdbus does it too.
+    //
+    // Per socket rather than per handshake: a reconnect gets a fresh queue,
+    // and the ones this one never delivered are closed with it below.
+    const received = [];
+    stream.on('fds', fds => {
+      for (const fd of fds) received.push(fd);
+    });
+
     stream.on('error', err => {
       // Remembered rather than only forwarded, so that whatever fails the
       // pending calls on teardown can name what killed the connection. The bus
@@ -208,6 +221,13 @@ function createConnection(opts) {
       const wasConnected = self.state === 'connected';
       self.state = 'disconnected';
       self.message = refuseMessage;
+      // Descriptors that arrived but that no message ever claimed. Nothing
+      // else can know about them -- the connection is gone, so no message is
+      // coming to take them -- and a real descriptor nobody closes is a leak.
+      // Only a transport that owns them can say how, hence the optional hook.
+      if (received.length > 0 && typeof stream.closeFds === 'function') {
+        stream.closeFds(received.splice(0, received.length));
+      }
       self.emit('close', self.lastError);
       if (reconnect && !ending && wasConnected) scheduleRetry(self.lastError);
     });
@@ -244,15 +264,6 @@ function createConnection(opts) {
       // 'reconnect', so a listener written for setup does not run twice.
       self.emit(reconnected ? 'reconnect' : 'connect');
 
-      // Descriptors arrive alongside the bytes but on their own event, so they
-      // are queued in arrival order and each message takes the number its
-      // UNIX_FDS header claims. SCM_RIGHTS delivers them in the same order as
-      // the bytes they accompany, which is what makes counting sufficient --
-      // and is how libdbus does it too.
-      const received = [];
-      stream.on('fds', fds => {
-        for (const fd of fds) received.push(fd);
-      });
       const takeFds = count => {
         // One capability, both directions: a stream that cannot send
         // descriptors is not going to have received any either, and saying

--- a/lib/address.js
+++ b/lib/address.js
@@ -5,6 +5,8 @@ const net = require('net');
 const { spawn, spawnSync } = require('child_process');
 const { Duplex } = require('stream');
 
+const bunTransport = require('./transport-bun');
+
 // A d-bus address is `family:key=value,key=value`, and DBUS_SESSION_BUS_ADDRESS
 // may hold several of them separated by `;`.
 function parseAddressParams(address) {
@@ -67,20 +69,43 @@ function unixexecArgs(params) {
   return args;
 }
 
-function connectToAddress(address) {
+/**
+ * A unix-socket connection, carrying file descriptors where it can.
+ *
+ * `target` is `{ path }` or `{ abstract }`. Under Bun the connection is one
+ * this package owns and drives with sendmsg/recvmsg, so it can carry a
+ * descriptor -- see lib/transport-bun.js, and docs/api.md "File descriptors"
+ * for what that turns on. Anywhere else, and whenever that fails for any
+ * reason, this is the ordinary socket it has always been.
+ *
+ * `opts.fdTransport: false` opts out, which is the switch to reach for if the
+ * reader thread is unwelcome or something about it misbehaves.
+ */
+function unixConnection(target, opts) {
+  if (!opts || opts.fdTransport !== false) {
+    const stream = bunTransport.connect(target);
+    if (stream) return stream;
+  }
+  if (target.abstract !== undefined) {
+    // Node supports Linux abstract sockets natively since v20.8.0 by
+    // prefixing the path with a NUL byte - no native addon required.
+    return net.createConnection(`\0${target.abstract}`);
+  }
+  return net.createConnection(target.path);
+}
+
+function connectToAddress(address, opts) {
   const { family, params } = parseAddressParams(address);
 
   switch (family) {
     case 'tcp':
       return net.createConnection(params.port, params.host || 'localhost');
     case 'unix':
-      if (params.socket) return net.createConnection(params.socket);
+      if (params.socket) return unixConnection({ path: params.socket }, opts);
       if (params.abstract) {
-        // Node supports Linux abstract sockets natively since v20.8.0 by
-        // prefixing the path with a NUL byte - no native addon required.
-        return net.createConnection(`\0${params.abstract}`);
+        return unixConnection({ abstract: params.abstract }, opts);
       }
-      if (params.path) return net.createConnection(params.path);
+      if (params.path) return unixConnection({ path: params.path }, opts);
       throw new Error(
         "not enough parameters for 'unix' connection - you need to specify 'socket' or 'abstract' or 'path' parameter"
       );
@@ -96,7 +121,7 @@ function connectToAddress(address) {
           `launchd address names ${params.env}, which is set neither in the launchd environment nor in this process. Is dbus running? (brew services start dbus)`
         );
       }
-      return net.createConnection(path);
+      return unixConnection({ path }, opts);
     }
     case 'unixexec': {
       if (!params.path) {
@@ -120,5 +145,6 @@ module.exports = {
   parseAddressParams,
   launchdSocketPath,
   unixexecArgs,
+  unixConnection,
   connectToAddress
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -85,9 +85,11 @@ module.exports = {
    * travels as ancillary data (SCM_RIGHTS) rather than in the body, and Node
    * has no API for that: nodejs/node#53391 is closed as not planned.
    *
-   * So the seam is on the stream. Supply one that implements `writeWithFds`
-   * and emits `'fds'` -- see docs/api.md, "File descriptors" -- and everything
-   * above it works. This affects systemd, the XDG desktop portals and PipeWire.
+   * So the seam is on the stream. Under Bun this package supplies one itself
+   * (lib/transport-bun.js, used automatically for unix connections); anywhere
+   * else, supply one that implements `writeWithFds` and emits `'fds'` -- see
+   * docs/api.md, "File descriptors" -- and everything above it works. This
+   * affects systemd, the XDG desktop portals and PipeWire.
    */
   noFdTransport(direction) {
     return (
@@ -95,9 +97,10 @@ module.exports = {
       'the stream does not support them. A descriptor is passed as ancillary ' +
       'data (SCM_RIGHTS) alongside the message rather than inside it, and Node ' +
       'has no API for that -- https://github.com/nodejs/node/issues/53391 is ' +
-      'closed as not planned. Pass your own transport as `opts.stream`, ' +
-      "implementing writeWithFds(bytes, fds) and emitting 'fds'. See " +
-      'docs/api.md and ROADMAP.md section 2.8.'
+      'closed as not planned. Under Bun this works on any unix connection, ' +
+      'unless `fdTransport: false` turned it off. On Node, pass your own ' +
+      'transport as `opts.stream`, implementing writeWithFds(bytes, fds) and ' +
+      "emitting 'fds'. See docs/api.md and ROADMAP.md section 2.8."
     );
   }
 };

--- a/lib/transport-bun.js
+++ b/lib/transport-bun.js
@@ -1,0 +1,796 @@
+// A unix-socket transport that can carry file descriptors, for Bun.
+//
+// ROADMAP 2.8 measured every way of doing this on Node and found none: there
+// is no ancillary-data API, nodejs/node#53391 is closed as not planned, and
+// every addon that works needs a compiler on every install -- which is the
+// property several releases were spent acquiring. So the capability was left
+// as a seam on the stream (`writeWithFds`, an `'fds'` event) and nothing here
+// filled it.
+//
+// Bun fills it with no dependency and no build step: `bun:ffi` can call
+// sendmsg(2)/recvmsg(2) directly. `dlopen`, not bun:ffi's `cc()` -- cc() would
+// make the CMSG_* macros free but compiles against the system libc and headers
+// at runtime, which a slim container need not have. Plain dlopen needs only
+// hand-built msghdr/cmsghdr bytes, which are small, fixed, and differ between
+// Linux and macOS in exactly two ways (see "wire structs").
+//
+// This transport OWNS the connection descriptor, because receiving is the half
+// that matters here and Bun's socket reader does a plain read(2), which
+// silently drops ancillary data. That is fatal for d-bus in a way it is not
+// for a protocol where descriptors only arrive if you ask: negotiation is
+// per-connection, so once NEGOTIATE_UNIX_FD is agreed, *any* peer may put a
+// descriptor in *any* reply -- and a message whose UNIX_FDS header says 1 when
+// none arrived is a protocol error that takes the connection down
+// (lib/message.js). Send-only would be a connection that dies the first time
+// something hands us a descriptor, so this is send *and* receive or nothing.
+//
+// Reading therefore happens on a worker thread blocked in poll(2), which is
+// what Bun's event loop cannot be asked to do for a descriptor it does not
+// own. The thread does the recvmsg too and posts { bytes, fds }: d-bus message
+// rates are low, descriptors are plain ints and valid process-wide, and it
+// keeps the re-arm protocol to one byte in each direction.
+//
+// Ownership, both directions:
+//   - descriptors given to writeWithFds() are DUPed here and the caller keeps
+//     its own, exactly as libdbus does. A queued write may be sent a tick
+//     later, so a caller that closed its descriptor on return would otherwise
+//     send a stale number;
+//   - descriptors that arrive are handed over by the 'fds' event and are the
+//     receiver's from then on. Anything that arrived but was never claimed by
+//     a message is closed by closeFds() when the connection goes away.
+
+const { Duplex } = require('stream');
+
+// require() behind an indirection: `bun:ffi` and the worker exist only on the
+// runtime that uses them, and a bundler must neither resolve nor inline them.
+// A computed specifier is not enough on its own -- esbuild folds `'bun' +
+// ':ffi'` straight back into a literal -- so the call is what hides it.
+const nodeRequire = require;
+const loadModule = name => nodeRequire(name);
+
+const isDarwin = process.platform === 'darwin';
+const supportedPlatform = isDarwin || process.platform === 'linux';
+
+const LIBC_CANDIDATES = isDarwin
+  ? ['/usr/lib/libSystem.B.dylib']
+  : ['libc.so.6', 'libc.so', 'libc.musl-x86_64.so.1', 'libc.musl-aarch64.so.1'];
+
+// Only non-variadic entry points. fcntl(2) and ioctl(2) are variadic, and a
+// variadic call made through a fixed FFI signature passes its arguments in the
+// wrong place on arm64 -- nothing here needs them, because MSG_DONTWAIT makes
+// every send and receive non-blocking per call rather than per descriptor.
+const SYMBOLS = {
+  socket: { args: ['int', 'int', 'int'], returns: 'int' },
+  connect: { args: ['int', 'ptr', 'int'], returns: 'int' },
+  setsockopt: {
+    args: ['int', 'int', 'int', 'ptr', 'int'],
+    returns: 'int'
+  },
+  sendmsg: { args: ['int', 'ptr', 'int'], returns: 'i64' },
+  send: { args: ['int', 'ptr', 'u64', 'int'], returns: 'i64' },
+  write: { args: ['int', 'ptr', 'u64'], returns: 'i64' },
+  shutdown: { args: ['int', 'int'], returns: 'int' },
+  dup: { args: ['int'], returns: 'int' },
+  pipe: { args: ['ptr'], returns: 'int' },
+  close: { args: ['int'], returns: 'int' }
+};
+
+const ERRNO_SYMBOL = isDarwin
+  ? { __error: { args: [], returns: 'ptr' } }
+  : { __errno_location: { args: [], returns: 'ptr' } };
+
+let libc = null;
+let libcProbed = false;
+
+function loadLibc() {
+  if (libcProbed) return libc;
+  libcProbed = true;
+  if (typeof Bun === 'undefined' || !supportedPlatform) return null;
+  let ffi;
+  try {
+    ffi = loadModule('bun:ffi');
+  } catch {
+    return null;
+  }
+  for (const name of LIBC_CANDIDATES) {
+    let lib;
+    try {
+      lib = ffi.dlopen(name, { ...SYMBOLS, ...ERRNO_SYMBOL });
+    } catch {
+      continue; // not this libc -- try the next candidate
+    }
+    const errnoLocation = isDarwin
+      ? lib.symbols.__error
+      : lib.symbols.__errno_location;
+    libc = {
+      name,
+      sym: lib.symbols,
+      ptr: ffi.ptr,
+      errno: () => ffi.read.i32(errnoLocation(), 0)
+    };
+    break;
+  }
+  return libc;
+}
+
+// ---------------------------------------------------------------------------
+// wire structs
+//
+// Both platforms are LP64, and struct msghdr is 56 bytes on both, but:
+//
+//   struct msghdr   msg_iovlen / msg_controllen are `int` + padding on macOS
+//                   and `size_t` on Linux
+//   struct cmsghdr  { len; int level; int type; } -- len is socklen_t (4) on
+//                   macOS and size_t (8) on Linux, so the header is 12 vs 16
+//                   bytes and the payload after it aligns to 4 vs 8
+//   struct iovec    { void *base; size_t len; } -- 16 bytes on both
+// ---------------------------------------------------------------------------
+
+const MSGHDR_SIZE = 56;
+const OFF_IOV = 16;
+const OFF_IOVLEN = 24;
+const OFF_CONTROL = 32;
+const OFF_CONTROLLEN = 40;
+
+const CMSG_HDR = isDarwin ? 12 : 16;
+const cmsgAlign = n => (isDarwin ? (n + 3) & ~3 : (n + 7) & ~7);
+const OFF_CMSG_LEVEL = isDarwin ? 4 : 8;
+const OFF_CMSG_TYPE = isDarwin ? 8 : 12;
+
+const AF_UNIX = 1;
+const SOCK_STREAM = 1;
+const SHUT_WR = 1;
+const SOL_SOCKET = isDarwin ? 0xffff : 1;
+const SCM_RIGHTS = 1;
+const MSG_DONTWAIT = isDarwin ? 0x80 : 0x40;
+// macOS only, and the reason they are needed at all is worth stating: Darwin
+// does NOT honour MSG_DONTWAIT for AF_UNIX -- a send larger than the socket
+// buffer blocks the calling thread, which for us is the event loop. The usual
+// fix, O_NONBLOCK through fcntl(2), is not available: fcntl is variadic, and a
+// variadic function called through a fixed FFI signature takes its third
+// argument from the wrong place on arm64. Measured, not assumed: F_SETFL
+// returns 0 and F_GETFL then shows the flag was never set.
+//
+// setsockopt(2) is not variadic, and a send timeout bounds the block instead:
+// BSD turns a timed-out send that moved some bytes into a short write, and one
+// that moved none into EWOULDBLOCK -- which is exactly the contract the flush
+// loop already handles. The receive side gets one too, so that a spurious poll
+// wakeup can never wedge the reader thread.
+const SO_SNDTIMEO = 0x1005;
+const SO_RCVTIMEO = 0x1006;
+const SEND_TIMEOUT_US = 2000;
+const EINTR = 4;
+const EAGAIN = isDarwin ? 35 : 11; // == EWOULDBLOCK on both
+const EMSGSIZE = isDarwin ? 40 : 90;
+const SUN_PATH_MAX = isDarwin ? 104 : 108;
+
+// Descriptors per message. dbus-daemon enforces its own limit
+// (`max_message_unix_fds`, 16 in the reference configuration), so this is a
+// backstop against a peer that claims more than a control buffer we are
+// willing to keep as a scratch allocation -- not a policy of our own.
+const MAX_FDS = 64;
+const READ_SIZE = 65536;
+
+// Scratch, reused for every call: libc is handed pointers into these, so they
+// must not move or be collected mid-call. Every use is synchronous and on the
+// main thread, so one set is enough.
+const msgScratch = Buffer.alloc(MSGHDR_SIZE);
+const iovScratch = Buffer.alloc(16);
+const ctlScratch = Buffer.alloc(cmsgAlign(CMSG_HDR) + cmsgAlign(4 * MAX_FDS));
+
+function setMsghdr(iovPtr, ctlPtr, ctlLen) {
+  msgScratch.fill(0);
+  msgScratch.writeBigUInt64LE(BigInt(iovPtr), OFF_IOV);
+  if (isDarwin) msgScratch.writeInt32LE(1, OFF_IOVLEN);
+  else msgScratch.writeBigUInt64LE(1n, OFF_IOVLEN);
+  if (ctlLen > 0) {
+    msgScratch.writeBigUInt64LE(BigInt(ctlPtr), OFF_CONTROL);
+    if (isDarwin) msgScratch.writeUInt32LE(ctlLen, OFF_CONTROLLEN);
+    else msgScratch.writeBigUInt64LE(BigInt(ctlLen), OFF_CONTROLLEN);
+  }
+}
+
+function setIovec(buf) {
+  iovScratch.writeBigUInt64LE(BigInt(libc.ptr(buf)), 0);
+  iovScratch.writeBigUInt64LE(BigInt(buf.length), 8);
+}
+
+/**
+ * Send `buf` with `fds` attached as SCM_RIGHTS ancillary data.
+ *
+ * Returns the number of bytes the kernel took -- which may be fewer than
+ * offered, in which case the descriptors went with the bytes it did take --
+ * or -1 with errno set.
+ */
+function sendmsgWithFds(fd, buf, fds) {
+  setIovec(buf);
+  const payload = 4 * fds.length;
+  const ctlLen = cmsgAlign(CMSG_HDR) + cmsgAlign(payload);
+  ctlScratch.fill(0, 0, ctlLen);
+  if (isDarwin) ctlScratch.writeUInt32LE(CMSG_HDR + payload, 0);
+  else ctlScratch.writeBigUInt64LE(BigInt(CMSG_HDR + payload), 0);
+  ctlScratch.writeInt32LE(SOL_SOCKET, OFF_CMSG_LEVEL);
+  ctlScratch.writeInt32LE(SCM_RIGHTS, OFF_CMSG_TYPE);
+  for (let i = 0; i < fds.length; i++) {
+    ctlScratch.writeInt32LE(fds[i], CMSG_HDR + 4 * i);
+  }
+  setMsghdr(libc.ptr(iovScratch), libc.ptr(ctlScratch), ctlLen);
+  return Number(libc.sym.sendmsg(fd, libc.ptr(msgScratch), MSG_DONTWAIT));
+}
+
+/**
+ * Bound how long a send or receive may block. macOS only -- see SO_SNDTIMEO.
+ *
+ * Returns false if either could not be set, which makes the descriptor unsafe
+ * to drive from the event loop and so unusable to us.
+ */
+function boundBlocking(fd) {
+  if (!isDarwin) return true;
+  const tv = Buffer.alloc(16); // struct timeval { time_t sec; suseconds_t usec }
+  tv.writeInt32LE(SEND_TIMEOUT_US, 8);
+  for (const option of [SO_SNDTIMEO, SO_RCVTIMEO]) {
+    const rc = libc.sym.setsockopt(
+      fd,
+      SOL_SOCKET,
+      option,
+      libc.ptr(tv),
+      tv.length
+    );
+    if (rc !== 0) return false;
+  }
+  return true;
+}
+
+function sendPlain(fd, buf) {
+  return Number(
+    libc.sym.send(fd, libc.ptr(buf), BigInt(buf.length), MSG_DONTWAIT)
+  );
+}
+
+function closeFds(fds) {
+  for (const fd of fds) {
+    if (typeof fd === 'number' && fd >= 0) libc.sym.close(fd);
+  }
+}
+
+/**
+ * sockaddr_un, and the exact length to pass with it.
+ *
+ * `{ u8 len; u8 family; char path[104] }` on macOS, `{ u16 family; char
+ * path[108] }` on Linux. An abstract address is Linux-only and starts with a
+ * NUL: the name is whatever follows, so the length must be exactly what the
+ * name needs -- pass the whole struct and the trailing NULs become part of the
+ * name, which is a different socket from the one the address meant.
+ */
+function sockaddrUn(target) {
+  const name = target.abstract === undefined ? target.path : target.abstract;
+  const bytes = Buffer.byteLength(name);
+  if (bytes >= SUN_PATH_MAX) return null;
+  const sa = Buffer.alloc(2 + SUN_PATH_MAX);
+  if (isDarwin) {
+    sa.writeUInt8(sa.length, 0);
+    sa.writeUInt8(AF_UNIX, 1);
+  } else {
+    sa.writeUInt16LE(AF_UNIX, 0);
+  }
+  if (target.abstract === undefined) {
+    sa.write(name, 2);
+    return { sa, len: sa.length };
+  }
+  sa.write(name, 3); // sun_path[0] stays NUL: that is what makes it abstract
+  return { sa, len: 2 + 1 + bytes };
+}
+
+// ---------------------------------------------------------------------------
+// the reader thread
+//
+// It blocks in poll(2) and does the recvmsg, posting { bytes, fds } to the
+// main thread. Main -> worker is a single byte on a pipe, which the poll wakes
+// on immediately:
+//
+//   'r'  the main thread has taken the last chunk: watch for readable again
+//   'o'  watch for writable  /  'p' stop watching for writable
+//   's'  stop: close what this thread owns and exit
+//
+// The thread holds its own dup() of the connection, so a descriptor number
+// reused after close() can never be polled by mistake, and the connection
+// stays open until the thread has actually gone.
+// ---------------------------------------------------------------------------
+
+const POLLER_SOURCE = `
+'use strict';
+const { parentPort, workerData } = require('worker_threads');
+const ffi = require('bun' + ':ffi');
+const isDarwin = process.platform === 'darwin';
+const lib = ffi.dlopen(workerData.libc, {
+    // nfds_t is unsigned long on Linux and unsigned int on macOS. Declaring
+    // it 64-bit is right on one and harmless on the other -- the callee reads
+    // the low half -- whereas a 32-bit argument in a 64-bit slot leaves the
+    // top half to chance.
+    poll:    { args: ['ptr', 'u64', 'int'], returns: 'int' },
+    recvmsg: { args: ['int', 'ptr', 'int'], returns: 'i64' },
+    read:    { args: ['int', 'ptr', 'u64'], returns: 'i64' },
+    close:   { args: ['int'], returns: 'int' },
+    ...(isDarwin
+        ? { __error: { args: [], returns: 'ptr' } }
+        : { __errno_location: { args: [], returns: 'ptr' } })
+});
+const sym = lib.symbols;
+const errnoLocation = isDarwin ? sym.__error : sym.__errno_location;
+const errno = () => ffi.read.i32(errnoLocation(), 0);
+
+const CMSG_HDR = isDarwin ? 12 : 16;
+const cmsgAlign = n => (isDarwin ? (n + 3) & ~3 : (n + 7) & ~7);
+const OFF_CMSG_LEVEL = isDarwin ? 4 : 8;
+const OFF_CMSG_TYPE = isDarwin ? 8 : 12;
+const SOL_SOCKET = isDarwin ? 0xffff : 1;
+const MSG_DONTWAIT = isDarwin ? 0x80 : 0x40;
+const MSG_CTRUNC = isDarwin ? 0x20 : 0x08;
+// Received descriptors must not survive an exec: a d-bus client that spawns a
+// child (a portal caller does this constantly) would otherwise hand the peer's
+// descriptors to it. Linux has the flag; macOS has no equivalent for recvmsg.
+const MSG_CMSG_CLOEXEC = isDarwin ? 0 : 0x40000000;
+const EINTR = 4;
+const EAGAIN = isDarwin ? 35 : 11;
+const POLLIN = 1, POLLOUT = 4, POLLERR = 8, POLLHUP = 16, POLLNVAL = 32;
+
+const sock = workerData.sock, wake = workerData.wake;
+const maxFds = workerData.maxFds, readSize = workerData.readSize;
+
+const msg = Buffer.alloc(56);
+const iov = Buffer.alloc(16);
+const ctl = Buffer.alloc(cmsgAlign(CMSG_HDR) + cmsgAlign(4 * maxFds));
+const data = Buffer.allocUnsafeSlow(readSize);
+const pollfds = Buffer.alloc(16); // two struct pollfd { int fd; short ev, rev; }
+const commands = Buffer.alloc(64);
+
+function receive() {
+    iov.writeBigUInt64LE(BigInt(ffi.ptr(data)), 0);
+    iov.writeBigUInt64LE(BigInt(data.length), 8);
+    ctl.fill(0);
+    msg.fill(0);
+    msg.writeBigUInt64LE(BigInt(ffi.ptr(iov)), 16);
+    if (isDarwin) msg.writeInt32LE(1, 24);
+    else msg.writeBigUInt64LE(1n, 24);
+    msg.writeBigUInt64LE(BigInt(ffi.ptr(ctl)), 32);
+    if (isDarwin) msg.writeUInt32LE(ctl.length, 40);
+    else msg.writeBigUInt64LE(BigInt(ctl.length), 40);
+    const n = Number(sym.recvmsg(sock, ffi.ptr(msg), MSG_DONTWAIT | MSG_CMSG_CLOEXEC));
+    if (n <= 0) return { n, fds: null, truncated: false };
+    const controlLen = isDarwin
+        ? msg.readUInt32LE(40)
+        : Number(msg.readBigUInt64LE(40));
+    const truncated = (msg.readInt32LE(48) & MSG_CTRUNC) !== 0;
+    let fds = null;
+    let off = 0;
+    while (off + CMSG_HDR <= controlLen) {
+        const len = isDarwin
+            ? ctl.readUInt32LE(off)
+            : Number(ctl.readBigUInt64LE(off));
+        if (len < CMSG_HDR) break;
+        if (ctl.readInt32LE(off + OFF_CMSG_LEVEL) === SOL_SOCKET &&
+            ctl.readInt32LE(off + OFF_CMSG_TYPE) === 1) {
+            fds = fds || [];
+            for (let p = off + CMSG_HDR; p + 4 <= off + len; p += 4)
+                fds.push(ctl.readInt32LE(p));
+        }
+        off += cmsgAlign(len);
+    }
+    return { n, fds, truncated };
+}
+
+let watchRead = true, watchWrite = false, running = true, failures = 0;
+while (running) {
+    pollfds.writeInt32LE(sock, 0);
+    pollfds.writeInt16LE((watchRead ? POLLIN : 0) | (watchWrite ? POLLOUT : 0), 4);
+    pollfds.writeInt16LE(0, 6);
+    pollfds.writeInt32LE(wake, 8);
+    pollfds.writeInt16LE(POLLIN, 12);
+    pollfds.writeInt16LE(0, 14);
+    const rc = sym.poll(ffi.ptr(pollfds), 2n, -1);
+    if (rc < 0) {
+        // EINTR: retry. A descriptor that has really gone bad shows up as
+        // POLLNVAL below instead, so a poll that keeps failing is something
+        // this thread cannot fix -- say so rather than spin.
+        if (errno() === EINTR && ++failures < 64) continue;
+        parentPort.postMessage({ type: 'error', message: 'waiting on the connection failed (errno ' + errno() + ')' });
+        break;
+    }
+    failures = 0;
+    if (pollfds.readInt16LE(14)) {
+        const n = Number(sym.read(wake, ffi.ptr(commands), 64n));
+        for (let i = 0; i < n; i++) {
+            const c = commands[i];
+            if (c === 115) running = false;         // 's'
+            else if (c === 114) watchRead = true;   // 'r'
+            else if (c === 111) watchWrite = true;  // 'o'
+            else if (c === 112) watchWrite = false; // 'p'
+        }
+        if (!running) break;
+    }
+    const revents = pollfds.readInt16LE(6);
+    if (revents & POLLNVAL) {
+        parentPort.postMessage({ type: 'error', message: 'the connection descriptor became invalid' });
+        break;
+    }
+    if (revents & POLLOUT) {
+        watchWrite = false;
+        parentPort.postMessage({ type: 'writable' });
+    }
+    if (!(revents & (POLLIN | POLLHUP | POLLERR))) continue;
+    const { n, fds, truncated } = receive();
+    if (truncated) {
+        if (fds) for (const fd of fds) sym.close(fd);
+        parentPort.postMessage({ type: 'error', message: 'descriptors were dropped: the control message was truncated' });
+        break;
+    }
+    if (n > 0) {
+        const out = new Uint8Array(n);
+        out.set(data.subarray(0, n));
+        // Level-triggered, so stop watching until the main thread says it has
+        // taken this chunk -- otherwise the poll returns immediately forever.
+        watchRead = false;
+        parentPort.postMessage({ type: 'data', data: out, fds: fds || null }, [out.buffer]);
+        continue;
+    }
+    if (n === 0) {
+        parentPort.postMessage({ type: 'eof' });
+        break;
+    }
+    const e = errno();
+    if (e === EAGAIN || e === EINTR) {
+        // Nothing there after all. With the peer gone that is the end of the
+        // stream rather than "not yet", and re-arming would spin.
+        if (revents & (POLLHUP | POLLERR)) {
+            parentPort.postMessage({ type: 'eof' });
+            break;
+        }
+        continue;
+    }
+    parentPort.postMessage({ type: 'error', message: 'reading from the connection failed (errno ' + e + ')' });
+    break;
+}
+sym.close(sock);
+sym.close(wake);
+`;
+
+// ---------------------------------------------------------------------------
+// the stream
+// ---------------------------------------------------------------------------
+
+/**
+ * A Duplex over a connected unix socket we own, plus `writeWithFds()` and an
+ * `'fds'` event -- the seam documented in docs/api.md.
+ *
+ * Being a real Duplex is not cosmetic: `unmarshalMessages()` frames messages
+ * with `stream.read(n)` on `'readable'`, the handshake reads lines the same
+ * way, and `connection.message()` batches with cork/uncork. All of that comes
+ * from the base class, which leaves this file with only the syscalls.
+ */
+class BunUnixSocket extends Duplex {
+  constructor(fd) {
+    super();
+    this._fd = fd;
+    this._wake = -1;
+    this._worker = null;
+    // Writes not yet taken by the kernel, in wire order: { buf, off, fds, cb }.
+    this._backlog = [];
+    // Descriptors tagged onto a chunk by writeWithFds(), matched back to it by
+    // identity in _writev() -- so they attach to their own message's bytes and
+    // to nothing else.
+    this._tagged = [];
+    this._watchingWrite = false;
+    this._readPaused = false;
+    this._flushing = false;
+    this._finalCb = null;
+    this._failure = null;
+  }
+
+  // ---- reading ------------------------------------------------------------
+
+  _startReader() {
+    const { Worker } = loadModule('worker_threads');
+    const pipefds = new Int32Array(2);
+    if (libc.sym.pipe(libc.ptr(pipefds)) !== 0) {
+      throw new Error(
+        `could not create the reader wake pipe (errno ${libc.errno()})`
+      );
+    }
+    const dup = libc.sym.dup(this._fd);
+    if (dup < 0) {
+      const err = libc.errno();
+      libc.sym.close(pipefds[0]);
+      libc.sym.close(pipefds[1]);
+      throw new Error(
+        `could not duplicate the connection descriptor (errno ${err})`
+      );
+    }
+    this._wake = pipefds[1];
+    try {
+      // The worker source is inlined rather than kept in a sibling file so
+      // that a bundled application still has it.
+      this._worker = new Worker(POLLER_SOURCE, {
+        eval: true,
+        workerData: {
+          libc: libc.name,
+          sock: dup,
+          wake: pipefds[0],
+          maxFds: MAX_FDS,
+          readSize: READ_SIZE
+        }
+      });
+    } catch (err) {
+      libc.sym.close(dup); // nothing owns these yet
+      libc.sym.close(pipefds[0]);
+      libc.sym.close(pipefds[1]);
+      this._wake = -1;
+      throw err;
+    }
+    this._worker.on('message', msg => this._onWorkerMessage(msg));
+    this._worker.on('error', err => this._fail(err));
+    // A thread blocked in poll() keeps the process alive, which is what an
+    // open connection should do. destroy() stops it.
+  }
+
+  _tell(command) {
+    if (this._wake < 0) return;
+    const byte = Buffer.from(command);
+    libc.sym.write(this._wake, libc.ptr(byte), 1n);
+  }
+
+  _onWorkerMessage(msg) {
+    if (this.destroyed) {
+      // Nobody is going to claim these, and they are real descriptors.
+      if (msg.type === 'data' && msg.fds) closeFds(msg.fds);
+      return;
+    }
+    switch (msg.type) {
+      case 'data': {
+        // Before the bytes, always. A message takes the descriptors its
+        // UNIX_FDS header claims, so they have to be queued by the time the
+        // parser reaches that header -- and SCM_RIGHTS can deliver them with
+        // bytes that precede their own message, never after.
+        if (msg.fds && msg.fds.length) this.emit('fds', msg.fds);
+        const chunk = Buffer.from(
+          msg.data.buffer,
+          msg.data.byteOffset,
+          msg.data.byteLength
+        );
+        if (this.push(chunk)) this._tell('r');
+        else this._readPaused = true;
+        return;
+      }
+      case 'writable':
+        this._watchingWrite = false;
+        this._flush();
+        return;
+      case 'eof':
+        this.push(null);
+        return;
+      case 'error':
+        this._fail(new Error(msg.message));
+        return;
+    }
+  }
+
+  _read() {
+    if (!this._readPaused) return;
+    this._readPaused = false;
+    this._tell('r');
+  }
+
+  // ---- writing ------------------------------------------------------------
+
+  /**
+   * The seam: a write that carries descriptors alongside its bytes.
+   *
+   * The descriptors are duped here and the caller keeps its own, which is what
+   * libdbus does and the only contract that works with a queue: a write may go
+   * out a tick later, and a caller that closed its descriptor on return would
+   * have handed us a number that means something else by then.
+   */
+  writeWithFds(bytes, fds) {
+    if (fds.length > MAX_FDS) {
+      // Thrown rather than reported on the connection, like the refusal in
+      // index.js: it is the caller's message that cannot be sent, and nothing
+      // about the connection is wrong.
+      throw new Error(
+        `a message may carry at most ${MAX_FDS} file descriptors, not ${fds.length}`
+      );
+    }
+    if (this.destroyed || this.writableEnded) return false;
+    const dups = [];
+    for (const fd of fds) {
+      const copy = libc.sym.dup(fd);
+      if (copy < 0) {
+        const err = libc.errno();
+        closeFds(dups);
+        this.destroy(
+          new Error(`could not duplicate file descriptor ${fd} (errno ${err})`)
+        );
+        return false;
+      }
+      dups.push(copy);
+    }
+    this._tagged.push({ bytes, fds: dups });
+    return this.write(bytes);
+  }
+
+  /** Descriptors that arrived and were never claimed by a message. */
+  closeFds(fds) {
+    closeFds(fds);
+  }
+
+  _write(chunk, encoding, cb) {
+    this._writev([{ chunk, encoding }], cb);
+  }
+
+  _writev(chunks, cb) {
+    // The callback answers for every chunk in this call, so it rides on the
+    // last one: writes complete in order, so that is when they are all out.
+    for (let i = 0; i < chunks.length; i++) {
+      const buf = chunks[i].chunk;
+      let fds = null;
+      if (this._tagged.length > 0 && this._tagged[0].bytes === buf) {
+        fds = this._tagged.shift().fds;
+      }
+      this._backlog.push({
+        buf,
+        off: 0,
+        fds,
+        cb: i === chunks.length - 1 ? cb : null
+      });
+    }
+    this._flush();
+  }
+
+  /** Write as much of the backlog as the kernel will take, in order. */
+  _flush() {
+    // A write callback lets the Writable hand us the next buffered chunk
+    // immediately, which lands back here. Re-entering is harmless -- the new
+    // chunk goes on the end of the same queue -- but the outer loop is already
+    // draining it, so let it.
+    if (this._flushing) return;
+    this._flushing = true;
+    try {
+      this._drain();
+    } finally {
+      this._flushing = false;
+    }
+  }
+
+  _drain() {
+    while (this._backlog.length > 0) {
+      const item = this._backlog[0];
+      const rest = item.buf.subarray(item.off);
+      let sent = 0;
+      if (rest.length > 0) {
+        sent = item.fds
+          ? sendmsgWithFds(this._fd, rest, item.fds)
+          : sendPlain(this._fd, rest);
+        if (sent < 0) {
+          const err = libc.errno();
+          // EMSGSIZE is how macOS says "no room for this one right now" when
+          // it carries control data; everywhere else that is EAGAIN.
+          if (err === EAGAIN || err === EINTR || err === EMSGSIZE) {
+            this._watchWritable();
+            return;
+          }
+          this._fail(
+            new Error(`writing to the connection failed (errno ${err})`)
+          );
+          return;
+        }
+        if (item.fds) {
+          // On the wire with the first byte the kernel took. Our dups have
+          // done their job either way.
+          closeFds(item.fds);
+          item.fds = null;
+        }
+      }
+      item.off += sent;
+      if (item.off < item.buf.length) {
+        this._watchWritable();
+        return;
+      }
+      this._backlog.shift();
+      if (item.cb) item.cb(null);
+    }
+    if (this._watchingWrite) {
+      this._watchingWrite = false;
+      this._tell('p');
+    }
+    if (this._finalCb) {
+      const cb = this._finalCb;
+      this._finalCb = null;
+      libc.sym.shutdown(this._fd, SHUT_WR);
+      cb(null);
+    }
+  }
+
+  _watchWritable() {
+    if (this._watchingWrite) return;
+    this._watchingWrite = true;
+    this._tell('o');
+  }
+
+  _final(cb) {
+    this._finalCb = cb;
+    this._flush();
+  }
+
+  // ---- teardown -----------------------------------------------------------
+
+  _destroy(err, cb) {
+    this._tell('s'); // the thread closes its dup and the wake pipe, then exits
+    if (this._worker) {
+      // A thread that somehow missed the stop byte must not hold the process
+      // open on its own.
+      this._worker.unref();
+      this._worker = null;
+    }
+    if (this._wake >= 0) libc.sym.close(this._wake);
+    this._wake = -1;
+    // Queued writes are dropped, but the descriptors we duped for them are
+    // ours to close.
+    for (const item of this._backlog) if (item.fds) closeFds(item.fds);
+    for (const item of this._tagged) closeFds(item.fds);
+    this._backlog = [];
+    this._tagged = [];
+    if (this._fd >= 0) libc.sym.close(this._fd);
+    this._fd = -1;
+    cb(err || this._failure || null);
+  }
+
+  _fail(err) {
+    if (this.destroyed) return;
+    this._failure = err;
+    this.destroy(err);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// entry points
+// ---------------------------------------------------------------------------
+
+/** Whether this runtime can carry descriptors at all. Cheap and memoised. */
+function available() {
+  return loadLibc() !== null;
+}
+
+/**
+ * Connect to a unix socket, fd-capable.
+ *
+ * `target` is `{ path }` or `{ abstract }`. Returns a connected stream, or
+ * null when this runtime cannot do it or anything at all went wrong -- the
+ * caller then opens an ordinary socket, which fails the same way it always
+ * did. Nothing here should turn a working connection into a broken one.
+ */
+function connect(target) {
+  if (!available()) return null;
+  const address = sockaddrUn(target);
+  if (!address) return null; // name too long for sockaddr_un
+  const fd = libc.sym.socket(AF_UNIX, SOCK_STREAM, 0);
+  if (fd < 0) return null;
+  // Blocking connect: a unix socket either has a listener or does not, and
+  // this is the same descriptor an ordinary client would have connected
+  // synchronously anyway.
+  if (libc.sym.connect(fd, libc.ptr(address.sa), address.len) !== 0) {
+    libc.sym.close(fd);
+    return null;
+  }
+  if (!boundBlocking(fd)) {
+    libc.sym.close(fd);
+    return null;
+  }
+  const stream = new BunUnixSocket(fd);
+  try {
+    stream._startReader();
+  } catch {
+    stream.destroy();
+    return null;
+  }
+  return stream;
+}
+
+module.exports = { available, connect, MAX_FDS };

--- a/package.json
+++ b/package.json
@@ -83,6 +83,8 @@
     "test:integration:wrap:broker": "DBUS_TEST_SHAPE=wrap npm run test:integration:broker",
     "test:integration:classic": "DBUS_TEST_SHAPE=classic npm run test:integration",
     "test:integration:classic:broker": "DBUS_TEST_SHAPE=classic npm run test:integration:broker",
+    "test:bun": "bun test test/bun",
+    "test:bun:integration": "node scripts/with-dbus.js -- bun test test/bun",
     "dbus:session": "node scripts/dbus-session.js",
     "test:types": "tsc --noEmit"
   },

--- a/test/bun/integration.test.js
+++ b/test/bun/integration.test.js
@@ -1,0 +1,152 @@
+// A file descriptor through a real dbus-daemon, under Bun.
+//
+//   node scripts/with-dbus.js -- bun test test/bun    (npm run test:bun:integration)
+//
+// Two connections to the same bus, one descriptor, and the daemon in the
+// middle doing the routing. This is the whole feature end to end -- the
+// handshake agreeing UNIX_FD, the UNIX_FDS header, `h` as an index, and
+// SCM_RIGHTS underneath -- and it is the case E2E_DOCKER_TESTING.md lists as
+// impossible, because until this transport existed it was.
+
+const { describe, it, expect, beforeAll, afterAll } = require('bun:test');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const dbus = require('../../index.js');
+const constants = require('../../lib/constants');
+
+const NO_BUS = !process.env.DBUS_SESSION_BUS_ADDRESS;
+
+/** A connection that has finished saying Hello, so it has a unique name. */
+function connected() {
+  const bus = dbus.sessionBus();
+  return new Promise((resolve, reject) => {
+    bus.invokeDbus({ member: 'GetId' }, err => {
+      if (err) return reject(err);
+      resolve(bus);
+    });
+  });
+}
+
+function payload(contents) {
+  const file = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'dbus-fd-e2e-')),
+    'payload'
+  );
+  fs.writeFileSync(file, contents);
+  return fs.openSync(file, 'r');
+}
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+describe.skipIf(NO_BUS)('a descriptor through a real bus', () => {
+  let sender;
+  let receiver;
+
+  beforeAll(async () => {
+    sender = await connected();
+    receiver = await connected();
+  });
+
+  afterAll(() => {
+    for (const bus of [sender, receiver]) {
+      if (bus) bus.connection.end();
+    }
+  });
+
+  it('negotiates UNIX_FD with the daemon', () => {
+    // Both halves: our transport can carry one, and the peer agreed to it.
+    expect(sender.connection.canPassFds).toBe(true);
+    expect(sender.connection.unixFdsAgreed).toBe(true);
+  });
+
+  it('carries one from client to client, with the daemon in between', async () => {
+    const received = [];
+    receiver.connection.on('message', msg => {
+      if (msg.member === 'Take') received.push(msg);
+    });
+
+    const fd = payload('through-the-daemon\n');
+    sender.connection.message({
+      type: constants.messageType.methodCall,
+      serial: sender.nextSerial(),
+      destination: receiver.name,
+      path: '/org/dbusnative/FdTest',
+      interface: 'org.dbusnative.FdTest',
+      member: 'Take',
+      signature: 'sh',
+      // The `h` is an index into the descriptors that accompany the message,
+      // not a descriptor -- which is the whole point of the type.
+      body: ['a name', 0],
+      fds: [fd],
+      flags: constants.flags.noReplyExpected
+    });
+    fs.closeSync(fd);
+
+    for (let i = 0; i < 200 && received.length === 0; i++) await sleep(10);
+    expect(received).toHaveLength(1);
+
+    const msg = received[0];
+    expect(msg.body[0]).toBe('a name');
+    expect(msg.unixFds).toBe(1);
+    expect(msg.fds).toHaveLength(1);
+    // The daemon passed the descriptor on rather than the number: this is a
+    // different open file description in a different process, and reading it
+    // is what proves it.
+    const arrived = msg.fds[msg.body[1]];
+    expect(fs.readFileSync(arrived, 'utf8')).toBe('through-the-daemon\n');
+    fs.closeSync(arrived);
+  });
+
+  it('carries several, in the order the sender put them in', async () => {
+    const received = [];
+    receiver.connection.on('message', msg => {
+      if (msg.member === 'TakeThree') received.push(msg);
+    });
+
+    const fds = [payload('one\n'), payload('two\n'), payload('three\n')];
+    sender.connection.message({
+      type: constants.messageType.methodCall,
+      serial: sender.nextSerial(),
+      destination: receiver.name,
+      path: '/org/dbusnative/FdTest',
+      interface: 'org.dbusnative.FdTest',
+      member: 'TakeThree',
+      signature: 'hhh',
+      body: [2, 1, 0], // deliberately not in order: they are indices
+      fds,
+      flags: constants.flags.noReplyExpected
+    });
+    fds.forEach(fd => fs.closeSync(fd));
+
+    for (let i = 0; i < 200 && received.length === 0; i++) await sleep(10);
+    expect(received).toHaveLength(1);
+
+    const msg = received[0];
+    expect(msg.unixFds).toBe(3);
+    const texts = msg.body.map(index => {
+      const text = fs.readFileSync(msg.fds[index], 'utf8');
+      return text;
+    });
+    msg.fds.forEach(fd => fs.closeSync(fd));
+    expect(texts).toEqual(['three\n', 'two\n', 'one\n']);
+  });
+
+  it('still carries ordinary messages, in both directions', async () => {
+    // The transport is the connection now, so the boring path has to keep
+    // working: this is a round trip through the daemon and back.
+    const id = await new Promise((resolve, reject) => {
+      sender.invokeDbus({ member: 'GetId' }, (err, value) =>
+        err ? reject(err) : resolve(value)
+      );
+    });
+    expect(typeof id).toBe('string');
+    expect(id.length).toBeGreaterThan(0);
+
+    const names = await new Promise((resolve, reject) => {
+      sender.listNames((err, value) => (err ? reject(err) : resolve(value)));
+    });
+    expect(names).toContain(receiver.name);
+  });
+});

--- a/test/bun/peer.js
+++ b/test/bun/peer.js
@@ -1,0 +1,226 @@
+// The other end of a unix socket, with its own hand-rolled SCM_RIGHTS.
+//
+// Deliberately a second implementation of the same struct layouts rather than
+// a reuse of lib/transport-bun.js: a mistake in msghdr/cmsghdr offsets that
+// both ends made identically would cancel itself out and the tests would pass
+// on a wire format nothing else can read. Written from cmsg(3) and unix(7).
+
+const { dlopen, ptr, read } = require('bun:ffi');
+
+const isDarwin = process.platform === 'darwin';
+
+const lib = dlopen(
+  isDarwin ? '/usr/lib/libSystem.B.dylib' : 'libc.so.6',
+  Object.assign(
+    {
+      socket: { args: ['int', 'int', 'int'], returns: 'int' },
+      bind: { args: ['int', 'ptr', 'int'], returns: 'int' },
+      listen: { args: ['int', 'int'], returns: 'int' },
+      accept: { args: ['int', 'ptr', 'ptr'], returns: 'int' },
+      sendmsg: { args: ['int', 'ptr', 'int'], returns: 'i64' },
+      recvmsg: { args: ['int', 'ptr', 'int'], returns: 'i64' },
+      close: { args: ['int'], returns: 'int' }
+    },
+    isDarwin
+      ? { __error: { args: [], returns: 'ptr' } }
+      : { __errno_location: { args: [], returns: 'ptr' } }
+  )
+);
+
+const sym = lib.symbols;
+const errnoAt = isDarwin ? sym.__error : sym.__errno_location;
+const errno = () => read.i32(errnoAt(), 0);
+
+const AF_UNIX = 1;
+const SOCK_STREAM = 1;
+const SOL_SOCKET = isDarwin ? 0xffff : 1;
+const SCM_RIGHTS = 1;
+const MSG_DONTWAIT = isDarwin ? 0x80 : 0x40;
+const EAGAIN = isDarwin ? 35 : 11;
+
+// cmsghdr is { socklen_t len; int level; int type; } on macOS and
+// { size_t len; int level; int type; } on Linux, and its payload aligns to the
+// width of that first field.
+const HDR = isDarwin ? 12 : 16;
+const align = n => (isDarwin ? (n + 3) & ~3 : (n + 7) & ~7);
+
+/**
+ * `{ path }` or `{ abstract }`, and the length to pass with it.
+ *
+ * An abstract name lives in sun_path with a leading NUL and is exactly as long
+ * as the address says -- pass the whole struct and every trailing NUL becomes
+ * part of the name, which is a different socket.
+ */
+function sockaddr(target) {
+  const sa = Buffer.alloc(2 + (isDarwin ? 104 : 108));
+  if (isDarwin) {
+    sa.writeUInt8(sa.length, 0);
+    sa.writeUInt8(AF_UNIX, 1);
+  } else {
+    sa.writeUInt16LE(AF_UNIX, 0);
+  }
+  if (target.abstract === undefined) {
+    sa.write(target.path, 2);
+    return { sa, len: sa.length };
+  }
+  sa.write(target.abstract, 3);
+  return { sa, len: 2 + 1 + Buffer.byteLength(target.abstract) };
+}
+
+/** A msghdr pointing at one iovec and one control buffer. */
+function msghdr(iov, ctl, ctlLen) {
+  const msg = Buffer.alloc(56);
+  msg.writeBigUInt64LE(BigInt(ptr(iov)), 16);
+  if (isDarwin) msg.writeInt32LE(1, 24);
+  else msg.writeBigUInt64LE(1n, 24);
+  if (ctlLen > 0) {
+    msg.writeBigUInt64LE(BigInt(ptr(ctl)), 32);
+    if (isDarwin) msg.writeUInt32LE(ctlLen, 40);
+    else msg.writeBigUInt64LE(BigInt(ctlLen), 40);
+  }
+  return msg;
+}
+
+function iovec(buf) {
+  const iov = Buffer.alloc(16);
+  iov.writeBigUInt64LE(BigInt(ptr(buf)), 0);
+  iov.writeBigUInt64LE(BigInt(buf.length), 8);
+  return iov;
+}
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+class Peer {
+  constructor(listenFd, target) {
+    this._listen = listenFd;
+    this._fd = -1;
+    this.target = target;
+    this.path = target.path;
+    /** Everything read so far. */
+    this.bytes = Buffer.alloc(0);
+    /** Where descriptors turned up: { offset, fds }, in arrival order. */
+    this.arrivals = [];
+  }
+
+  accept() {
+    this._fd = sym.accept(this._listen, null, null);
+    if (this._fd < 0) throw new Error(`accept failed (errno ${errno()})`);
+    return this;
+  }
+
+  /** Send `buf` with `fds` attached, the way a peer that passes fds does. */
+  send(buf, fds) {
+    const iov = iovec(buf);
+    const payload = 4 * fds.length;
+    const ctlLen = align(HDR) + align(payload);
+    const ctl = Buffer.alloc(ctlLen);
+    if (isDarwin) ctl.writeUInt32LE(HDR + payload, 0);
+    else ctl.writeBigUInt64LE(BigInt(HDR + payload), 0);
+    ctl.writeInt32LE(SOL_SOCKET, isDarwin ? 4 : 8);
+    ctl.writeInt32LE(SCM_RIGHTS, isDarwin ? 8 : 12);
+    fds.forEach((fd, i) => ctl.writeInt32LE(fd, HDR + 4 * i));
+    const msg = msghdr(iov, ctl, ctlLen);
+    const sent = Number(sym.sendmsg(this._fd, ptr(msg), 0));
+    if (sent !== buf.length) {
+      throw new Error(`sendmsg sent ${sent} of ${buf.length}`);
+    }
+    return sent;
+  }
+
+  /** One non-blocking recvmsg. Returns the byte count, or -1 for "nothing". */
+  poll() {
+    const data = Buffer.alloc(65536);
+    const ctl = Buffer.alloc(align(HDR) + align(4 * 64));
+    const iov = iovec(data);
+    const msg = msghdr(iov, ctl, ctl.length);
+    const n = Number(sym.recvmsg(this._fd, ptr(msg), MSG_DONTWAIT));
+    if (n < 0) {
+      if (errno() === EAGAIN) return -1;
+      throw new Error(`recvmsg failed (errno ${errno()})`);
+    }
+    const controlLen = isDarwin
+      ? msg.readUInt32LE(40)
+      : Number(msg.readBigUInt64LE(40));
+    const fds = [];
+    let off = 0;
+    while (off + HDR <= controlLen) {
+      const len = isDarwin
+        ? ctl.readUInt32LE(off)
+        : Number(ctl.readBigUInt64LE(off));
+      if (len < HDR) break;
+      if (
+        ctl.readInt32LE(off + (isDarwin ? 4 : 8)) === SOL_SOCKET &&
+        ctl.readInt32LE(off + (isDarwin ? 8 : 12)) === SCM_RIGHTS
+      ) {
+        for (let p = off + HDR; p + 4 <= off + len; p += 4) {
+          fds.push(ctl.readInt32LE(p));
+        }
+      }
+      off += align(len);
+    }
+    if (fds.length > 0) {
+      this.arrivals.push({ offset: this.bytes.length, fds });
+    }
+    if (n > 0) this.bytes = Buffer.concat([this.bytes, data.subarray(0, n)]);
+    return n;
+  }
+
+  /** Read until at least `count` bytes have arrived, or time out. */
+  async readAtLeast(count, timeoutMs = 5000) {
+    const deadline = Date.now() + timeoutMs;
+    while (this.bytes.length < count) {
+      if (this.poll() === 0) break; // end of stream
+      if (this.bytes.length >= count) break;
+      if (Date.now() > deadline) {
+        throw new Error(
+          `timed out with ${this.bytes.length} of ${count} bytes read`
+        );
+      }
+      await sleep(1);
+    }
+    return this.bytes;
+  }
+
+  /** Read until descriptors have turned up, or time out. */
+  async readUntilFds(timeoutMs = 5000) {
+    const deadline = Date.now() + timeoutMs;
+    while (this.arrivals.length === 0) {
+      if (this.poll() === 0) break;
+      if (Date.now() > deadline) throw new Error('timed out waiting for fds');
+      await sleep(1);
+    }
+    return this.arrivals;
+  }
+
+  close() {
+    if (this._fd >= 0) sym.close(this._fd);
+    if (this._listen >= 0) sym.close(this._listen);
+    this._fd = this._listen = -1;
+    if (this.path !== undefined) {
+      try {
+        require('fs').unlinkSync(this.path);
+      } catch {}
+    }
+  }
+}
+
+/** Bind and listen on `{ path }` or `{ abstract }`, ready for one connection. */
+function listenAt(target) {
+  const where = typeof target === 'string' ? { path: target } : target;
+  const fd = sym.socket(AF_UNIX, SOCK_STREAM, 0);
+  if (fd < 0) throw new Error(`socket failed (errno ${errno()})`);
+  const address = sockaddr(where);
+  if (sym.bind(fd, ptr(address.sa), address.len) !== 0) {
+    const e = errno();
+    sym.close(fd);
+    throw new Error(`bind failed (errno ${e})`);
+  }
+  if (sym.listen(fd, 4) !== 0) {
+    const e = errno();
+    sym.close(fd);
+    throw new Error(`listen failed (errno ${e})`);
+  }
+  return new Peer(fd, where);
+}
+
+module.exports = { listenAt, sleep };

--- a/test/bun/transport.test.js
+++ b/test/bun/transport.test.js
@@ -125,7 +125,22 @@ describe('sending descriptors', () => {
     await peer.readAtLeast(bulk.length + 1);
     const arrivals = await peer.readUntilFds();
     expect(peer.bytes.length).toBe(bulk.length + 1);
-    expect(arrivals[0].offset).toBe(bulk.length);
+    expect(arrivals).toHaveLength(1);
+
+    // Early is allowed; late is not. Linux glues queued messages into one
+    // recvmsg and hands over the descriptors of the first one that carries
+    // any, so they can be reported against bytes that precede their own
+    // message -- measured at 48000 bytes early on CI. macOS stops at the
+    // message boundary and reports them exactly. Either way a descriptor is
+    // never delivered after the bytes it belongs to, which is what makes a
+    // queue popped by the message that declares them correct on both.
+    expect(arrivals[0].offset).toBeLessThanOrEqual(bulk.length);
+    if (process.platform === 'darwin') {
+      expect(arrivals[0].offset).toBe(bulk.length);
+    }
+    expect(peer.bytes.subarray(0, bulk.length).equals(bulk)).toBe(true);
+    expect(peer.bytes[bulk.length]).toBe(0x21);
+
     fs.closeSync(arrivals[0].fds[0]);
     fs.closeSync(fd);
   });

--- a/test/bun/transport.test.js
+++ b/test/bun/transport.test.js
@@ -1,0 +1,294 @@
+// lib/transport-bun.js against a real unix socket, both directions.
+//
+// Run with `npm run test:bun`. These are the only tests in the suite that
+// cannot run on Node: the transport under test does not exist there.
+
+const { describe, it, expect, afterEach } = require('bun:test');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const transport = require('../../lib/transport-bun');
+const { listenAt, sleep } = require('./peer');
+
+const open = [];
+
+function socketPath(name) {
+  const p = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'dbus-fd-')),
+    `${name}.sock`
+  );
+  return p;
+}
+
+/** A file with known contents, to send as a descriptor and read back. */
+function payload(contents) {
+  const file = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'dbus-fd-')),
+    'payload'
+  );
+  fs.writeFileSync(file, contents);
+  return { fd: fs.openSync(file, 'r'), file, contents };
+}
+
+/** A connected { stream, peer } pair, torn down after each test. */
+function pair(name, target) {
+  const where = target || { path: socketPath(name) };
+  const peer = listenAt(where);
+  const stream = transport.connect(where);
+  expect(stream).not.toBe(null);
+  peer.accept();
+  open.push({ stream, peer });
+  return { stream, peer };
+}
+
+afterEach(() => {
+  for (const { stream, peer } of open.splice(0, open.length)) {
+    stream.destroy();
+    peer.close();
+  }
+});
+
+describe('the Bun fd transport', () => {
+  it('is available under Bun', () => {
+    expect(transport.available()).toBe(true);
+  });
+
+  it('looks like the seam the connection expects', () => {
+    const { stream } = pair('seam');
+    // What index.js probes for: writeWithFds is the capability declaration,
+    // cork/uncork is what lets messages without descriptors batch.
+    expect(typeof stream.writeWithFds).toBe('function');
+    expect(typeof stream.cork).toBe('function');
+    expect(typeof stream.uncork).toBe('function');
+    expect(typeof stream.read).toBe('function');
+  });
+});
+
+describe('sending descriptors', () => {
+  it('puts them on the wire with their own bytes', async () => {
+    const { stream, peer } = pair('send');
+    const { fd, contents } = payload('sent-through-the-socket\n');
+
+    stream.writeWithFds(Buffer.from('carrier'), [fd]);
+
+    await peer.readAtLeast(7);
+    const arrivals = await peer.readUntilFds();
+    expect(peer.bytes.toString()).toBe('carrier');
+    expect(arrivals).toHaveLength(1);
+    expect(arrivals[0].fds).toHaveLength(1);
+    expect(fs.readFileSync(arrivals[0].fds[0], 'utf8')).toBe(contents);
+    fs.closeSync(arrivals[0].fds[0]);
+
+    // The caller keeps its own descriptor: we duped, so this one is still
+    // open and still ours to close. (Reading it again would come up empty --
+    // SCM_RIGHTS shares the open file description, offset included, so the
+    // peer's read above moved this one too.)
+    expect(() => fs.fstatSync(fd)).not.toThrow();
+    fs.closeSync(fd);
+  });
+
+  it('carries several at once', async () => {
+    const { stream, peer } = pair('send-many');
+    const a = payload('one\n');
+    const b = payload('two\n');
+    const c = payload('three\n');
+
+    stream.writeWithFds(Buffer.from('three-of-them'), [a.fd, b.fd, c.fd]);
+
+    const arrivals = await peer.readUntilFds();
+    expect(arrivals[0].fds).toHaveLength(3);
+    const seen = arrivals[0].fds.map(f => {
+      const text = fs.readFileSync(f, 'utf8');
+      fs.closeSync(f);
+      return text;
+    });
+    // Order is the order they were sent in, which is what lets a message take
+    // its share by count.
+    expect(seen).toEqual(['one\n', 'two\n', 'three\n']);
+    [a, b, c].forEach(p => fs.closeSync(p.fd));
+  });
+
+  it('never lets descriptors overtake the bytes written before them', async () => {
+    const { stream, peer } = pair('order');
+    const { fd } = payload('after-a-megabyte\n');
+    const bulk = Buffer.alloc(1024 * 1024, 0x61);
+
+    // A megabyte does not fit in a socket buffer, so this backs up and the
+    // rest of it goes out as the peer drains -- while the fd write waits its
+    // turn behind it. Ancillary data attaches to the byte it is sent with, so
+    // a descriptor that jumped the queue would arrive against someone else's
+    // message.
+    stream.write(bulk);
+    stream.writeWithFds(Buffer.from('!'), [fd]);
+
+    await peer.readAtLeast(bulk.length + 1);
+    const arrivals = await peer.readUntilFds();
+    expect(peer.bytes.length).toBe(bulk.length + 1);
+    expect(arrivals[0].offset).toBe(bulk.length);
+    fs.closeSync(arrivals[0].fds[0]);
+    fs.closeSync(fd);
+  });
+
+  it('refuses more descriptors than a message may carry', () => {
+    const { stream } = pair('too-many');
+    const { fd } = payload('x');
+    expect(() =>
+      stream.writeWithFds(
+        Buffer.from('x'),
+        new Array(transport.MAX_FDS + 1).fill(fd)
+      )
+    ).toThrow(/at most \d+ file descriptors/);
+    fs.closeSync(fd);
+  });
+});
+
+describe('receiving descriptors', () => {
+  it('emits them before the bytes that claim them are readable', async () => {
+    const { stream, peer } = pair('receive');
+    const { fd, contents } = payload('received-through-the-socket\n');
+
+    const order = [];
+    let received = null;
+    stream.on('fds', fds => {
+      order.push('fds');
+      received = fds;
+    });
+    stream.on('readable', () => order.push('readable'));
+
+    peer.send(Buffer.from('carrier'), [fd]);
+    fs.closeSync(fd); // the peer's own copy; ours arrives independently
+
+    while (received === null) await sleep(5);
+    // The parser takes descriptors while reading a header, so they have to be
+    // queued by the time any of that message is readable.
+    expect(order[0]).toBe('fds');
+    expect(order).toContain('readable');
+    expect(stream.read(7).toString()).toBe('carrier');
+    expect(fs.readFileSync(received[0], 'utf8')).toBe(contents);
+    fs.closeSync(received[0]);
+  });
+
+  it('hands over what arrived, in arrival order', async () => {
+    const { stream, peer } = pair('receive-many');
+    const a = payload('first\n');
+    const b = payload('second\n');
+
+    const received = [];
+    stream.on('fds', fds => received.push(...fds));
+    stream.on('readable', () => stream.read());
+
+    peer.send(Buffer.from('one'), [a.fd]);
+    peer.send(Buffer.from('two'), [b.fd]);
+    fs.closeSync(a.fd);
+    fs.closeSync(b.fd);
+
+    while (received.length < 2) await sleep(5);
+    const texts = received.map(f => {
+      const text = fs.readFileSync(f, 'utf8');
+      fs.closeSync(f);
+      return text;
+    });
+    expect(texts).toEqual(['first\n', 'second\n']);
+  });
+
+  it('closes descriptors nobody claimed, on request', async () => {
+    const { stream, peer } = pair('orphan');
+    const { fd } = payload('orphaned\n');
+
+    const received = [];
+    stream.on('fds', fds => received.push(...fds));
+    peer.send(Buffer.from('x'), [fd]);
+    fs.closeSync(fd);
+    while (received.length === 0) await sleep(5);
+
+    // What index.js does on 'close' for descriptors no message ever took.
+    const orphan = received[0];
+    expect(() => fs.fstatSync(orphan)).not.toThrow();
+    stream.closeFds([orphan]);
+    expect(() => fs.fstatSync(orphan)).toThrow();
+  });
+});
+
+describe('the stream underneath', () => {
+  it('reads a byte stream like any other socket', async () => {
+    const { stream, peer } = pair('bytes');
+    const chunks = [];
+    stream.on('data', chunk => chunks.push(chunk));
+    peer.send(Buffer.from('hello '), []);
+    peer.send(Buffer.from('world'), []);
+    while (Buffer.concat(chunks).length < 11) await sleep(5);
+    expect(Buffer.concat(chunks).toString()).toBe('hello world');
+  });
+
+  it('writes more than a socket buffer holds, in order', async () => {
+    const { stream, peer } = pair('backpressure');
+    const bulk = Buffer.alloc(512 * 1024);
+    for (let i = 0; i < bulk.length; i++) bulk[i] = i & 0xff;
+
+    const backpressured = !stream.write(bulk);
+    await peer.readAtLeast(bulk.length);
+    expect(peer.bytes.equals(bulk)).toBe(true);
+    // Not an assertion about the exact high-water mark -- just that a write
+    // this size is reported one way or the other and still arrives whole.
+    expect(typeof backpressured).toBe('boolean');
+  });
+
+  it('ends the stream when the peer goes away', async () => {
+    const { stream, peer } = pair('eof');
+    let ended = false;
+    stream.on('end', () => {
+      ended = true;
+    });
+    stream.resume();
+    peer.close();
+    for (let i = 0; i < 200 && !ended; i++) await sleep(5);
+    expect(ended).toBe(true);
+  });
+
+  it('stops the reader thread when destroyed', async () => {
+    const peer = listenAt(socketPath('teardown'));
+    const stream = transport.connect({ path: peer.path });
+    peer.accept();
+    let closed = false;
+    stream.on('close', () => {
+      closed = true;
+    });
+    stream.destroy();
+    for (let i = 0; i < 200 && !closed; i++) await sleep(5);
+    expect(closed).toBe(true);
+    peer.close();
+  });
+});
+
+// Linux-only, and the one address shape whose sockaddr differs: the name goes
+// after a leading NUL and the length passed to connect(2) has to be exactly
+// what the name needs -- pass the whole struct and the trailing NULs are part
+// of the name, so it is a different socket and nothing is listening on it.
+describe.skipIf(process.platform !== 'linux')('abstract addresses', () => {
+  it('connects to one, and carries a descriptor over it', async () => {
+    const name = `dbus-native-fd-test-${process.pid}`;
+    const { stream, peer } = pair(null, { abstract: name });
+    const { fd, contents } = payload('over-an-abstract-socket\n');
+
+    stream.writeWithFds(Buffer.from('carrier'), [fd]);
+    const arrivals = await peer.readUntilFds();
+    expect(peer.bytes.toString()).toBe('carrier');
+    expect(fs.readFileSync(arrivals[0].fds[0], 'utf8')).toBe(contents);
+    fs.closeSync(arrivals[0].fds[0]);
+    fs.closeSync(fd);
+  });
+});
+
+describe('when it cannot be used', () => {
+  it('says so rather than throwing, for a path that is too long', () => {
+    const tooLong = `/tmp/${'x'.repeat(200)}.sock`;
+    expect(transport.connect({ path: tooLong })).toBe(null);
+  });
+
+  it('says so rather than throwing, for a socket nobody is listening on', () => {
+    expect(transport.connect({ path: '/tmp/definitely-not-there.sock' })).toBe(
+      null
+    );
+  });
+});

--- a/test/transport-bun.js
+++ b/test/transport-bun.js
@@ -1,0 +1,61 @@
+// What lib/transport-bun.js does when it is not running under Bun.
+//
+// The transport itself is tested in test/bun/, which only Bun can run. This
+// file is the other half of the contract and the half that matters to every
+// Node user: the module loads, answers "no", and hands back an ordinary
+// socket, so requiring it costs nothing and changes nothing.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+const transport = require('../lib/transport-bun');
+const { unixConnection } = require('../lib/address');
+
+const UNDER_BUN = typeof Bun !== 'undefined';
+
+describe('the Bun fd transport, on Node', { skip: UNDER_BUN }, () => {
+  it('reports that it is unavailable', () => {
+    assert.strictEqual(transport.available(), false);
+  });
+
+  it('returns null rather than throwing', () => {
+    assert.strictEqual(transport.connect({ path: '/tmp/nothing.sock' }), null);
+    assert.strictEqual(transport.connect({ abstract: 'nothing' }), null);
+  });
+
+  it('leaves unix connections to net, exactly as before', () => {
+    // No listener, so this fails -- the point is which kind of thing it is and
+    // that nothing threw on the way. An unhandled 'error' would take the
+    // process down, so it is answered here.
+    const stream = unixConnection({ path: '/tmp/definitely-not-there.sock' });
+    stream.on('error', () => {});
+    assert.strictEqual(typeof stream.writeWithFds, 'undefined');
+    assert.ok(typeof stream.destroy === 'function');
+    stream.destroy();
+  });
+
+  it('can be switched off explicitly', () => {
+    const stream = unixConnection(
+      { path: '/tmp/definitely-not-there.sock' },
+      { fdTransport: false }
+    );
+    stream.on('error', () => {});
+    assert.strictEqual(typeof stream.writeWithFds, 'undefined');
+    stream.destroy();
+  });
+});
+
+describe('the module itself', () => {
+  it('states the descriptor limit it enforces', () => {
+    assert.ok(Number.isInteger(transport.MAX_FDS));
+    // Enough for anything d-bus carries: dbus-daemon's own default limit is
+    // 16 per message.
+    assert.ok(transport.MAX_FDS >= 16);
+  });
+
+  it('does not pull in bun:ffi merely by being required', () => {
+    // Loading it on Node must not throw, which is what makes it safe to
+    // require unconditionally from lib/address.js.
+    assert.doesNotThrow(() => require('../lib/transport-bun'));
+  });
+});


### PR DESCRIPTION
Closes the transport half of [ROADMAP §2.8](https://github.com/sidorares/dbus-native/blob/master/ROADMAP.md#28-unix_fd-h-support). Follows the approach of sidorares/node-x11#290, with the differences d-bus forces.

## The gap

UNIX_FD has worked since #368 — for anyone who supplies their own fd-capable stream. §2.8 measured every way of building one on Node and found none: no ancillary-data API, [nodejs/node#53391](https://github.com/nodejs/node/issues/53391) closed as not planned, `pipe_wrap` aborts the process on the descriptors d-bus actually carries, and the one addon that works needs a compiler on every install — which undoes the property three releases were spent acquiring.

That table is a table of **Node** options. `bun:ffi` can `dlopen` `sendmsg(2)`/`recvmsg(2)` and call them directly, so under Bun the transport costs no dependency, no compiler and no build step.

```js
const bus = dbus.sessionBus();  // under Bun
bus.connection.canPassFds;      // true
```

`lib/transport-bun.js` is that transport, selected by `lib/address.js` for every unix connection under Bun (`socket:`, `unix:path=`, `unix:abstract=`, `launchd:`) and inert everywhere else — on Node the module loads, answers `available() === false`, and hands back the ordinary socket it always did. `fdTransport: false` opts out.

## Why it owns the descriptor, rather than wrapping Bun's socket

The x11 PR can offer send-only as the cheap default. Here it would be a bug. Bun's reader does a plain `read(2)`, which drops ancillary data silently:

```
server fd 7 sendmsg -> 10
client (Bun reader) got: "with-an-fd"
process still alive after receiving an SCM_RIGHTS message -> true
```

`NEGOTIATE_UNIX_FD` is per-connection, so once agreed **any** peer may put a descriptor in **any** reply — and a message whose `UNIX_FDS` header says 1 when none arrived is a `ProtocolError` that takes the connection down (`lib/message.js`). Send-only would be a connection that dies the first time something hands it a descriptor. So this is send *and* receive, with reading on a worker thread in `poll(2)`: one thread per fd-capable connection, which is what `fdTransport: false` turns off.

It is a real `Duplex`, which is the other difference. `unmarshalMessages()` frames with `stream.read(n)` on `'readable'`, `lib/readline.js` reads the handshake the same way, and `connection.message()` batches with cork/uncork — all of that comes from the base class, so the file is only the syscalls. `writeWithFds()` tags the chunk and calls `this.write()`, and `_writev` matches the tag back by identity, so ordering is the Writable's problem and descriptors attach to their own message's bytes and nothing else.

## Two things measured on macOS, not read about

- **Darwin does not honour `MSG_DONTWAIT` for AF_UNIX.** A send larger than the socket buffer blocks the calling thread — the event loop. `SO_SNDTIMEO` through `setsockopt(2)` bounds it instead, and BSD turns a timed-out send that moved some bytes into a short write, which is the case the flush loop already handled. Without this a 1 MB write hangs the process; with it, 3 ms of main-thread block for the same write.
- **`fcntl(F_SETFL, O_NONBLOCK)` cannot be used to fix that.** `fcntl` is variadic, and through a fixed FFI signature on arm64 the third argument comes from the wrong place — silently:

  ```
  F_GETFL before = 2
  F_SETFL rc = 0
  F_GETFL after = 2   nonblock set: false
  ```

  Which is why nothing here calls a variadic libc function, and why `poll`'s `nfds_t` is declared 64-bit.

## Ownership

Descriptors handed to `writeWithFds()` are **duped**, so the caller keeps its own and may close them as soon as the call returns — what libdbus does, and the only contract that works with a queue, since a write may go out a tick later. Received descriptors are the receiver's. Ones that arrived and that no message ever claimed are closed with the connection, through a new optional `stream.closeFds(fds)` — nothing else can know about them, and a live fd nobody closes is a leak.

## What this turns on

For anyone running on Bun: systemd `DumpByFileDescriptor`, the XDG portals (`ScreenCast.OpenPipeWireRemote`, `OpenURI.OpenFile`, `Documents.Add`, `Flatpak.Spawn`), logind `Inhibit` and `TakeDevice`, UDisks2 `LoopSetup` and `OpenForBackup`, BlueZ `MediaTransport1.Acquire`, machine1 `OpenMachinePTY`.

## Testing

- `test/bun/transport.test.js` — both directions over a real unix socket against a peer built from its own hand-rolled `sendmsg`/`recvmsg` (`test/bun/peer.js`), so a mistake in the struct layouts cannot cancel itself out: multiple descriptors per message, the dup contract, write ordering behind 1 MB of buffered output (the fd arrives at exactly offset 1048576), end of stream, teardown, the refusal paths, and a Linux-only abstract-address case.
- `test/bun/integration.test.js` — a descriptor passed **between two clients through a real dbus-daemon**, plus ordinary traffic on the same connection. That is the case [E2E_DOCKER_TESTING.md](https://github.com/sidorares/dbus-native/blob/master/E2E_DOCKER_TESTING.md) listed as impossible to cover; it is covered now.
- `test/transport-bun.js` — the Node half, in the ordinary suite: unavailable, returns `null`, ordinary socket, opt-out honoured.
- Node suites unchanged in behaviour: 954 passing (was 948). `npm run test:integration` has the same 2 pre-existing codegen failures as `master`, verified by stashing.

CI gains a `bun` job on ubuntu-latest and macos-latest running `test:bun` and `test:bun:integration`.

**Verified on macOS arm64 locally (Bun 1.4.0, dbus 1.16 from brew), and on both platforms in CI** — including the descriptor through a real daemon on Linux, and the Linux-only halves (`MSG_CMSG_CLOEXEC`, the 8-byte `cmsghdr`, abstract addresses), which no local machine here could run.

One behaviour worth recording, found by the Linux CI run and now in the test and in `docs/api.md`: descriptors can be delivered **early** but never late. Linux glues queued messages into one `recvmsg` and hands over the descriptors of the first one that carries any, so they arrive against bytes that precede their own message — 48000 bytes early in the ordering test. macOS stops at the message boundary. Either way a descriptor is never delivered *after* the bytes it belongs to, which is what makes a queue popped by the message that declares it correct on both.

## Scope limits

- **Client only.** `lib/server.js` and `lib/broker.js` hand an accepted socket straight to `createConnection`, and Bun is reading it by then — exporting a service that hands out descriptors needs an fd-capable listener too (`socket`/`bind`/`listen`/`accept` through the same FFI, plus the poll thread). Noted in §2.8 as the remaining work.
- One worker thread per fd-capable connection. A broker with many connections would want one shared poller.
- Deno has `Deno.dlopen` and could host the same transport; not attempted.
